### PR TITLE
Add formatting rules to .rustfmt.toml

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          # We currently use some unstable features in rustfmt, hence the nightly toolchain
+          toolchain: nightly
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,10 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+imports_layout = "Vertical"
+reorder_modules = true
+
+max_width = 100
+
+comment_width = 100
+wrap_comments = true
+

--- a/compact_str/benches/compact_str.rs
+++ b/compact_str/benches/compact_str.rs
@@ -1,5 +1,9 @@
 use compact_str::CompactStr;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
 
 fn empty(c: &mut Criterion) {
     let word = "";

--- a/compact_str/benches/comparison.rs
+++ b/compact_str/benches/comparison.rs
@@ -1,5 +1,10 @@
 use compact_str::CompactStr;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{
+    criterion_group,
+    criterion_main,
+    BenchmarkId,
+    Criterion,
+};
 use smartstring::alias::String as SmartString;
 use smol_str::SmolStr;
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,25 +1,26 @@
-//! `CompactStr` is a compact immutable string type that stores itself on the stack, if possible, and seamlessly
-//! interacts with `String`s and `&str`s.
+//! `CompactStr` is a compact immutable string type that stores itself on the stack, if possible,
+//! and seamlessly interacts with `String`s and `&str`s.
 //!
 //! ### Memory Layout
-//! Normally strings are stored on the heap, since they're dynamically sized. In Rust a `String` consists of
-//! three things:
+//! Normally strings are stored on the heap, since they're dynamically sized. In Rust a `String`
+//! consists of three things:
 //! 1. A `usize` denoting the length of the string
 //! 2. A pointer to a location on the heap where the string is stored
 //! 3. A `usize` denoting the capacity of the string
 //!
-//! On 64-bit architectures this results in 24 bytes being stored on the stack, 12 bytes for 32-bit architectures.
-//! For small strings, e.g. < 23 characters
+//! On 64-bit architectures this results in 24 bytes being stored on the stack, 12 bytes for 32-bit
+//! architectures. For small strings, e.g. < 23 characters
 
-use core::{
-    borrow::Borrow,
-    cmp::Ordering,
-    fmt,
-    hash::{Hash, Hasher},
-    iter::FromIterator,
-    ops::Deref,
-    str::FromStr,
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{
+    Hash,
+    Hasher,
 };
+use core::iter::FromIterator;
+use core::ops::Deref;
+use core::str::FromStr;
 
 mod repr;
 use repr::Repr;
@@ -30,8 +31,8 @@ mod serde;
 #[cfg(test)]
 mod tests;
 
-/// A `CompactStr` is a memory efficient immuatable string that can be used almost anywhere a `String`
-/// or `&str` can be used.
+/// A `CompactStr` is a memory efficient immuatable string that can be used almost anywhere a
+/// `String` or `&str` can be used.
 ///
 /// ## Using `CompactStr`
 /// ```

--- a/compact_str/src/repr/discriminant.rs
+++ b/compact_str/src/repr/discriminant.rs
@@ -1,4 +1,8 @@
-use super::{HEAP_MASK, LEADING_BIT_MASK, MAX_SIZE};
+use super::{
+    HEAP_MASK,
+    LEADING_BIT_MASK,
+    MAX_SIZE,
+};
 
 const PADDING_SIZE: usize = MAX_SIZE - std::mem::size_of::<Discriminant>();
 

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -1,6 +1,10 @@
-use std::{mem, sync::Arc};
+use std::mem;
+use std::sync::Arc;
 
-use super::{HEAP_MASK, MAX_SIZE};
+use super::{
+    HEAP_MASK,
+    MAX_SIZE,
+};
 
 const PADDING_SIZE: usize = MAX_SIZE - mem::size_of::<Arc<str>>();
 const PADDING: [u8; PADDING_SIZE] = [HEAP_MASK; PADDING_SIZE];

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -1,4 +1,7 @@
-use super::{LEADING_BIT_MASK, MAX_SIZE};
+use super::{
+    LEADING_BIT_MASK,
+    MAX_SIZE,
+};
 
 pub const MAX_INLINE_SIZE: usize = MAX_SIZE - core::mem::size_of::<Metadata>();
 
@@ -37,8 +40,9 @@ impl InlineString {
     #[inline]
     pub const fn new_const(text: &str) -> Self {
         if text.len() > MAX_INLINE_SIZE {
-            // HACK: This allows us to make assertions within a `const fn` without requiring nightly,
-            // see unstable `const_panic` feature. This results in a build failure, not a runtime panic
+            // HACK: This allows us to make assertions within a `const fn` without requiring
+            // nightly, see unstable `const_panic` feature. This results in a build
+            // failure, not a runtime panic
             #[allow(clippy::no_effect)]
             #[allow(unconditional_panic)]
             ["Provided string has a length greater than MAX_INLINE_SIZE!"][42];

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,7 +1,14 @@
 //! Implementations of the `FromIterator` trait to make building `CompactStr`s more ergonomic
 
-use super::{inline::MAX_INLINE_SIZE, HeapString, InlineString, Repr};
-use core::{iter::FromIterator, mem::ManuallyDrop};
+use core::iter::FromIterator;
+use core::mem::ManuallyDrop;
+
+use super::inline::MAX_INLINE_SIZE;
+use super::{
+    HeapString,
+    InlineString,
+    Repr,
+};
 
 impl FromIterator<char> for Repr {
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
@@ -22,7 +29,8 @@ impl FromIterator<char> for Repr {
         while let Some(c) = iter.next() {
             let char_len = c.len_utf8();
 
-            // If this new character is too large to fit into the inline buffer, then create a heap string
+            // If this new character is too large to fit into the inline buffer, then create a heap
+            // string
             if char_len + curr_len > MAX_INLINE_SIZE {
                 let (min_remaining, _) = iter.size_hint();
                 let mut heap_buf = String::with_capacity(char_len + curr_len + min_remaining);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1,5 +1,9 @@
-use static_assertions::{assert_eq_size, const_assert_eq};
 use std::mem::ManuallyDrop;
+
+use static_assertions::{
+    assert_eq_size,
+    const_assert_eq,
+};
 
 mod iter;
 
@@ -8,7 +12,10 @@ mod heap;
 mod inline;
 mod packed;
 
-use discriminant::{Discriminant, DiscriminantMask};
+use discriminant::{
+    Discriminant,
+    DiscriminantMask,
+};
 use heap::HeapString;
 use inline::InlineString;
 use packed::PackedString;
@@ -60,8 +67,9 @@ impl Repr {
             let packed = PackedString::new_const(text);
             Repr { packed }
         } else {
-            // HACK: This allows us to make assertions within a `const fn` without requiring nightly,
-            // see unstable `const_panic` feature. This results in a build failure, not a runtime panic
+            // HACK: This allows us to make assertions within a `const fn` without requiring
+            // nightly, see unstable `const_panic` feature. This results in a build
+            // failure, not a runtime panic
             #[allow(clippy::no_effect)]
             #[allow(unconditional_panic)]
             ["Trying to create a non-inline-able string at compile time!"][42];

--- a/compact_str/src/repr/packed.rs
+++ b/compact_str/src/repr/packed.rs
@@ -21,15 +21,17 @@ impl PackedString {
     #[inline]
     pub const fn new_const(text: &str) -> Self {
         if text.len() != MAX_SIZE {
-            // HACK: This allows us to make assertions within a `const fn` without requiring nightly,
-            // see unstable `const_panic` feature. This results in a build failure, not a runtime panic
+            // HACK: This allows us to make assertions within a `const fn` without requiring
+            // nightly, see unstable `const_panic` feature. This results in a build
+            // failure, not a runtime panic
             #[allow(clippy::no_effect)]
             #[allow(unconditional_panic)]
             ["Provided string has a length greater than MAX_SIZE!"][42];
         }
         if text.as_bytes()[0] > 127 {
-            // HACK: This allows us to make assertions within a `const fn` without requiring nightly,
-            // see unstable `const_panic` feature. This results in a build failure, not a runtime panic
+            // HACK: This allows us to make assertions within a `const fn` without requiring
+            // nightly, see unstable `const_panic` feature. This results in a build
+            // failure, not a runtime panic
             #[allow(clippy::no_effect)]
             #[allow(unconditional_panic)]
             ["leading character of packed string isn't ASCII!"][42];

--- a/compact_str/src/serde.rs
+++ b/compact_str/src/serde.rs
@@ -1,6 +1,13 @@
-use super::CompactStr;
-use serde::de::{Deserializer, Error, Unexpected, Visitor};
 use std::fmt;
+
+use serde::de::{
+    Deserializer,
+    Error,
+    Unexpected,
+    Visitor,
+};
+
+use super::CompactStr;
 
 fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<CompactStr, D::Error> {
     struct CompactStrVisitor;

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1,6 +1,9 @@
-use crate::CompactStr;
-use proptest::{prelude::*, strategy::Strategy};
 use std::str::FromStr;
+
+use proptest::prelude::*;
+use proptest::strategy::Strategy;
+
+use crate::CompactStr;
 
 #[cfg(target_pointer_width = "64")]
 const MAX_INLINED_SIZE: usize = 24;

--- a/compact_str/tests/alloc.rs
+++ b/compact_str/tests/alloc.rs
@@ -1,5 +1,10 @@
 use compact_str::CompactStr;
-use rand::{distributions, rngs::StdRng, Rng, SeedableRng};
+use rand::rngs::StdRng;
+use rand::{
+    distributions,
+    Rng,
+    SeedableRng,
+};
 use tracing_alloc::TracingAllocator;
 
 #[global_allocator]

--- a/compact_str/tests/correctness.rs
+++ b/compact_str/tests/correctness.rs
@@ -1,5 +1,10 @@
 use compact_str::CompactStr;
-use rand::{distributions, rngs::StdRng, Rng, SeedableRng};
+use rand::rngs::StdRng;
+use rand::{
+    distributions,
+    Rng,
+    SeedableRng,
+};
 
 #[cfg(target_pointer_width = "64")]
 const MAX_INLINED_SIZE: usize = 24;

--- a/tracing_alloc/src/lib.rs
+++ b/tracing_alloc/src/lib.rs
@@ -1,6 +1,16 @@
-use parking_lot::{const_fair_mutex, FairMutex};
-use std::alloc::{GlobalAlloc, System};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::alloc::{
+    GlobalAlloc,
+    System,
+};
+use std::sync::atomic::{
+    AtomicBool,
+    Ordering,
+};
+
+use parking_lot::{
+    const_fair_mutex,
+    FairMutex,
+};
 
 #[derive(Debug, Clone)]
 pub enum Event {


### PR DESCRIPTION
This PR just adds a `.rustfmt.toml` to the root of the repo to customize some of the formatting. Unfortunately some of the rustfmt rules are unstable, so we need to use nightly to run rustfmt.

For future reference, you can run `rustfmt` by doing the following `cargo +nightly fmt`