### PR TITLE
testing: Add Miri to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           components: miri
       - name: Run Miri
         run: |
-          cargo miri test
+          cargo miri test -- --nocapture
 
   example-serde:
     name: example - serde

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           components: miri
       - name: Run Miri
         run: |
-          cargo miri test -- --nocapture
+          cargo miri test
 
   example-serde:
     name: example - serde

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,24 @@ jobs:
           command: test
           args: --all-features
 
+  miri:
+    name: cargo miri test
+    runs-on: ubuntu-latest
+    env:
+      # We reduce the number of "randomized runs" because Miri is quite slow
+      RANDOMIZED_RUNS: 1000
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+      - name: Run Miri
+        run: |
+          cargo miri test
+
   example-serde:
     name: example - serde
     runs-on: ubuntu-latest

--- a/compact_str/src/repr/heap/arc.rs
+++ b/compact_str/src/repr/heap/arc.rs
@@ -230,6 +230,7 @@ mod test {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn test_strings_roundtrip(word in rand_unicode()) {
             let arc_str = ArcString::from(word.as_str());
             prop_assert_eq!(&word, arc_str.as_str());

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -22,6 +22,7 @@ fn rand_unicode_collection() -> impl Strategy<Value = Vec<String>> {
 
 proptest! {
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_strings_roundtrip(word in rand_unicode()) {
         let compact = CompactStr::new(&word);
         prop_assert_eq!(&word, &compact);
@@ -29,6 +30,7 @@ proptest! {
 
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_strings_allocated_properly(word in rand_unicode()) {
         let compact = CompactStr::new(&word);
 
@@ -42,12 +44,14 @@ proptest! {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_char_iterator_roundtrips(word in rand_unicode()) {
         let compact: CompactStr = word.clone().chars().collect();
         prop_assert_eq!(&word, &compact)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_string_iterator_roundtrips(collection in rand_unicode_collection()) {
         let compact: CompactStr = collection.clone().into_iter().collect();
         let word: String = collection.into_iter().collect();


### PR DESCRIPTION
This diff adds a CI workflow for [miri](https://github.com/rust-lang/miri), and makes a few small changes to skip proptest which can't currently run with miri, [issue](https://github.com/AltSysrq/proptest/issues/253).