### PR TITLE
docs: Improve and add workflow to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-features
+          args: --tests --all-features
 
   test:
     name: cargo test

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -42,3 +42,20 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
+
+  doc:
+    name: cargo doc
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features --no-deps --manifest-path compact_str/Cargo.toml

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,14 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        name: Checkout compact_str
       - uses: actions-rs/toolchain@v1
+        name: Install Rust
         with:
           profile: minimal
           # We currently use some unstable features in rustfmt, hence the nightly toolchain
           toolchain: nightly
           override: true
       - run: rustup component add rustfmt
+        name: Add rustfmt
       - uses: actions-rs/cargo@v1
+        name: Run rustfmt
         with:
           command: fmt
           args: --all -- --check
@@ -33,13 +37,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        name: Checkout compact_str
       - uses: actions-rs/toolchain@v1
+        name: Install Rust
         with:
           profile: minimal
           toolchain: stable
           override: true
       - run: rustup component add clippy
+        name: Add clippy
       - uses: actions-rs/cargo@v1
+        name: Run clippy
         with:
           command: clippy
 
@@ -50,12 +58,15 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
+        name: Checkout compact_str
       - uses: actions-rs/toolchain@v1
+        name: Install Rust
         with:
           profile: minimal
           toolchain: stable
           override: true
       - uses: actions-rs/cargo@v1
+        name: Run rustdoc
         with:
           command: doc
           args: --all-features --no-deps --manifest-path compact_str/Cargo.toml

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
 
   macos:
     name: macOS
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
 
   linux_arm7:
     name: Linux ARMv7
@@ -56,7 +56,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
 
   linux_32bit:
     name: Linux 32-bit
@@ -72,7 +72,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu -- --include-ignored
 
   linux_mips_le_32bit:
     name: Linux MIPS Little Endian 32-bit
@@ -88,7 +88,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu -- --include-ignored
 
   linux_powerpc_le_64bit:
     name: Linux PowerPC Little Endian 64-bit
@@ -104,4 +104,4 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --all-features --manifest-path=compact_str/Cargo.toml --target powerpc64le-unknown-linux-gnu
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target powerpc64le-unknown-linux-gnu -- --include-ignored

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml
 
   linux_32bit:
     name: Linux 32-bit
@@ -72,7 +72,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu -- --include-ignored
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu
 
   linux_mips_le_32bit:
     name: Linux MIPS Little Endian 32-bit
@@ -88,7 +88,7 @@ jobs:
         with:
           use-cross: true
           command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu -- --include-ignored
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu
 
   linux_powerpc_le_64bit:
     name: Linux PowerPC Little Endian 64-bit

--- a/compact_str/src/asserts.rs
+++ b/compact_str/src/asserts.rs
@@ -1,7 +1,7 @@
 //! Macros used to statically assert the size different components (e.g. structs).
 //!
-//! These macros were directly copied from the [`static-assertions`]
-//! (https://github.com/nvzqz/static-assertions-rs) crate with the following license:
+//! These macros were directly copied from the [`static-assertions`](https://github.com/nvzqz/static-assertions-rs)
+//! crate with the following license:
 //!
 //! MIT License
 //!

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 impl CompactStr {
-    /// Converts a buffer of bytes to a `CompactStr`
+    /// Converts a buffer of bytes to a [`CompactStr`]
     ///
     /// # Examples
     /// ### Basic usage
@@ -39,7 +39,7 @@ impl CompactStr {
         Repr::from_utf8_buf(buf).map(|repr| CompactStr { repr })
     }
 
-    /// Converts a buffer of bytes to a `CompactStr`, without checking that the provided buffer is
+    /// Converts a buffer of bytes to a [`CompactStr`], without checking that the provided buffer is
     /// valid UTF-8.
     ///
     /// # Safety

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -34,7 +34,7 @@ fn rand_unicode_collection() -> impl Strategy<Value = Vec<String>> {
     proptest::collection::vec(rand_unicode(), 0..40)
 }
 
-/// Asserts a CompactStr is allocated properly
+/// Asserts a [`CompactStr`] is allocated properly
 fn assert_allocated_properly(compact: &CompactStr) {
     if compact.len() <= MAX_SIZE {
         assert!(!compact.is_heap_allocated())


### PR DESCRIPTION
This PR does a few things:

1. Uses intra-doc links to (ideally) make the documentation easier to navigate and understand
2. Adds a workflow in CI that builds docs and denys warnings to make sure our links are up-to-date
3. Adds more documentation and a few more doc tests
4. Update docs after change to `BoxString` introduced in #56 