### PR TITLE
feature: as_mut_slice API

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -157,6 +157,13 @@ impl CompactStr {
         self.repr.as_mut_slice()
     }
 
+    /// # Safety
+    /// * TODO: Document safety here
+    #[inline]
+    pub unsafe fn set_len(&mut self, length: usize) {
+        self.repr.set_len(length)
+    }
+
     #[inline]
     pub fn is_heap_allocated(&self) -> bool {
         self.repr.is_heap_allocated()

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -115,8 +115,11 @@ impl CompactStr {
     /// use compact_str::CompactStr;
     ///
     /// const WORD: usize = std::mem::size_of::<usize>();
-    /// let compact = CompactStr::default();
+    /// let mut compact = CompactStr::default();
     /// assert!(compact.capacity() >= (WORD * 3) - 1);
+    ///
+    /// compact.reserve(200);
+    /// assert!(compact.is_heap_allocated());
     /// ```
     ///
     /// # Panics
@@ -129,6 +132,29 @@ impl CompactStr {
     #[inline]
     pub fn as_str(&self) -> &str {
         self.repr.as_str()
+    }
+
+    // TODO: Implement a `try_as_mut_slice(...)` that will fail if it results in cloning?
+    //
+    /// Provides a mutable reference to the underlying buffer of bytes.
+    ///
+    /// Note: If the given `CompactStr` is heap allocated, _and_ multiple references exist to the
+    /// underlying buffer (e.g. you previously cloned this `CompactStr`), calling this method will
+    /// clone the entire buffer to prevent silently mutating other owned `CompactStr`s.
+    ///
+    /// ### Futher Explanation
+    /// When a `CompactStr` becomes sufficiently large, the underlying buffer becomes a reference
+    /// counted buffer on the heap. Then, cloning a `CompactStr` increments a reference count
+    /// instead of cloning the entire buffer (very similar to `Arc<str>`). To prevent silently
+    /// mutating the data of other owned `CompactStr`s when taking a mutable slice, we clone the
+    /// underlying buffer and mutate that, if more than one outstanding reference exists.
+    ///
+    /// # Safety
+    /// * All Rust strings, including `CompactStr`, must be valid UTF-8. The caller must guarantee
+    /// that any modifications made to the underlying buffer are valid UTF-8.
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self) -> &[u8] {
+        self.repr.as_mut_slice()
     }
 
     #[inline]

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -153,7 +153,7 @@ impl CompactStr {
     /// * All Rust strings, including `CompactStr`, must be valid UTF-8. The caller must guarantee
     /// that any modifications made to the underlying buffer are valid UTF-8.
     #[inline]
-    pub unsafe fn as_mut_slice(&mut self) -> &[u8] {
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         self.repr.as_mut_slice()
     }
 

--- a/compact_str/src/repr/heap/arc.rs
+++ b/compact_str/src/repr/heap/arc.rs
@@ -78,7 +78,10 @@ impl ArcString {
 
             // Assign self to our new instsance
             *self = new;
-        };
+        } else {
+            // We were the sole reference of either kind; bump back up the strong ref count.
+            self.inner().ref_count.store(1, Ordering::Release);
+        }
 
         // Return a mutable slice to the underlying buffer
         //

--- a/compact_str/src/repr/heap/arc.rs
+++ b/compact_str/src/repr/heap/arc.rs
@@ -43,6 +43,25 @@ impl ArcString {
     }
 
     #[inline]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner().capacity
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        let buffer = self.inner().as_bytes();
+
+        // SAFETY: The only way you can construct an `ArcString` is via a `&str` so it must be valid
+        // UTF-8, or the caller has manually made those guarantees
+        unsafe { str::from_utf8_unchecked(&buffer[..self.len]) }
+    }
+
+    #[inline]
     pub unsafe fn make_mut_slice(&mut self) -> &mut [u8] {
         if self
             .inner()
@@ -69,22 +88,8 @@ impl ArcString {
     }
 
     #[inline]
-    pub const fn len(&self) -> usize {
-        self.len
-    }
-
-    #[inline]
-    pub fn capacity(&self) -> usize {
-        self.inner().capacity
-    }
-
-    #[inline]
-    pub fn as_str(&self) -> &str {
-        let buffer = self.inner().as_bytes();
-
-        // SAFETY: The only way you can construct an `ArcString` is via a `&str` so it must be valid
-        // UTF-8, or the caller has manually made those guarantees
-        unsafe { str::from_utf8_unchecked(&buffer[..self.len]) }
+    pub unsafe fn set_len(&mut self, length: usize) {
+        self.len = length;
     }
 
     /// Returns a shared reference to the heap allocated `ArcStringInner`

--- a/compact_str/src/repr/heap/mod.rs
+++ b/compact_str/src/repr/heap/mod.rs
@@ -38,6 +38,16 @@ impl HeapString {
 
         HeapString { padding, string }
     }
+
+    /// Makes a mutable reference to the underlying buffer, cloning if there is more than one out
+    /// standing reference.
+    ///
+    /// # Invariants
+    /// * Please see `super::Repr` for all invariants
+    #[inline]
+    pub unsafe fn make_mut_slice(&mut self) -> &mut [u8] {
+        self.string.make_mut_slice()
+    }
 }
 
 impl From<String> for HeapString {

--- a/compact_str/src/repr/heap/mod.rs
+++ b/compact_str/src/repr/heap/mod.rs
@@ -48,6 +48,11 @@ impl HeapString {
     pub unsafe fn make_mut_slice(&mut self) -> &mut [u8] {
         self.string.make_mut_slice()
     }
+
+    #[inline]
+    pub unsafe fn set_len(&mut self, length: usize) {
+        self.string.set_len(length)
+    }
 }
 
 impl From<String> for HeapString {

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -96,6 +96,14 @@ impl InlineString {
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.buffer[..]
     }
+
+    #[inline]
+    pub unsafe fn set_len(&mut self, length: usize) {
+        debug_assert!(length <= MAX_INLINE_SIZE);
+
+        // Set the leading bit mask, and then or our length
+        self.metadata = LEADING_BIT_MASK | length as u8;
+    }
 }
 
 static_assertions::assert_eq_size!(InlineString, String);

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -87,6 +87,15 @@ impl InlineString {
         // SAFETY: You can only construct an InlineString via a &str
         unsafe { ::std::str::from_utf8_unchecked(slice) }
     }
+
+    /// Provides a mutable reference to the underlying buffer
+    ///
+    /// # Invariants
+    /// * Please see `super::Repr` for all invariants
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.buffer[..]
+    }
 }
 
 static_assertions::assert_eq_size!(InlineString, String);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -93,7 +93,7 @@ impl Repr {
         let new_capacity = self.len() + additional;
 
         // We already have at least `additional` capacity, so we don't need to do anything
-        if self.capacity() > new_capacity {
+        if self.capacity() >= new_capacity {
             return;
         }
 

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -103,7 +103,7 @@ impl Repr {
         // Create a `HeapString` with `text.len() + additional` capacity
         let heap = HeapString::with_additional(self.as_str(), additional);
 
-        // Set self to this new String
+        // Replace `self` with the new Repr
         let heap = ManuallyDrop::new(heap);
         *self = Repr { heap };
     }

--- a/compact_str/src/repr/packed.rs
+++ b/compact_str/src/repr/packed.rs
@@ -71,6 +71,13 @@ impl PackedString {
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.buffer[..]
     }
+
+    #[inline]
+    pub unsafe fn set_len(&mut self, length: usize) {
+        // An invariant of the Packed representation is that the size always equals MAX_SIZE, so
+        // theres no work to do here, other than assert the length we're trying to set is MAX_SIZE
+        debug_assert_eq!(length, MAX_SIZE);
+    }
 }
 
 static_assertions::assert_eq_size!(PackedString, String);

--- a/compact_str/src/repr/packed.rs
+++ b/compact_str/src/repr/packed.rs
@@ -62,6 +62,15 @@ impl PackedString {
         // SAFETY: You can only construct a PackedString via a &str
         unsafe { ::std::str::from_utf8_unchecked(&self.buffer) }
     }
+
+    /// Provides a mutable reference to the underlying buffer
+    ///
+    /// # Invariants
+    /// * Please see `super::Repr` for all invariants
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.buffer[..]
+    }
 }
 
 static_assertions::assert_eq_size!(PackedString, String);


### PR DESCRIPTION
This PR adds an API to `CompactStr` that provides a mutable slice of the underlying buffer