### PR TITLE
impl From<Cow<'_, str>> for CompactStr

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -26,6 +26,7 @@ use core::str::{
     FromStr,
     Utf8Error,
 };
+use std::borrow::Cow;
 
 mod asserts;
 mod features;
@@ -564,6 +565,12 @@ impl From<String> for CompactStr {
 impl<'a> From<&'a String> for CompactStr {
     fn from(s: &'a String) -> Self {
         CompactStr::new(&s)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for CompactStr {
+    fn from(s: Cow<'a, str>) -> Self {
+        CompactStr::new(s)
     }
 }
 


### PR DESCRIPTION
Super small; just something I noticed when I went to benchmark replacing `smartstring` with `compact_str` in one of my projects :)

Kudos on the awesome crate!  It turns out that, at least in `imdb_async`, I deal with a _lot_ of strings that are 24 bytes in length.  Average performance seems to be approx. 10% faster with `compact_str` for that crate, presumably a result of increasing the allocation threshold from 23 to 24 bytes.