### PR TITLE
vendor: static-assertions

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["encoding", "parsing", "memory-management", "text-processing"]
 [dependencies]
 bytes = { version = "1", optional = true }
 serde = { version = "1", optional = true }
-static_assertions = "1"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/compact_str/src/asserts.rs
+++ b/compact_str/src/asserts.rs
@@ -1,0 +1,42 @@
+//! Macros used to statically assert the size different components (e.g. structs).
+//!
+//! These macros were directly copied from the [`static-assertions`]
+//! (https://github.com/nvzqz/static-assertions-rs) crate with the following license:
+//!
+//! MIT License
+//!
+//! Copyright (c) 2017 Nikolai Vazquez
+//!
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//!
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//!
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+
+macro_rules! assert_size_eq {
+    ($x:ty, $($xs:ty),+ $(,)?) => {
+        const _: fn() = || {
+            $(let _ = ::core::mem::transmute::<$x, $xs>;)+
+        };
+    };
+}
+pub(crate) use assert_size_eq;
+
+macro_rules! assert_size {
+    ($x:ty, $s:expr) => {
+        const _: [u8; ::core::mem::size_of::<$x>()] = [0; $s];
+    };
+}
+pub(crate) use assert_size;

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -24,6 +24,7 @@ use core::iter::FromIterator;
 use core::ops::Deref;
 use core::str::FromStr;
 
+mod asserts;
 mod features;
 
 mod repr;
@@ -616,4 +617,4 @@ impl Extend<String> for CompactStr {
     }
 }
 
-static_assertions::assert_eq_size!(CompactStr, String);
+crate::asserts::assert_size_eq!(CompactStr, String);

--- a/compact_str/src/repr/arc/mod.rs
+++ b/compact_str/src/repr/arc/mod.rs
@@ -290,4 +290,4 @@ mod test {
     }
 }
 
-static_assertions::const_assert_eq!(mem::size_of::<ArcString>(), 2 * mem::size_of::<usize>());
+crate::asserts::assert_size!(ArcString, 2 * mem::size_of::<usize>());

--- a/compact_str/src/repr/discriminant.rs
+++ b/compact_str/src/repr/discriminant.rs
@@ -33,4 +33,4 @@ impl DiscriminantMask {
     }
 }
 
-static_assertions::assert_eq_size!(DiscriminantMask, String);
+crate::asserts::assert_size_eq!(DiscriminantMask, String);

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -74,4 +74,4 @@ impl From<String> for HeapString {
     }
 }
 
-static_assertions::assert_eq_size!(HeapString, String);
+crate::asserts::assert_size_eq!(HeapString, String);

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -108,7 +108,7 @@ impl InlineString {
     }
 }
 
-static_assertions::assert_eq_size!(InlineString, String);
+crate::asserts::assert_size_eq!(InlineString, String);
 
 #[cfg(test)]
 mod tests {

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1,11 +1,6 @@
 use std::iter::Extend;
 use std::mem::ManuallyDrop;
 
-use static_assertions::{
-    assert_eq_size,
-    const_assert_eq,
-};
-
 #[cfg(feature = "bytes")]
 mod bytes;
 
@@ -470,12 +465,12 @@ impl<'a> MutStrongRepr<'a> {
     }
 }
 
-assert_eq_size!(Repr, String);
+crate::asserts::assert_size_eq!(Repr, String);
 
 #[cfg(target_pointer_width = "64")]
-const_assert_eq!(std::mem::size_of::<Repr>(), 24);
+crate::asserts::assert_size!(Repr, 24);
 #[cfg(target_pointer_width = "32")]
-const_assert_eq!(std::mem::size_of::<Repr>(), 12);
+crate::asserts::assert_size!(Repr, 12);
 
 #[cfg(test)]
 mod tests {

--- a/compact_str/src/repr/packed.rs
+++ b/compact_str/src/repr/packed.rs
@@ -92,4 +92,4 @@ impl PackedString {
     }
 }
 
-static_assertions::assert_eq_size!(PackedString, String);
+crate::asserts::assert_size_eq!(PackedString, String);


### PR DESCRIPTION
This PR vendors the two macros that are used from the [`static-assertions`](https://github.com/nvzqz/static-assertions-rs) crate. 

This removes what was the only required dependency from `compact_str` which has a marginal benefit in compile time and binary size, but now allows the library to be dependency free