### PR TITLE
Bump version to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
+
+# 0.2.0
+### November 14, 2021
 * Change Minimum Supported Rust Version to 1.49
+    * Implemented in [`#24 Make Minimum Supported Rust Version 1.49`](https://github.com/ParkMyCar/compact_str/pull/24)
+* Implement `FromIterator` for `CompactStr`
+    * Implemented in [`#23 impl FromIterator<...> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/23)
 
 # 0.1.2
 ### October 29, 2021
@@ -10,7 +16,7 @@
     * Fixes [`#3 Document minimal supported Rust Version`](https://github.com/ParkMyCar/compact_str/issues/3)
     * Implemented by [`#17 Upgrade to Edition 2021 and mac MSRV 1.56`](https://github.com/ParkMyCar/compact_str/pull/17)
 * Upgrade to Edition 2021
-    * [`#17 Upgrade to Edition 2021 and mac MSRV 1.56`](https://github.com/ParkMyCar/compact_str/pull/17)
+    * [`#17 Upgrade to Edition 2021 and make MSRV 1.56`](https://github.com/ParkMyCar/compact_str/pull/17)
 
 # 0.1.1
 ### September 30, 2021

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://crates.io/crates/compact_str">
     <img alt="version on crates.io" src="https://img.shields.io/crates/v/compact_str"/>
   </a>
-  <img alt="Minimum supported Rust Version: 1.56" src="https://img.shields.io/badge/MSRV-1.56-blueviolet">
+  <img alt="Minimum supported Rust Version: 1.49" src="https://img.shields.io/badge/MSRV-1.49-blueviolet">
   <a href="LICENSE">
     <img alt="mit license" src="https://img.shields.io/crates/l/compact_str"/>
   </a>

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient immutable string type that transparently stores strings on the stack, when possible"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR bumps the version of CompactStr to `v0.2`. It now supports new features, and we move the MSRV back to 1.49 and edition 2018