### PR TITLE
chore: Add rustc 1.57 to the MSRV CI workflow

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -13,6 +13,21 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  test-1_57:
+    name: cargo test 1.57
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.57
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+
   test-1_56:
     name: cargo test 1.56
     runs-on: ubuntu-latest


### PR DESCRIPTION
As the title says, adds a CI workflow for the recently released rust v1.57