### PR TITLE
chore: Cleanup use of proptest with test-strategy

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -19,3 +19,4 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
+test-strategy = "0.2"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -19,4 +19,4 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
-test-strategy = "0.2"
+test-strategy = "0.1.2"

--- a/compact_str/src/repr/arc/mod.rs
+++ b/compact_str/src/repr/arc/mod.rs
@@ -206,9 +206,10 @@ impl Extend<String> for ArcString {
 #[cfg(test)]
 mod test {
     use proptest::prelude::*;
-    use proptest::strategy::Strategy;
+    use test_strategy::proptest;
 
     use super::ArcString;
+    use crate::tests::rand_unicode;
 
     #[test]
     fn test_empty() {
@@ -277,19 +278,11 @@ mod test {
         assert_eq!(arc_str.len, example.len());
     }
 
-    // generates random unicode strings, upto 80 chars long
-    fn rand_unicode() -> impl Strategy<Value = String> {
-        proptest::collection::vec(proptest::char::any(), 0..80)
-            .prop_map(|v| v.into_iter().collect())
-    }
-
-    proptest! {
-        #[test]
-        #[cfg_attr(miri, ignore)]
-        fn test_strings_roundtrip(word in rand_unicode()) {
-            let arc_str = ArcString::from(word.as_str());
-            prop_assert_eq!(&word, arc_str.as_str());
-        }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
+        let arc_str = ArcString::from(word.as_str());
+        prop_assert_eq!(&word, arc_str.as_str());
     }
 }
 

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -116,12 +116,13 @@ mod tests {
     use std::convert::TryFrom;
 
     use proptest::prelude::*;
+    use test_strategy::proptest;
 
     use super::{
         InlineString,
         MAX_SIZE,
     };
-    use crate::tests::rand_unicode_bytes;
+    use crate::tests::rand_unicode_with_max_len;
 
     #[test]
     fn test_sanity() {
@@ -133,15 +134,13 @@ mod tests {
         assert_eq!(inline.capacity(), MAX_SIZE);
     }
 
-    proptest! {
-        #[test]
-        #[cfg_attr(miri, ignore)]
-        fn test_roundtrip(s in rand_unicode_bytes(MAX_SIZE)) {
-            let inline = InlineString::new(&s);
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_roundtrip(#[strategy(rand_unicode_with_max_len(MAX_SIZE))] s: String) {
+        let inline = InlineString::new(&s);
 
-            assert_eq!(inline.as_str(), s);
-            assert_eq!(inline.len(), s.len());
-        }
+        prop_assert_eq!(inline.len(), s.len());
+        prop_assert_eq!(inline.as_str(), s);
     }
 
     #[test]


### PR DESCRIPTION
This PR uses the newer [`test-strategy`](https://github.com/frozenlib/test-strategy) crate, specifically the `#[proptest]` macro to, IMO, make the use a `proptest` a bit cleaner