### PR TITLE
add missing repr(C)

### DIFF
--- a/compact_str/src/repr/discriminant.rs
+++ b/compact_str/src/repr/discriminant.rs
@@ -9,6 +9,7 @@ pub enum Discriminant {
     Packed,
 }
 
+#[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DiscriminantMask {
     val: u8,


### PR DESCRIPTION
We store `DiscriminantMask` in a union, so we need to repr-c it to
guarantee that type-punning works