### PR TITLE
version: 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Upcoming
-* impl `Extend<Cow<'_, str>>` for `CompactStr`
-    * Implemented in [`#64 feature: impl Extend<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/64)
-* impl `From<Cow<'_, str>>` for `CompactStr`
-    * Implemented in [`#62 impl From<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/62)
 
 
 # 0.3.1
-### March 1, 2022
+### March 6, 2022
+* impl `Extend<Cow<str>>` for `CompactStr`
+    * Implemented in [`#64 feature: impl Extend<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/64)
 * impl `From<Cow<str>>` for `CompactStr`
     * Implemented in [`#62 impl From<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/62)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
     * Implemented in [`#62 impl From<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/62)
 
 
+# 0.3.1
+### March 1, 2022
+* impl `From<Cow<str>>` for `CompactStr`
+    * Implemented in [`#62 impl From<Cow<'_, str>> for CompactStr`](https://github.com/ParkMyCar/compact_str/pull/62)
+
 # 0.3.0
-### February 27, 2021
+### February 27, 2022
 * Add `CompactStr::from_utf8(...)` API
     * Implemented in [`#57 feature: Add from_utf8 API`](https://github.com/ParkMyCar/compact_str/pull/57)
 * Changed the heap variant from an atomically reference counted string, to a normal heap allocated string

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient immutable string type that transparently stores strings on the stack, when possible"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR updates the version of `compact_str` to `v0.3.1` and updates the CHANGELOG accordingly