### PR TITLE
impl FromIterator<...> for CompactStr

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -16,6 +16,7 @@ use core::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
+    iter::FromIterator,
     ops::Deref,
     str::FromStr,
 };
@@ -200,5 +201,41 @@ impl fmt::Display for CompactStr {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
+
+impl FromIterator<char> for CompactStr {
+    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
+        let repr = iter.into_iter().collect();
+        CompactStr { repr }
+    }
+}
+
+impl<'a> FromIterator<&'a char> for CompactStr {
+    fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
+        let repr = iter.into_iter().collect();
+        CompactStr { repr }
+    }
+}
+
+impl<'a> FromIterator<&'a str> for CompactStr {
+    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+        let repr = iter.into_iter().collect();
+        CompactStr { repr }
+    }
+}
+
+impl FromIterator<Box<str>> for CompactStr {
+    fn from_iter<T: IntoIterator<Item = Box<str>>>(iter: T) -> Self {
+        let repr = iter.into_iter().collect();
+        CompactStr { repr }
+    }
+}
+
+impl FromIterator<String> for CompactStr {
+    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+        let repr = iter.into_iter().collect();
+        CompactStr { repr }
+    }
+}
+
 
 static_assertions::assert_eq_size!(CompactStr, String);

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -237,5 +237,4 @@ impl FromIterator<String> for CompactStr {
     }
 }
 
-
 static_assertions::assert_eq_size!(CompactStr, String);

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -21,4 +21,13 @@ impl HeapString {
     }
 }
 
+impl From<String> for HeapString {
+    fn from(s: String) -> Self {
+        let padding = PADDING;
+        let string = s.into();
+
+        HeapString { padding, string }
+    }
+}
+
 static_assertions::assert_eq_size!(HeapString, String);

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -58,6 +58,13 @@ impl InlineString {
         InlineString { metadata, buffer }
     }
 
+    /// Creates an `InlineString` from raw parts without checking that it's valid UTF-8.
+    #[inline]
+    pub const unsafe fn from_parts(len: usize, buffer: [u8; MAX_INLINE_SIZE]) -> Self {
+        let metadata = (len as u8) | LEADING_BIT_MASK;
+        InlineString { metadata, buffer }
+    }
+
     #[inline]
     pub const fn len(&self) -> usize {
         (self.metadata & !LEADING_BIT_MASK) as usize

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -29,7 +29,8 @@ impl FromIterator<char> for Repr {
 
                 // push existing characters onto the heap
                 // SAFETY: `inline_buf` has been filled with `char`s which are valid UTF-8
-                heap_buf.push_str(unsafe { core::str::from_utf8_unchecked(&inline_buf[..curr_len]) });
+                heap_buf
+                    .push_str(unsafe { core::str::from_utf8_unchecked(&inline_buf[..curr_len]) });
                 // push current char onto the heap
                 heap_buf.push(c);
                 // extend heap with remaining characters

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,0 +1,95 @@
+//! Implementations of the `FromIterator` trait to make building `CompactStr`s easier
+
+use core::{
+    iter::FromIterator,
+    mem::ManuallyDrop,
+};
+use super::{
+    inline::MAX_INLINE_SIZE,
+    Repr,
+    HeapString,
+    InlineString,
+};
+
+impl FromIterator<char> for Repr {
+    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
+        let mut iter = iter.into_iter();
+
+        // If the size hint indicates we can't store this inline, then create a heap string
+        let (size_hint, _) = iter.size_hint();
+        if size_hint > MAX_INLINE_SIZE {
+            let heap = HeapString::from(iter.collect::<String>());
+            return Repr { heap: ManuallyDrop::new(heap) };
+        }
+
+        // Otherwise, continuously pull chars from the iterator
+        let mut curr_len = 0;
+        let mut inline_buf = [0u8; MAX_INLINE_SIZE];
+        while let Some(c) = iter.next() {
+            let char_len = c.len_utf8();
+
+            // If this new character is too large to fit into the inline buffer, then create a heap string
+            if char_len + curr_len > inline_buf.len() {
+                let (min_remaining, _) = iter.size_hint();
+                let mut heap_buf = String::with_capacity(char_len + curr_len + min_remaining);
+
+                // push existing characters onto the heap
+                // SAFETY: `inline_buf` has been filled with `char`s which are valid UTF-8
+                heap_buf.push_str(unsafe { core::str::from_utf8_unchecked(&inline_buf) });
+                // push current char onto the heap
+                heap_buf.push(c);
+                // extend heap with remaining characters
+                heap_buf.extend(iter);
+
+                let heap = HeapString::from(heap_buf);
+                return Repr { heap: ManuallyDrop::new(heap) };
+            }
+
+            // write the current char into a slice of the unoccupied space
+            c.encode_utf8(&mut inline_buf[curr_len..]);
+            curr_len += char_len;
+        }
+
+        // SAFETY: We know `inline_buf` is valid UTF-8 because it consists entriely of `char`s
+        let inline = unsafe { InlineString::from_parts(curr_len, inline_buf) };
+        Repr { inline }
+    }
+}
+
+impl<'a> FromIterator<&'a char> for Repr {
+    fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
+        iter.into_iter().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Repr;
+
+    #[test]
+    fn short_char_iter() {
+        let chars = ['a', 'b', 'c'];
+        let repr: Repr = chars.into_iter().collect();
+
+        assert_eq!(repr.as_str(), "abc");
+        assert!(!repr.is_heap_allocated());
+    }
+
+    #[test]
+    fn short_char_ref_iter() {
+        let chars = ['a', 'b', 'c'];
+        let repr: Repr = chars.iter().collect();
+
+        assert_eq!(repr.as_str(), "abc");
+        assert!(!repr.is_heap_allocated());
+    }
+
+    #[test]
+    fn long_char_iter() {
+        let long = "This is supposed to be a really long string";
+        let repr: Repr = long.chars().collect();
+
+        assert_eq!(repr.as_str(), "This is supposed to be a really long string");
+        assert!(repr.is_heap_allocated());
+    }
+}

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1,6 +1,8 @@
 use static_assertions::{assert_eq_size, const_assert_eq};
 use std::mem::ManuallyDrop;
 
+mod iter;
+
 mod discriminant;
 mod heap;
 mod inline;


### PR DESCRIPTION
This PR implements the `FromIterator` trait for a common string types to make building `CompactStr`s more ergonomic