### PR TITLE
impl FromStr for CompactStr

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -17,6 +17,7 @@ use core::{
     fmt,
     hash::{Hash, Hasher},
     ops::Deref,
+    str::FromStr,
 };
 
 mod repr;
@@ -178,6 +179,13 @@ impl From<String> for CompactStr {
 impl<'a> From<&'a String> for CompactStr {
     fn from(s: &'a String) -> Self {
         CompactStr::new(&s)
+    }
+}
+
+impl FromStr for CompactStr {
+    type Err = core::convert::Infallible;
+    fn from_str(s: &str) -> Result<CompactStr, Self::Err> {
+        Ok(CompactStr::from(s))
     }
 }
 

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::CompactStr;
 use proptest::{prelude::*, strategy::Strategy};
+use std::str::FromStr;
 
 #[cfg(target_pointer_width = "64")]
 const MAX_INLINED_SIZE: usize = 24;
@@ -128,4 +129,14 @@ fn test_medium_unicode() {
 
         assert_eq!(compact.is_heap_allocated(), is_heap);
     }
+}
+
+#[test]
+fn test_from_str_trait() {
+    let s = "hello_world";
+
+    // Until the never type `!` is stabilized, we have to unwrap here
+    let c = CompactStr::from_str(s).unwrap();
+
+    assert_eq!(s, c);
 }


### PR DESCRIPTION
Fixes #18

This PR implements the `std::str::FromStr` trait for `CompactStr`, where the error type is `core::convert::Infallible`. The ergonomics here aren't _great_ because despite making the error type "infallible" we still have to call unwrap. Once the never type, `!`, is stabilized, we can use that instead. 