### PR TITLE
avoid incompatibility with future warnings hazard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ on: [push, pull_request, workflow_dispatch]
 
 name: CI
 
+env:
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   check:
     name: cargo check
@@ -82,4 +85,3 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 //! `CompactStr` is a compact immutable string type that stores itself on the stack, if possible, and seamlessly
 //! interacts with `String`s and `&str`s.
 //!


### PR DESCRIPTION
`#![deny(warnings)]` is an antipattern:

* it breaks downstream when compiler adds new warnings
* it has to be repeated for every crate (currenty, eg, tests don't deny warnings)
* it makes local development harder

A better approach is to deny warnings on CI