### PR TITLE
feature: pb-jelly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
-Cargo.lock
+**/target
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["examples/serde", "compact_str", "tracing_alloc"]
+members = ["examples/pb-jelly","examples/pb-jelly/gen","examples/pb-jelly/protos/gen/proto_user", "examples/serde", "compact_str", "tracing_alloc"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["encoding", "parsing", "memory-management", "text-processing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = { version = "1" }
 pb-jelly = { version = "0.0.11" }
 serde = { version = "1", optional = true }
 static_assertions = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["encoding", "parsing", "memory-management", "text-processing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+pb-jelly = { version = "0.0.11" }
 serde = { version = "1", optional = true }
 static_assertions = "1"
 

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -14,10 +14,13 @@ categories = ["encoding", "parsing", "memory-management", "text-processing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = { version = "1" }
-pb-jelly = { version = "0.0.11" }
+bytes = { version = "1", optional = true }
+pb-jelly = { version = "0.0.11", optional = true }
 serde = { version = "1", optional = true }
 static_assertions = "1"
+
+[features]
+proto = ["bytes", "pb-jelly"]
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -1,0 +1,71 @@
+use core::str::Utf8Error;
+
+use bytes::Buf;
+
+use crate::{
+    CompactStr,
+    Repr,
+};
+
+impl CompactStr {
+    /// Converts a buffer of bytes to a `CompactStr`
+    pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
+        Repr::from_utf8_buf(buf).map(|repr| CompactStr { repr })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::CompactStr;
+    use proptest::prelude::*;
+    use proptest::strategy::Strategy;
+    use std::io::Cursor;
+
+    const MAX_INLINED_SIZE: usize = core::mem::size_of::<String>();
+
+    // generates random unicode strings, upto 80 chars long
+    fn rand_unicode() -> impl Strategy<Value = String> {
+        proptest::collection::vec(proptest::char::any(), 0..80).prop_map(|v| v.into_iter().collect())
+    }
+
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn test_buffers_roundtrip(word in rand_unicode()) {
+            let mut buf = Cursor::new(word.as_bytes());
+            let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+
+            prop_assert_eq!(&word, &compact);
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn test_allocated_properly(word in rand_unicode()) {
+            let mut buf = Cursor::new(word.as_bytes());
+            let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+
+            if word.len() < MAX_INLINED_SIZE {
+                prop_assert!(!compact.is_heap_allocated())
+            } else if word.len() == MAX_INLINED_SIZE && word.as_bytes()[0] <= 127 {
+                prop_assert!(!compact.is_heap_allocated())
+            } else {
+                prop_assert!(compact.is_heap_allocated())
+            }
+        }
+
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn test_only_accept_valid_utf8(bytes in proptest::collection::vec(any::<u8>(), 0..80)) {
+            let mut buf = Cursor::new(bytes.as_slice());
+
+            let compact_result = CompactStr::from_utf8_buf(&mut buf);
+            let str_result = core::str::from_utf8(bytes.as_slice());
+
+            match (compact_result, str_result) {
+                (Ok(c), Ok(s)) => prop_assert_eq!(c, s),
+                (Err(c_err), Err(s_err)) => prop_assert_eq!(c_err, s_err),
+                _ => panic!("CompactStr and core::str read UTF-8 differently?"),
+            }
+        }
+    }
+}

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -1,7 +1,8 @@
 //! A module that contains the implementations for optional features. For example `serde` support
 
+#[cfg(feature = "bytes")]
 mod bytes;
-// #[cfg(feature = "pb_jelly")]
+#[cfg(feature = "proto")]
 mod pb_jelly;
 #[cfg(feature = "serde")]
 mod serde;

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -1,5 +1,6 @@
 //! A module that contains the implementations for optional features. For example `serde` support
 
+mod bytes;
 // #[cfg(feature = "pb_jelly")]
 mod pb_jelly;
 #[cfg(feature = "serde")]

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -1,0 +1,6 @@
+//! A module that contains the implementations for optional features. For example `serde` support
+
+// #[cfg(feature = "pb_jelly")]
+mod pb_jelly;
+#[cfg(feature = "serde")]
+mod serde;

--- a/compact_str/src/features/pb_jelly.rs
+++ b/compact_str/src/features/pb_jelly.rs
@@ -1,6 +1,11 @@
-use pb_jelly::Message;
+use pb_jelly::{
+    Message,
+    Reflection,
+};
 
 use crate::CompactStr;
+
+impl Reflection for CompactStr {}
 
 impl Message for CompactStr {
     fn compute_size(&self) -> usize {

--- a/compact_str/src/features/pb_jelly.rs
+++ b/compact_str/src/features/pb_jelly.rs
@@ -1,5 +1,6 @@
-use crate::CompactStr;
 use pb_jelly::Message;
+
+use crate::CompactStr;
 
 impl Message for CompactStr {
     fn compute_size(&self) -> usize {
@@ -12,7 +13,12 @@ impl Message for CompactStr {
     }
 
     fn deserialize<B: pb_jelly::PbBufferReader>(&mut self, r: &mut B) -> std::io::Result<()> {
-
-        todo!()
+        match CompactStr::from_utf8_buf(r) {
+            Ok(compact) => {
+                *self = compact;
+                Ok(())
+            }
+            Err(_) => Err(std::io::ErrorKind::InvalidData.into()),
+        }
     }
 }

--- a/compact_str/src/features/pb_jelly.rs
+++ b/compact_str/src/features/pb_jelly.rs
@@ -1,0 +1,18 @@
+use crate::CompactStr;
+use pb_jelly::Message;
+
+impl Message for CompactStr {
+    fn compute_size(&self) -> usize {
+        self.len()
+    }
+
+    fn serialize<W: pb_jelly::PbBufferWriter>(&self, w: &mut W) -> std::io::Result<()> {
+        w.write_all(self.as_bytes())?;
+        Ok(())
+    }
+
+    fn deserialize<B: pb_jelly::PbBufferReader>(&mut self, r: &mut B) -> std::io::Result<()> {
+
+        todo!()
+    }
+}

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -7,7 +7,7 @@ use serde::de::{
     Visitor,
 };
 
-use super::CompactStr;
+use crate::CompactStr;
 
 fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<CompactStr, D::Error> {
     struct CompactStrVisitor;

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -22,11 +22,10 @@ use core::iter::FromIterator;
 use core::ops::Deref;
 use core::str::FromStr;
 
+mod features;
+
 mod repr;
 use repr::Repr;
-
-#[cfg(feature = "serde")]
-mod serde;
 
 #[cfg(test)]
 mod tests;

--- a/compact_str/src/repr/bytes.rs
+++ b/compact_str/src/repr/bytes.rs
@@ -1,0 +1,126 @@
+use core::str::Utf8Error;
+
+use bytes::Buf;
+
+use super::{
+    Repr,
+    MAX_SIZE,
+};
+
+#[cfg(target_pointer_width = "32")]
+const DEFAULT_TEXT: str = "000000000000";
+#[cfg(target_pointer_width = "64")]
+const DEFAULT_TEXT: &str = "000000000000000000000000";
+
+const DEFAULT_PACKED: Repr = Repr::new_const(DEFAULT_TEXT);
+
+impl Repr {
+    /// Converts a buffer of bytes to a `Repr`
+    pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
+        let size = buf.remaining();
+        let chunk = buf.chunk();
+
+        // Check to make sure we're not empty, so accessing the first byte below doesn't panic
+        if chunk.is_empty() {
+            // If the chunk is empty, then we should have 0 remaining bytes
+            debug_assert_eq!(size, 0);
+            return Ok(super::EMPTY);
+        }
+        let first_byte = buf.chunk()[0];
+
+        // Get an "empty" Repr we can write into
+        //
+        // HACK: There currently isn't a way to provide an "empty" Packed repr, so we do this check
+        // and return a "default" Packed repr if the buffer can fit
+        let mut repr = if size == MAX_SIZE && first_byte <= 127 {
+            // Note: No need to reserve additional bytes here, because we know we can fit all
+            // remaining bytes of `buf` into a Packed repr
+            DEFAULT_PACKED
+        } else {
+            let mut default = super::EMPTY;
+            debug_assert_eq!(default.len(), 0);
+
+            // Reserve enough bytes, possibly allocating on the heap, to store the text
+            default.reserve(size);
+
+            default
+        };
+
+        // SAFETY: Before returning this Repr we check to make sure the provided bytes are valid
+        // UTF-8
+        let slice = unsafe { repr.as_mut_slice() };
+        // Copy the bytes from the buffer into our Repr!
+        buf.copy_to_slice(&mut slice[..size]);
+
+        // Set the length of the Repr
+        // SAFETY: We just wrote `size` bytes into the Repr
+        unsafe { repr.set_len(size) };
+
+        // Check to make sure the provided bytes are valid UTF-8, return the Repr if they are!
+        //
+        // TODO: Add an `as_slice()` method to Repr and refactor this call
+        match core::str::from_utf8(repr.as_str().as_bytes()) {
+            Ok(_) => Ok(repr),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+
+    use super::Repr;
+
+    #[test]
+    fn test_smoke() {
+        let word = "hello world";
+        let mut buf = Cursor::new(word.as_bytes());
+
+        let repr = Repr::from_utf8_buf(&mut buf).unwrap();
+        assert_eq!(repr.as_str(), word);
+    }
+
+    #[test]
+    fn test_heap_allocated() {
+        let word = "hello, this is a long string which should be heap allocated";
+        let mut buf = Cursor::new(word.as_bytes());
+
+        let repr = Repr::from_utf8_buf(&mut buf).unwrap();
+        assert_eq!(repr.as_str(), word);
+    }
+
+    #[test]
+    fn test_empty() {
+        let mut buf: Cursor<&[u8]> = Cursor::new(&[]);
+
+        let repr = Repr::from_utf8_buf(&mut buf).unwrap();
+        assert_eq!(repr.len(), 0);
+        assert_eq!(repr.as_str(), "");
+    }
+
+    #[test]
+    fn test_packed() {
+        #[cfg(target_pointer_width = "64")]
+        let packed = "this string is 24 chars!";
+        #[cfg(target_pointer_width = "32")]
+        let packed = "i am 12 char";
+
+        let mut buf = Cursor::new(packed.as_bytes());
+
+        let repr = Repr::from_utf8_buf(&mut buf).unwrap();
+        assert_eq!(repr.as_str(), packed);
+
+        // This repr should __not__ be heap allocated
+        assert!(!repr.is_heap_allocated());
+    }
+
+    #[test]
+    #[should_panic(expected = "Utf8Error")]
+    fn test_invalid_utf8() {
+        let invalid = &[0, 159];
+        let mut buf: Cursor<&[u8]> = Cursor::new(invalid);
+
+        Repr::from_utf8_buf(&mut buf).unwrap();
+    }
+}

--- a/compact_str/src/repr/heap/arc.rs
+++ b/compact_str/src/repr/heap/arc.rs
@@ -22,6 +22,8 @@ pub struct ArcString {
     len: usize,
     ptr: ptr::NonNull<ArcStringInner>,
 }
+unsafe impl Sync for ArcString {}
+unsafe impl Send for ArcString {}
 
 impl ArcString {
     #[inline]

--- a/compact_str/src/repr/heap/mod.rs
+++ b/compact_str/src/repr/heap/mod.rs
@@ -1,5 +1,7 @@
 use std::mem;
 
+use std::sync::Arc;
+
 use super::{
     HEAP_MASK,
     MAX_SIZE,

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -5,7 +5,9 @@ use static_assertions::{
     const_assert_eq,
 };
 
+#[cfg(feature = "bytes")]
 mod bytes;
+
 mod iter;
 
 mod discriminant;

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -5,6 +5,7 @@ use static_assertions::{
     const_assert_eq,
 };
 
+mod bytes;
 mod iter;
 
 mod discriminant;

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -220,3 +220,9 @@ fn test_from_char_iter() {
     assert!(compact.is_heap_allocated());
     assert_eq!(s, compact);
 }
+
+#[test]
+fn test_compact_str_is_send_and_sync() {
+    fn is_send_and_sync<T: Send + Sync>() {}
+    is_send_and_sync::<CompactStr>();
+}

--- a/examples/pb-jelly/Cargo.toml
+++ b/examples/pb-jelly/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pb-jelly"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+compact_str = { path = "../../compact_str", features = ["proto"] }
+pb-jelly = "0.0.11"
+proto_user = { path = "protos/gen/proto_user" }

--- a/examples/pb-jelly/gen/Cargo.toml
+++ b/examples/pb-jelly/gen/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gen"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+pb-jelly-gen = "0.0.11"

--- a/examples/pb-jelly/gen/src/main.rs
+++ b/examples/pb-jelly/gen/src/main.rs
@@ -1,0 +1,11 @@
+use pb_jelly_gen::GenProtos;
+
+fn main() -> std::io::Result<()> {
+    GenProtos::builder()
+        .out_path("../protos/gen")
+        .src_path("../protos")
+        .cleanup_out_path(true)
+        .gen_protos();
+
+    Ok(())
+}

--- a/examples/pb-jelly/protos/gen/proto_user/Cargo.toml
+++ b/examples/pb-jelly/protos/gen/proto_user/Cargo.toml
@@ -1,0 +1,10 @@
+# @generated, do not edit
+[package]
+name = "proto_user"
+version = "0.0.1"
+edition = "2018"
+
+[dependencies]
+compact_str = { path = "../../../../../compact_str", features = ["proto"] }
+lazy_static = { version = "1.4.0" }
+pb-jelly = { version = "0.0.11" }

--- a/examples/pb-jelly/protos/gen/proto_user/src/basic.rs
+++ b/examples/pb-jelly/protos/gen/proto_user/src/basic.rs
@@ -1,0 +1,327 @@
+// @generated, do not edit
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Address {
+  pub street: ::compact_str::CompactStr,
+  pub city: ::compact_str::CompactStr,
+}
+impl ::std::default::Default for Address {
+  fn default() -> Self {
+    Address {
+      street: ::std::default::Default::default(),
+      city: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref Address_default: Address = Address::default();
+}
+impl ::pb_jelly::Message for Address {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "Address",
+      full_name: "basic.Address",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "street",
+          full_name: "basic.Address.street",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "city",
+          full_name: "basic.Address.city",
+          index: 1,
+          number: 2,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut street_size = 0;
+    if self.street != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.street;
+      let l = ::pb_jelly::Message::compute_size(val);
+      street_size += ::pb_jelly::wire_format::serialized_length(1);
+      street_size += ::pb_jelly::varint::serialized_length(l as u64);
+      street_size += l;
+    }
+    size += street_size;
+    let mut city_size = 0;
+    if self.city != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.city;
+      let l = ::pb_jelly::Message::compute_size(val);
+      city_size += ::pb_jelly::wire_format::serialized_length(2);
+      city_size += ::pb_jelly::varint::serialized_length(l as u64);
+      city_size += l;
+    }
+    size += city_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    if self.street != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.street;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    if self.city != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.city;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.street != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.street;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    if self.city != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.city;
+      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Address", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: ::compact_str::CompactStr = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.street = val;
+        }
+        2 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "Address", 2)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: ::compact_str::CompactStr = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.city = val;
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for Address {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "street" => {
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.street)
+      }
+      "city" => {
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.city)
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct User {
+  pub name: ::compact_str::CompactStr,
+  pub age: u32,
+  pub address: ::std::option::Option<Address>,
+}
+impl ::std::default::Default for User {
+  fn default() -> Self {
+    User {
+      name: ::std::default::Default::default(),
+      age: ::std::default::Default::default(),
+      address: ::std::default::Default::default(),
+    }
+  }
+}
+lazy_static! {
+  pub static ref User_default: User = User::default();
+}
+impl ::pb_jelly::Message for User {
+  fn descriptor(&self) -> ::std::option::Option<::pb_jelly::MessageDescriptor> {
+    Some(::pb_jelly::MessageDescriptor {
+      name: "User",
+      full_name: "basic.User",
+      fields: &[
+        ::pb_jelly::FieldDescriptor {
+          name: "name",
+          full_name: "basic.User.name",
+          index: 0,
+          number: 1,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "age",
+          full_name: "basic.User.age",
+          index: 1,
+          number: 2,
+          typ: ::pb_jelly::wire_format::Type::Varint,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+        ::pb_jelly::FieldDescriptor {
+          name: "address",
+          full_name: "basic.User.address",
+          index: 2,
+          number: 3,
+          typ: ::pb_jelly::wire_format::Type::LengthDelimited,
+          label: ::pb_jelly::Label::Optional,
+          oneof_index: None,
+        },
+      ],
+      oneofs: &[
+      ],
+    })
+  }
+  fn compute_size(&self) -> usize {
+    let mut size = 0;
+    let mut name_size = 0;
+    if self.name != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.name;
+      let l = ::pb_jelly::Message::compute_size(val);
+      name_size += ::pb_jelly::wire_format::serialized_length(1);
+      name_size += ::pb_jelly::varint::serialized_length(l as u64);
+      name_size += l;
+    }
+    size += name_size;
+    let mut age_size = 0;
+    if self.age != <u32 as ::std::default::Default>::default() {
+      let val = &self.age;
+      let l = ::pb_jelly::Message::compute_size(val);
+      age_size += ::pb_jelly::wire_format::serialized_length(2);
+      age_size += l;
+    }
+    size += age_size;
+    let mut address_size = 0;
+    for val in &self.address {
+      let l = ::pb_jelly::Message::compute_size(val);
+      address_size += ::pb_jelly::wire_format::serialized_length(3);
+      address_size += ::pb_jelly::varint::serialized_length(l as u64);
+      address_size += l;
+    }
+    size += address_size;
+    size
+  }
+  fn compute_grpc_slices_size(&self) -> usize {
+    let mut size = 0;
+    if self.name != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.name;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    if self.age != <u32 as ::std::default::Default>::default() {
+      let val = &self.age;
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    for val in &self.address {
+      size += ::pb_jelly::Message::compute_grpc_slices_size(val);
+    }
+    size
+  }
+  fn serialize<W: ::pb_jelly::PbBufferWriter>(&self, w: &mut W) -> ::std::io::Result<()> {
+    if self.name != <::compact_str::CompactStr as ::std::default::Default>::default() {
+      let val = &self.name;
+      ::pb_jelly::wire_format::write(1, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    if self.age != <u32 as ::std::default::Default>::default() {
+      let val = &self.age;
+      ::pb_jelly::wire_format::write(2, ::pb_jelly::wire_format::Type::Varint, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    for val in &self.address {
+      ::pb_jelly::wire_format::write(3, ::pb_jelly::wire_format::Type::LengthDelimited, w)?;
+      let l = ::pb_jelly::Message::compute_size(val);
+      ::pb_jelly::varint::write(l as u64, w)?;
+      ::pb_jelly::Message::serialize(val, w)?;
+    }
+    Ok(())
+  }
+  fn deserialize<B: ::pb_jelly::PbBufferReader>(&mut self, mut buf: &mut B) -> ::std::io::Result<()> {
+    while let Some((field_number, typ)) = ::pb_jelly::wire_format::read(&mut buf)? {
+      match field_number {
+        1 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "User", 1)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: ::compact_str::CompactStr = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.name = val;
+        }
+        2 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::Varint, "User", 2)?;
+          let mut val: u32 = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, buf)?;
+          self.age = val;
+        }
+        3 => {
+          ::pb_jelly::ensure_wire_format(typ, ::pb_jelly::wire_format::Type::LengthDelimited, "User", 3)?;
+          let len = ::pb_jelly::varint::ensure_read(&mut buf)?;
+          let mut next = ::pb_jelly::ensure_split(buf, len as usize)?;
+          let mut val: Address = ::std::default::Default::default();
+          ::pb_jelly::Message::deserialize(&mut val, &mut next)?;
+          self.address = Some(val);
+        }
+        _ => {
+          ::pb_jelly::skip(typ, &mut buf)?;
+        }
+      }
+    }
+    Ok(())
+  }
+}
+impl ::pb_jelly::Reflection for User {
+  fn which_one_of(&self, oneof_name: &str) -> ::std::option::Option<&'static str> {
+    match oneof_name {
+      _ => {
+        panic!("unknown oneof name given");
+      }
+    }
+  }
+  fn get_field_mut(&mut self, field_name: &str) -> ::pb_jelly::reflection::FieldMut<'_> {
+    match field_name {
+      "name" => {
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.name)
+      }
+      "age" => {
+        ::pb_jelly::reflection::FieldMut::Value(&mut self.age)
+      }
+      "address" => {
+        ::pb_jelly::reflection::FieldMut::Value(self.address.get_or_insert_with(::std::default::Default::default))
+      }
+      _ => {
+        panic!("unknown field name given")
+      }
+    }
+  }
+}
+

--- a/examples/pb-jelly/protos/gen/proto_user/src/lib.rs
+++ b/examples/pb-jelly/protos/gen/proto_user/src/lib.rs
@@ -1,0 +1,27 @@
+// @generated, do not edit
+
+#![warn(rust_2018_idioms)]
+#![allow(irrefutable_let_patterns)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(irrefutable_let_patterns)]
+#![allow(broken_intra_doc_links)]
+
+// Modules are generated based on the naming conventions of protobuf, which might cause "module inception"
+#![allow(clippy::module_inception)]
+// This is all generated code, so "manually" implementing derivable impls is okay
+#![allow(clippy::derivable_impls)]
+// For enums with many variants, the matches!(...) macro isn't obviously better
+#![allow(clippy::match_like_matches_macro)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::option_as_ref_deref)]
+// TODO: Ideally we don't allow this
+#![allow(clippy::match_single_binding)]
+
+#[macro_use]
+extern crate lazy_static;
+
+pub mod basic;

--- a/examples/pb-jelly/protos/user/basic.proto
+++ b/examples/pb-jelly/protos/user/basic.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package basic;
+
+// rust/extensions.proto is included by default
+import "rust/extensions.proto";
+
+message Address {
+    string street = 1 [(rust.type)="::compact_str::CompactStr"];
+    string city = 2 [(rust.type)="::compact_str::CompactStr"];
+}
+
+message User {
+    string name = 1 [(rust.type)="::compact_str::CompactStr"];
+    uint32 age = 2;
+    Address address = 3;
+}

--- a/examples/pb-jelly/src/main.rs
+++ b/examples/pb-jelly/src/main.rs
@@ -1,0 +1,22 @@
+use compact_str::CompactStr;
+use pb_jelly::Message;
+use proto_user::basic::{
+    Address,
+    User,
+};
+
+fn main() {
+    let user = User {
+        name: CompactStr::new_inline("John"),
+        age: 42,
+        address: Some(Address {
+            street: "432 Park Ave".into(),
+            city: "New York City".into(),
+        })
+    };
+    let bytes = user.serialize_to_vec();
+
+    let roundtrip_user = User::deserialize_from_slice(&bytes).unwrap();
+    println!("{:#?}", roundtrip_user);
+    assert_eq!(user, roundtrip_user);
+}


### PR DESCRIPTION
This PR implements the [`Message`](https://docs.rs/pb-jelly/0.0.11/pb_jelly/trait.Message.html) and [`Reflection`](https://docs.rs/pb-jelly/0.0.11/pb_jelly/reflection/trait.Reflection.html) traits from [`pb-jelly`](https://github.com/dropbox/pb-jelly). This allows users to use `CompactStr` in protobuf files.

Note: Would need to resolve an issue in `pb-jelly` with the generated `Cargo.toml` to get it working 100%