### PR TITLE
feature: Add from_utf8 API

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -22,7 +22,10 @@ use core::hash::{
 };
 use core::iter::FromIterator;
 use core::ops::Deref;
-use core::str::FromStr;
+use core::str::{
+    FromStr,
+    Utf8Error,
+};
 
 mod asserts;
 mod features;
@@ -197,6 +200,39 @@ impl CompactStr {
         CompactStr {
             repr: Repr::with_capacity(capacity),
         }
+    }
+
+    /// Convert a slice of bytes into a [`CompactStr`].
+    ///
+    /// A [`CompactStr`] is a contiguous collection of bytes (`u8`s) that is valid [`UTF-8`](https://en.wikipedia.org/wiki/UTF-8).
+    /// This method converts from an arbitrary contiguous collection of bytes into a [`CompactStr`],
+    /// failing if the provided bytes are not `UTF-8`.
+    ///
+    /// Note: If you want to create a [`CompactStr`] from a non-contiguous collection of bytes, enable
+    /// the `bytes` feature of this crate, and checkout [`CompactStr::from_utf8_buf`]
+    ///
+    /// # Examples
+    /// ### Valid UTF-8
+    /// ```
+    /// # use compact_str::CompactStr;
+    /// let bytes = vec![240, 159, 166, 128, 240, 159, 146, 175];
+    /// let compact = CompactStr::from_utf8(bytes).expect("valid UTF-8");
+    ///
+    /// assert_eq!(compact, "🦀💯");
+    /// ```
+    ///
+    /// ### Invalid UTF-8
+    /// ```
+    /// # use compact_str::CompactStr;
+    /// let bytes = vec![255, 255, 255];
+    /// let result = CompactStr::from_utf8(bytes);
+    ///
+    /// assert!(result.is_err());
+    /// ```
+    #[inline]
+    pub fn from_utf8<B: AsRef<[u8]>>(buf: B) -> Result<Self, Utf8Error> {
+        let repr = Repr::from_utf8(buf)?;
+        Ok(CompactStr { repr })
     }
 
     /// Returns the length of the `CompactStr` in `bytes`, not `chars` or graphemes.

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -208,8 +208,8 @@ impl CompactStr {
     /// This method converts from an arbitrary contiguous collection of bytes into a [`CompactStr`],
     /// failing if the provided bytes are not `UTF-8`.
     ///
-    /// Note: If you want to create a [`CompactStr`] from a non-contiguous collection of bytes, enable
-    /// the `bytes` feature of this crate, and checkout [`CompactStr::from_utf8_buf`]
+    /// Note: If you want to create a [`CompactStr`] from a non-contiguous collection of bytes,
+    /// enable the `bytes` feature of this crate, and checkout [`CompactStr::from_utf8_buf`]
     ///
     /// # Examples
     /// ### Valid UTF-8

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1,5 +1,6 @@
 use std::iter::Extend;
 use std::mem::ManuallyDrop;
+use std::str::Utf8Error;
 
 #[cfg(feature = "bytes")]
 mod bytes;
@@ -76,6 +77,14 @@ impl Repr {
             let heap = ManuallyDrop::new(HeapString::with_capacity(capacity));
             Repr { heap }
         }
+    }
+
+    #[inline]
+    pub fn from_utf8<B: AsRef<[u8]>>(buf: B) -> Result<Self, Utf8Error> {
+        // Get a &str from the Vec, failing if it's not valid UTF-8
+        let s = core::str::from_utf8(buf.as_ref())?;
+        // Construct a Repr from the &str
+        Ok(Self::new(s))
     }
 
     #[inline]

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -80,7 +80,7 @@ impl Creation<'_> {
                     }
                     _ => panic!("CompactStr and core::str read UTF-8 differently?"),
                 }
-            },
+            }
             // Create a `CompactStr` from a buffer of bytes
             Buf(data) => {
                 let mut buffer = Cursor::new(data);

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -62,8 +62,8 @@ impl Creation<'_> {
             }
             // Create a `CompactStr` from a slice of bytes
             Bytes(data) => {
-                let compact = CompactStr::from_utf8(&data);
-                let std_str = std::str::from_utf8(&data);
+                let compact = CompactStr::from_utf8(data);
+                let std_str = std::str::from_utf8(data);
 
                 match (compact, std_str) {
                     // valid UTF-8


### PR DESCRIPTION
This PR adds a `CompactStr::from_utf8(...)` API that is similar to `String::from_utf8(...)`. It also adds property based testing and fuzz testing for the new API