### PR TITLE
refactor: Rename CompactStr to CompactString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Upcoming
+* Rename `CompactStr` to `CompactString`, add deprecation note for `CompactStr`
 
 # 0.3.2
 ### March 27, 2022

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@
 <br />
 
 ### About
-A `CompactStr` is a more memory efficient string type, that can store smaller strings on the stack, and transparently stores longer strings on the heap (aka a small string optimization).
+A `CompactString` is a more memory efficient string type, that can store smaller strings on the stack, and transparently stores longer strings on the heap (aka a small string optimization).
 They can mostly be used as a drop in replacement for `String` and are particularly useful in parsing, deserializing, or any other application where you may
 have smaller strings.
 
 ### Properties
-A `CompactStr` specifically has the following properties:
-  * `size_of::<CompactStr>() == size_of::<String>()`
+A `CompactString` specifically has the following properties:
+  * `size_of::<CompactString>() == size_of::<String>()`
   * Stores up to 24 bytes on the stack
     * 12 bytes if running on a 32 bit architecture
   * Strings longer than 24 bytes are stored on the heap
@@ -49,8 +49,8 @@ A `CompactStr` specifically has the following properties:
 
 ### Features
 `compact_str` has the following features:
-1. `serde`, which implements [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) and [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) from the popular [`serde`](https://docs.rs/serde/latest/serde/) crate, for `CompactStr`.
-2. `bytes`, which provides two methods `from_utf8_buf<B: Buf>(buf: &mut B)` and `from_utf8_buf_unchecked<B: Buf>(buf: &mut B)`, which allows for the creation of a `CompactStr` from a [`bytes::Buf`](https://docs.rs/bytes/latest/bytes/trait.Buf.html)
+1. `serde`, which implements [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) and [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) from the popular [`serde`](https://docs.rs/serde/latest/serde/) crate, for `CompactString`.
+2. `bytes`, which provides two methods `from_utf8_buf<B: Buf>(buf: &mut B)` and `from_utf8_buf_unchecked<B: Buf>(buf: &mut B)`, which allows for the creation of a `CompactString` from a [`bytes::Buf`](https://docs.rs/bytes/latest/bytes/trait.Buf.html)
 
 ### How it works
 Note: this explanation assumes a 64-bit architecture, for 32-bit architectures generally divide any number by 2.
@@ -65,27 +65,27 @@ e.g. its layout is something like the following:
 
 This results in 24 bytes being stored on the stack, 8 bytes for each field. Then the actual string is stored on the heap, usually with additional memory allocated to prevent re-allocating if the string is mutated.
 
-The idea of `CompactStr` is instead of storing metadata on the stack, just store the string itself. This way for smaller strings we save a bit of memory, and we
-don't have to heap allocate so it's more performant. A `CompactStr` is limited to 24 bytes (aka `size_of::<String>()`) so it won't ever use more memory than a
+The idea of `CompactString` is instead of storing metadata on the stack, just store the string itself. This way for smaller strings we save a bit of memory, and we
+don't have to heap allocate so it's more performant. A `CompactString` is limited to 24 bytes (aka `size_of::<String>()`) so it won't ever use more memory than a
 `String` would.
 
-The memory layout of a `CompactStr` looks something like:
+The memory layout of a `CompactString` looks something like:
 
-`CompactStr: [ buffer<23> | len<1> ]`
+`CompactString: [ buffer<23> | len<1> ]`
 
 #### Memory Layout
-Internally a `CompactStr` has two variants:
+Internally a `CompactString` has two variants:
 1. **Inline**, a string <= 24 bytes long
 2. **Heap** allocated, a string > 24 bytes long
 
 To maximize memory usage, we use a [`union`](https://doc.rust-lang.org/reference/items/unions.html) instead of an `enum`. In Rust an `enum` requires at least 1 byte
-for the discriminant (tracking what variant we are), instead we use a `union` which allows us to manually define the discriminant. `CompactStr` defines the
+for the discriminant (tracking what variant we are), instead we use a `union` which allows us to manually define the discriminant. `CompactString` defines the
 discriminant *within* the last byte, using any extra bits for metadata. Specifically the discriminant has two variants:
 
 1. `0b11111111` - All 1s, indicates **heap** allocated
 2. `0b11XXXXXX` - Two leading 1s, indicates **inline**, with the trailing 6 bits used to store the length
 
-and specifically the overall memory layout of a `CompactStr` is:
+and specifically the overall memory layout of a `CompactString` is:
 
 1. `heap:   { string: BoxString, _padding: [u8; 8] }`
 2. `inline: { buffer: [u8; 24] }`
@@ -98,11 +98,11 @@ For **inline** strings we only have a 24 byte buffer on the stack. This might ma
 
 To do this, we utilize the fact that the last byte of our string could only ever have a value in the range `[0, 192)`. We know this because all strings in Rust are valid [UTF-8](https://en.wikipedia.org/wiki/UTF-8), and the only valid byte pattern for the last byte of a UTF-8 character (and thus the possible last byte of a string) is `0b0XXXXXXX` aka `[0, 128)` or `0b10XXXXXX` aka `[128, 192)`. This leaves all values in `[192, 255]` as unused in our last byte. Therefore, we can use values in the range of `[192, 215]` to represent a length in the range of `[0, 23]`, and if our last byte has a value `< 192`, we know that's a UTF-8 character, and can interpret the length of our string as `24`.
 
-Specifically, the last byte on the stack for a `CompactStr` has the following uses:
-* `[0, 192)` - Is the last byte of a UTF-8 char, the `CompactStr` is stored on the stack and implicitly has a length of `24`
-* `[192, 215]` - Denotes a length in the range of `[0, 23]`, this `CompactStr` is stored on the stack.
+Specifically, the last byte on the stack for a `CompactString` has the following uses:
+* `[0, 192)` - Is the last byte of a UTF-8 char, the `CompactString` is stored on the stack and implicitly has a length of `24`
+* `[192, 215]` - Denotes a length in the range of `[0, 23]`, this `CompactString` is stored on the stack.
 * `[215, 255)` - Unused
-* `255` - Denotes this `CompactStr` is stored on the heap
+* `255` - Denotes this `CompactString` is stored on the heap
 
 ### Testing
 Strings and unicode can be quite messy, even further, we're working with things at the bit level. `compact_str` has an _extensive_ test suite comprised of unit testing, property testing, and fuzz testing, to ensure our invariants are upheld. We test across all major OSes (Windows, macOS, and Linux), architectures (64-bit and 32-bit), and endian-ness (big endian and little endian).
@@ -110,7 +110,7 @@ Strings and unicode can be quite messy, even further, we're working with things 
 Fuzz testing is run with `libFuzzer` _and_ `AFL++` with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every rust compiler since `v1.49` to ensure support for our minimum supported Rust version (MSRV).
 
 ### `unsafe` code
-`CompactStr` uses a bit of unsafe code because accessing fields from a `union` is inherently unsafe, the compiler can't guarantee what value is actually stored.
+`CompactString` uses a bit of unsafe code because accessing fields from a `union` is inherently unsafe, the compiler can't guarantee what value is actually stored.
 We also have some manually implemented heap data structures, i.e. `BoxString`, and mess with bytes at a bit level.
 That being said, uses of unsafe code in this library are quite limited and constrained to only where absolutely necessary, and always documented with
 `// SAFETY: <reason>`.

--- a/bench/benches/apis.rs
+++ b/bench/benches/apis.rs
@@ -1,8 +1,8 @@
-//! Benchmarks for various APIs to make sure `CompactStr` is at least no slower than `String`
+//! Benchmarks for various APIs to make sure `CompactString` is at least no slower than `String`
 
 use std::time::Instant;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{
     black_box,
     criterion_group,
@@ -14,7 +14,7 @@ static VERY_LONG_STR: &str = include_str!("../data/moby10b.txt");
 
 fn compact_str_inline_length(c: &mut Criterion) {
     let word = "i am short";
-    let compact_str = CompactStr::new(word);
+    let compact_str = CompactString::new(word);
     c.bench_function("inline length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -25,7 +25,7 @@ fn compact_str_inline_length(c: &mut Criterion) {
 
 fn compact_str_heap_length(c: &mut Criterion) {
     let word = "I am a very long string that will get allocated on the heap";
-    let compact_str = CompactStr::new(word);
+    let compact_str = CompactString::new(word);
     c.bench_function("heap length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -35,7 +35,7 @@ fn compact_str_heap_length(c: &mut Criterion) {
 }
 
 fn compact_str_very_big_heap_length(c: &mut Criterion) {
-    let compact_str = CompactStr::new(VERY_LONG_STR);
+    let compact_str = CompactString::new(VERY_LONG_STR);
     c.bench_function("very long heap length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -47,7 +47,7 @@ fn compact_str_very_big_heap_length(c: &mut Criterion) {
 fn compact_str_reserve_small(c: &mut Criterion) {
     c.bench_function("reserve small", |b| {
         b.iter(|| {
-            let mut compact_str = CompactStr::default();
+            let mut compact_str = CompactString::default();
             black_box(compact_str.reserve(10));
         })
     });
@@ -56,19 +56,19 @@ fn compact_str_reserve_small(c: &mut Criterion) {
 fn compact_str_reserve_large(c: &mut Criterion) {
     c.bench_function("reserve large", |b| {
         b.iter(|| {
-            let mut compact_str = CompactStr::default();
+            let mut compact_str = CompactString::default();
             black_box(compact_str.reserve(100));
         })
     });
 }
 
 fn compact_str_clone_small(c: &mut Criterion) {
-    let compact = CompactStr::new("i am short");
+    let compact = CompactString::new("i am short");
     c.bench_function("clone small", |b| b.iter(|| compact.clone()));
 }
 
 fn compact_str_clone_large_and_modify(c: &mut Criterion) {
-    let compact = CompactStr::new("I am a very long string that will get allocated on the heap");
+    let compact = CompactString::new("I am a very long string that will get allocated on the heap");
     c.bench_function("clone large", |b| {
         b.iter(|| {
             let mut clone = compact.clone();
@@ -83,7 +83,7 @@ fn compact_str_extend_chars_empty(c: &mut Criterion) {
     c.bench_function("extend chars empty", |b| {
         b.iter(|| {
             let mut compact =
-                CompactStr::new("I am a very long string that will get allocated on the heap");
+                CompactString::new("I am a very long string that will get allocated on the heap");
             compact.extend("".chars());
         })
     });
@@ -92,7 +92,7 @@ fn compact_str_extend_chars_empty(c: &mut Criterion) {
 fn compact_str_extend_chars_short(c: &mut Criterion) {
     c.bench_function("extend chars short", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("hello");
+            let mut compact = CompactString::new("hello");
             compact.extend((0..10).map(|_| '!'));
         })
     });
@@ -101,7 +101,7 @@ fn compact_str_extend_chars_short(c: &mut Criterion) {
 fn compact_str_extend_chars_inline_to_heap_20(c: &mut Criterion) {
     c.bench_function("extend chars inline to heap, 20", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("hello world");
+            let mut compact = CompactString::new("hello world");
             compact.extend((0..20).map(|_| '!'));
         })
     });
@@ -110,7 +110,8 @@ fn compact_str_extend_chars_inline_to_heap_20(c: &mut Criterion) {
 fn compact_str_extend_chars_heap_20(c: &mut Criterion) {
     c.bench_function("extend chars heap, 20", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("this is a long string that will start on the heap");
+            let mut compact =
+                CompactString::new("this is a long string that will start on the heap");
             compact.extend((0..20).map(|_| '!'));
         })
     });
@@ -123,9 +124,9 @@ fn compact_str_from_string_inline(c: &mut Criterion) {
             for _ in 0..iters {
                 let word = String::from("I am short");
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing
@@ -145,9 +146,9 @@ fn compact_str_from_string_heap(c: &mut Criterion) {
             for _ in 0..iters {
                 let word = String::from("I am a long string, look at me!");
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing
@@ -167,9 +168,9 @@ fn compact_str_from_string_heap_long(c: &mut Criterion) {
             for _ in 0..iters {
                 let word = String::from(VERY_LONG_STR);
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing

--- a/bench/benches/compact_str.rs
+++ b/bench/benches/compact_str.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{
     criterion_group,
     criterion_main,
@@ -7,22 +7,22 @@ use criterion::{
 
 fn empty(c: &mut Criterion) {
     let word = "";
-    c.bench_function("empty", |b| b.iter(|| CompactStr::new(word)));
+    c.bench_function("empty", |b| b.iter(|| CompactString::new(word)));
 }
 
 fn inline(c: &mut Criterion) {
     let word = "im sixteen chars";
-    c.bench_function("inline", |b| b.iter(|| CompactStr::new(word)));
+    c.bench_function("inline", |b| b.iter(|| CompactString::new(word)));
 }
 
 fn packed(c: &mut Criterion) {
     let word = "i am twenty four chars!!";
-    c.bench_function("packed", |b| b.iter(|| CompactStr::new(word)));
+    c.bench_function("packed", |b| b.iter(|| CompactString::new(word)));
 }
 
 fn heap(c: &mut Criterion) {
     let word = "I am a very long string that will get allocated on the heap";
-    c.bench_function("heap", |b| b.iter(|| CompactStr::new(word)));
+    c.bench_function("heap", |b| b.iter(|| CompactString::new(word)));
 }
 
 fn std_string(c: &mut Criterion) {

--- a/bench/benches/comparison.rs
+++ b/bench/benches/comparison.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{
     criterion_group,
     criterion_main,
@@ -18,9 +18,9 @@ fn creation(c: &mut Criterion) {
 
     for word in words {
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", word.len()),
+            BenchmarkId::new("CompactString", word.len()),
             &word,
-            |b, word| b.iter(|| CompactStr::new(word)),
+            |b, word| b.iter(|| CompactString::new(word)),
         );
         group.bench_with_input(BenchmarkId::new("SmolStr", word.len()), &word, |b, word| {
             b.iter(|| SmolStr::new(word))
@@ -48,9 +48,9 @@ fn cloning(c: &mut Criterion) {
         .collect();
 
     for word in words {
-        let compact = CompactStr::new(&word);
+        let compact = CompactString::new(&word);
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", compact.len()),
+            BenchmarkId::new("CompactString", compact.len()),
             &compact,
             |b, compact| b.iter(|| compact.clone()),
         );
@@ -86,9 +86,9 @@ fn access(c: &mut Criterion) {
         .collect();
 
     for word in words {
-        let compact = CompactStr::new(&word);
+        let compact = CompactString::new(&word);
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", compact.len()),
+            BenchmarkId::new("CompactString", compact.len()),
             &compact,
             |b, compact| b.iter(|| compact.as_str()),
         );

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient string type that transparently stores strings on the stack, when possible"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2018"
 license = "MIT"

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -3,65 +3,65 @@ use core::str::Utf8Error;
 use bytes::Buf;
 
 use crate::{
-    CompactStr,
+    CompactString,
     Repr,
 };
 
-impl CompactStr {
-    /// Converts a buffer of bytes to a [`CompactStr`]
+impl CompactString {
+    /// Converts a buffer of bytes to a [`CompactString`]
     ///
     /// # Examples
     /// ### Basic usage
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::collections::VecDeque;
     ///
     /// // `bytes::Buf` is implemented for `VecDeque<u8>`
     /// let mut sparkle_heart = VecDeque::from(vec![240, 159, 146, 150]);
     /// // We know these bytes are valid, so we can `.unwrap()` or `.expect(...)` here
-    /// let compact_str = CompactStr::from_utf8_buf(&mut sparkle_heart).expect("valid utf-8");
+    /// let compact_str = CompactString::from_utf8_buf(&mut sparkle_heart).expect("valid utf-8");
     ///
     /// assert_eq!(compact_str, "💖");
     /// ```
     ///
     /// ### With invalid/non-UTF8 bytes
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::io;
     ///
     /// // `bytes::Buf` is implemented for `std::io::Cursor<&[u8]>`
     /// let mut invalid = io::Cursor::new(&[0, 159]);
     ///
     /// // The provided buffer is invalid, so trying to create a `ComapctStr` will fail
-    /// assert!(CompactStr::from_utf8_buf(&mut invalid).is_err());
+    /// assert!(CompactString::from_utf8_buf(&mut invalid).is_err());
     /// ```
     pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
-        Repr::from_utf8_buf(buf).map(|repr| CompactStr { repr })
+        Repr::from_utf8_buf(buf).map(|repr| CompactString { repr })
     }
 
-    /// Converts a buffer of bytes to a [`CompactStr`], without checking that the provided buffer is
-    /// valid UTF-8.
+    /// Converts a buffer of bytes to a [`CompactString`], without checking that the provided buffer
+    /// is valid UTF-8.
     ///
     /// # Safety
     /// This function is unsafe because it does not check that the provided bytes are valid UTF-8.
     /// If this constraint is violated, it may cause memory safety issues with futures uses of the
-    /// `ComapctStr`, as the rest of the library assumes that `CompactStr`s are valid UTF-8
+    /// `ComapctStr`, as the rest of the library assumes that `CompactString`s are valid UTF-8
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::io;
     ///
     /// let word = "hello world";
     /// // `bytes::Buf` is implemented for `std::io::Cursor<&[u8]>`
     /// let mut buffer = io::Cursor::new(word.as_bytes());
-    /// let compact_str = unsafe { CompactStr::from_utf8_buf_unchecked(&mut buffer) };
+    /// let compact_str = unsafe { CompactString::from_utf8_buf_unchecked(&mut buffer) };
     ///
     /// assert_eq!(compact_str, word);
     /// ```
     pub unsafe fn from_utf8_buf_unchecked<B: Buf>(buf: &mut B) -> Self {
         let repr = Repr::from_utf8_buf_unchecked(buf);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
@@ -76,7 +76,7 @@ mod test {
         rand_bytes,
         rand_unicode,
     };
-    use crate::CompactStr;
+    use crate::CompactString;
 
     const MAX_SIZE: usize = core::mem::size_of::<String>();
 
@@ -84,7 +84,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn test_buffers_roundtrip(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
-        let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+        let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
         proptest::prop_assert_eq!(&word, &compact);
     }
@@ -93,7 +93,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn test_allocated_properly(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
-        let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+        let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
         if word.len() <= MAX_SIZE {
             proptest::prop_assert!(!compact.is_heap_allocated())
@@ -107,13 +107,13 @@ mod test {
     fn test_only_accept_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
         let mut buf = Cursor::new(bytes.as_slice());
 
-        let compact_result = CompactStr::from_utf8_buf(&mut buf);
+        let compact_result = CompactString::from_utf8_buf(&mut buf);
         let str_result = core::str::from_utf8(bytes.as_slice());
 
         match (compact_result, str_result) {
             (Ok(c), Ok(s)) => prop_assert_eq!(c, s),
             (Err(c_err), Err(s_err)) => prop_assert_eq!(c_err, s_err),
-            _ => panic!("CompactStr and core::str read UTF-8 differently?"),
+            _ => panic!("CompactString and core::str read UTF-8 differently?"),
         }
     }
 }

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -7,47 +7,49 @@ use serde::de::{
     Visitor,
 };
 
-use crate::CompactStr;
+use crate::CompactString;
 
-fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<CompactStr, D::Error> {
-    struct CompactStrVisitor;
+fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<CompactString, D::Error> {
+    struct CompactStringVisitor;
 
-    impl<'a> Visitor<'a> for CompactStrVisitor {
-        type Value = CompactStr;
+    impl<'a> Visitor<'a> for CompactStringVisitor {
+        type Value = CompactString;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a string")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_borrowed_str<E: Error>(self, v: &'a str) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
             match std::str::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }
         }
 
         fn visit_borrowed_bytes<E: Error>(self, v: &'a [u8]) -> Result<Self::Value, E> {
             match std::str::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }
         }
 
         fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
             match String::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(e) => Err(Error::invalid_value(
                     Unexpected::Bytes(&e.into_bytes()),
                     &self,
@@ -56,16 +58,16 @@ fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<Com
         }
     }
 
-    deserializer.deserialize_str(CompactStrVisitor)
+    deserializer.deserialize_str(CompactStringVisitor)
 }
 
-impl serde::Serialize for CompactStr {
+impl serde::Serialize for CompactString {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.as_str().serialize(serializer)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for CompactStr {
+impl<'de> serde::Deserialize<'de> for CompactString {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         compact_str(deserializer)
     }

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -82,10 +82,12 @@ pub struct CompactString {
 
 /// # DEPRECATED
 /// Renamed `CompactStr` to `CompactString`. Using the suffix "String" as opposed to "Str" more
-/// accurately reflects that we own the underlying string
+/// accurately reflects that we own the underlying string.
+/// 
+/// Type alias `CompactStr` will be removed in v0.5
 #[deprecated(
     since = "0.4.0",
-    note = "Renamed to CompactString, which more accurately reflects that it owns the underlying string"
+    note = "Renamed to CompactString, type alias will be removed in v0.5"
 )]
 pub type CompactStr = CompactString;
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -83,7 +83,7 @@ pub struct CompactString {
 /// # DEPRECATED
 /// Renamed `CompactStr` to `CompactString`. Using the suffix "String" as opposed to "Str" more
 /// accurately reflects that we own the underlying string.
-/// 
+///
 /// Type alias `CompactStr` will be removed in v0.5
 #[deprecated(
     since = "0.4.0",

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,5 +1,5 @@
-//! [`CompactStr`] is a compact string type that stores itself on the stack if possible, otherwise
-//! known as a "small string optimization".
+//! [`CompactString`] is a compact string type that stores itself on the stack if possible,
+//! otherwise known as a "small string optimization".
 //!
 //! ### Memory Layout
 //! Normally strings are stored on the heap, since they're dynamically sized. In Rust a [`String`]
@@ -37,58 +37,67 @@ use repr::Repr;
 #[cfg(test)]
 mod tests;
 
-/// A [`CompactStr`] is a compact string type that can be used almost anywhere a
+/// A [`CompactString`] is a compact string type that can be used almost anywhere a
 /// [`String`] or [`str`] can be used.
 ///
-/// ## Using `CompactStr`
+/// ## Using `CompactString`
 /// ```
-/// use compact_str::CompactStr;
+/// use compact_str::CompactString;
 /// # use std::collections::HashMap;
 ///
-/// // CompactStr auto derefs into a str so you can use all methods from `str`
+/// // CompactString auto derefs into a str so you can use all methods from `str`
 /// // that take a `&self`
-/// if CompactStr::new("hello world!").is_ascii() {
+/// if CompactString::new("hello world!").is_ascii() {
 ///     println!("we're all ASCII")
 /// }
 ///
-/// // You can use a CompactStr in collections like you would a String or &str
-/// let mut map: HashMap<CompactStr, CompactStr> = HashMap::new();
+/// // You can use a CompactString in collections like you would a String or &str
+/// let mut map: HashMap<CompactString, CompactString> = HashMap::new();
 ///
-/// // directly construct a new `CompactStr`
-/// map.insert(CompactStr::new("nyc"), CompactStr::new("empire state building"));
-/// // create a `CompactStr` from a `&str`
+/// // directly construct a new `CompactString`
+/// map.insert(CompactString::new("nyc"), CompactString::new("empire state building"));
+/// // create a `CompactString` from a `&str`
 /// map.insert("sf".into(), "transamerica pyramid".into());
-/// // create a `CompactStr` from a `String`
+/// // create a `CompactString` from a `String`
 /// map.insert(String::from("sea").into(), String::from("space needle").into());
 ///
 /// fn wrapped_print<T: AsRef<str>>(text: T) {
 ///     println!("{}", text.as_ref());
 /// }
 ///
-/// // CompactStr impls AsRef<str> and Borrow<str>, so it can be used anywhere
+/// // CompactString impls AsRef<str> and Borrow<str>, so it can be used anywhere
 /// // that excepts a generic string
 /// if let Some(building) = map.get("nyc") {
 ///     wrapped_print(building);
 /// }
 ///
-/// // CompactStr can also be directly compared to a String or &str
-/// assert_eq!(CompactStr::new("chicago"), "chicago");
-/// assert_eq!(CompactStr::new("houston"), String::from("houston"));
+/// // CompactString can also be directly compared to a String or &str
+/// assert_eq!(CompactString::new("chicago"), "chicago");
+/// assert_eq!(CompactString::new("houston"), String::from("houston"));
 /// ```
 #[derive(Clone)]
-pub struct CompactStr {
+pub struct CompactString {
     repr: Repr,
 }
 
-impl CompactStr {
-    /// Creates a new [`CompactStr`] from any type that implements `AsRef<str>`.
+/// # DEPRECATED
+/// Renamed `CompactStr` to `CompactString`. Using the suffix "String" as opposed to "Str" more
+/// accurately reflects that we own the underlying string
+#[deprecated(
+    since = "0.4.0",
+    note = "Renamed to CompactString, which more accurately reflects that it owns the underlying string"
+)]
+pub type CompactStr = CompactString;
+
+impl CompactString {
+    /// Creates a new [`CompactString`] from any type that implements `AsRef<str>`.
     /// If the string is short enough, then it will be inlined on the stack!
     ///
     /// # Examples
     ///
     /// ### Inlined
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// // We can inline strings up to 12 characters long on 32-bit architectures...
     /// #[cfg(target_pointer_width = "32")]
     /// let s = "i'm 12 chars";
@@ -96,7 +105,7 @@ impl CompactStr {
     /// #[cfg(target_pointer_width = "64")]
     /// let s = "i am 24 characters long!";
     ///
-    /// let compact = CompactStr::new(&s);
+    /// let compact = CompactString::new(&s);
     ///
     /// assert_eq!(compact, s);
     /// // we are not allocated on the heap!
@@ -105,10 +114,10 @@ impl CompactStr {
     ///
     /// ### Heap
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// // For longer strings though, we get allocated on the heap
     /// let long = "I am a longer string that will be allocated on the heap";
-    /// let compact = CompactStr::new(long);
+    /// let compact = CompactString::new(long);
     ///
     /// assert_eq!(compact, long);
     /// // we are allocated on the heap!
@@ -117,63 +126,63 @@ impl CompactStr {
     ///
     /// ### Creation
     /// ```
-    /// use compact_str::CompactStr;
+    /// use compact_str::CompactString;
     ///
     /// // Using a `&'static str`
     /// let s = "hello world!";
-    /// let hello = CompactStr::new(&s);
+    /// let hello = CompactString::new(&s);
     ///
     /// // Using a `String`
     /// let u = String::from("🦄🌈");
-    /// let unicorn = CompactStr::new(u);
+    /// let unicorn = CompactString::new(u);
     ///
     /// // Using a `Box<str>`
     /// let b: Box<str> = String::from("📦📦📦").into_boxed_str();
-    /// let boxed = CompactStr::new(&b);
+    /// let boxed = CompactString::new(&b);
     /// ```
     #[inline]
     pub fn new<T: AsRef<str>>(text: T) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::new(text),
         }
     }
 
-    /// Creates a new inline [`CompactStr`] at compile time.
+    /// Creates a new inline [`CompactString`] at compile time.
     ///
     /// # Examples
     /// ```
-    /// use compact_str::CompactStr;
+    /// use compact_str::CompactString;
     ///
-    /// const DEFAULT_NAME: CompactStr = CompactStr::new_inline("untitled");
+    /// const DEFAULT_NAME: CompactString = CompactString::new_inline("untitled");
     /// ```
     ///
     /// Note: Trying to create a long string that can't be inlined, will fail to build.
     /// ```compile_fail
-    /// # use compact_str::CompactStr;
-    /// const LONG: CompactStr = CompactStr::new_inline("this is a long string that can't be stored on the stack");
+    /// # use compact_str::CompactString;
+    /// const LONG: CompactString = CompactString::new_inline("this is a long string that can't be stored on the stack");
     /// ```
     #[inline]
     pub const fn new_inline(text: &str) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::new_const(text),
         }
     }
 
-    /// Creates a new empty [`CompactStr`] with the capacity to fit at least `capacity` bytes.
+    /// Creates a new empty [`CompactString`] with the capacity to fit at least `capacity` bytes.
     ///
-    /// A `CompactStr` will inline strings on the stack, if they're small enough. Specifically, if
-    /// the string has a length less than or equal to `std::mem::size_of::<String>` bytes then it
-    /// will be inlined. This also means that `CompactStr`s have a minimum capacity of
-    /// `std::mem::size_of::<String>`.
+    /// A `CompactString` will inline strings on the stack, if they're small enough. Specifically,
+    /// if the string has a length less than or equal to `std::mem::size_of::<String>` bytes
+    /// then it will be inlined. This also means that `CompactString`s have a minimum capacity
+    /// of `std::mem::size_of::<String>`.
     ///
     /// # Examples
     ///
     /// ### "zero" Capacity
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // Creating a CompactStr with a capacity of 0 will create
+    /// # use compact_str::CompactString;
+    /// // Creating a CompactString with a capacity of 0 will create
     /// // one with capacity of std::mem::size_of::<String>();
-    /// let empty = CompactStr::with_capacity(0);
+    /// let empty = CompactString::with_capacity(0);
     /// let min_size = std::mem::size_of::<String>();
     ///
     /// assert_eq!(empty.capacity(), min_size);
@@ -183,11 +192,11 @@ impl CompactStr {
     ///
     /// ### Max Inline Size
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // Creating a CompactStr with a capacity of std::mem::size_of::<String>()
+    /// # use compact_str::CompactString;
+    /// // Creating a CompactString with a capacity of std::mem::size_of::<String>()
     /// // will not heap allocate.
     /// let str_size = std::mem::size_of::<String>();
-    /// let empty = CompactStr::with_capacity(str_size);
+    /// let empty = CompactString::with_capacity(str_size);
     ///
     /// assert_eq!(empty.capacity(), str_size);
     /// assert!(!empty.is_heap_allocated());
@@ -195,57 +204,57 @@ impl CompactStr {
     ///
     /// ### Heap Allocating
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // If you create a `CompactStr` with a capacity greater than
+    /// # use compact_str::CompactString;
+    /// // If you create a `CompactString` with a capacity greater than
     /// // `std::mem::size_of::<String>`, it will heap allocated
     ///
     /// let heap_size = std::mem::size_of::<String>() + 1;
-    /// let empty = CompactStr::with_capacity(heap_size);
+    /// let empty = CompactString::with_capacity(heap_size);
     ///
     /// assert_eq!(empty.capacity(), heap_size);
     /// assert!(empty.is_heap_allocated());
     /// ```
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::with_capacity(capacity),
         }
     }
 
-    /// Convert a slice of bytes into a [`CompactStr`].
+    /// Convert a slice of bytes into a [`CompactString`].
     ///
-    /// A [`CompactStr`] is a contiguous collection of bytes (`u8`s) that is valid [`UTF-8`](https://en.wikipedia.org/wiki/UTF-8).
-    /// This method converts from an arbitrary contiguous collection of bytes into a [`CompactStr`],
-    /// failing if the provided bytes are not `UTF-8`.
+    /// A [`CompactString`] is a contiguous collection of bytes (`u8`s) that is valid [`UTF-8`](https://en.wikipedia.org/wiki/UTF-8).
+    /// This method converts from an arbitrary contiguous collection of bytes into a
+    /// [`CompactString`], failing if the provided bytes are not `UTF-8`.
     ///
-    /// Note: If you want to create a [`CompactStr`] from a non-contiguous collection of bytes,
-    /// enable the `bytes` feature of this crate, and checkout [`CompactStr::from_utf8_buf`]
+    /// Note: If you want to create a [`CompactString`] from a non-contiguous collection of bytes,
+    /// enable the `bytes` feature of this crate, and checkout [`CompactString::from_utf8_buf`]
     ///
     /// # Examples
     /// ### Valid UTF-8
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let bytes = vec![240, 159, 166, 128, 240, 159, 146, 175];
-    /// let compact = CompactStr::from_utf8(bytes).expect("valid UTF-8");
+    /// let compact = CompactString::from_utf8(bytes).expect("valid UTF-8");
     ///
     /// assert_eq!(compact, "🦀💯");
     /// ```
     ///
     /// ### Invalid UTF-8
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let bytes = vec![255, 255, 255];
-    /// let result = CompactStr::from_utf8(bytes);
+    /// let result = CompactString::from_utf8(bytes);
     ///
     /// assert!(result.is_err());
     /// ```
     #[inline]
     pub fn from_utf8<B: AsRef<[u8]>>(buf: B) -> Result<Self, Utf8Error> {
         let repr = Repr::from_utf8(buf)?;
-        Ok(CompactStr { repr })
+        Ok(CompactString { repr })
     }
 
-    /// Returns the length of the [`CompactStr`] in `bytes`, not [`char`]s or graphemes.
+    /// Returns the length of the [`CompactString`] in `bytes`, not [`char`]s or graphemes.
     ///
     /// When using `UTF-8` encoding (which all strings in Rust do) a single character will be 1 to 4
     /// bytes long, therefore the return value of this method might not be what a human considers
@@ -253,11 +262,11 @@ impl CompactStr {
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let ascii = CompactStr::new("hello world");
+    /// # use compact_str::CompactString;
+    /// let ascii = CompactString::new("hello world");
     /// assert_eq!(ascii.len(), 11);
     ///
-    /// let emoji = CompactStr::new("👱");
+    /// let emoji = CompactString::new("👱");
     /// assert_eq!(emoji.len(), 4);
     /// ```
     #[inline]
@@ -265,12 +274,12 @@ impl CompactStr {
         self.repr.len()
     }
 
-    /// Returns `true` if the [`CompactStr`] has a length of 0, `false` otherwise
+    /// Returns `true` if the [`CompactString`] has a length of 0, `false` otherwise
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut msg = CompactStr::new("");
+    /// # use compact_str::CompactString;
+    /// let mut msg = CompactString::new("");
     /// assert!(msg.is_empty());
     ///
     /// // add some characters
@@ -282,25 +291,25 @@ impl CompactStr {
         self.len() == 0
     }
 
-    /// Returns the capacity of the [`CompactStr`], in bytes.
+    /// Returns the capacity of the [`CompactString`], in bytes.
     ///
     /// # Note
-    /// * A `CompactStr` will always have a capacity of at least `std::mem::size_of::<String>()`
+    /// * A `CompactString` will always have a capacity of at least `std::mem::size_of::<String>()`
     ///
     /// # Examples
     /// ### Minimum Size
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let min_size = std::mem::size_of::<String>();
-    /// let compact = CompactStr::new("");
+    /// let compact = CompactString::new("");
     ///
     /// assert!(compact.capacity() >= min_size);
     /// ```
     ///
     /// ### Heap Allocated
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let compact = CompactStr::with_capacity(128);
+    /// # use compact_str::CompactString;
+    /// let compact = CompactString::with_capacity(128);
     /// assert_eq!(compact.capacity(), 128);
     /// ```
     #[inline]
@@ -308,23 +317,23 @@ impl CompactStr {
         self.repr.capacity()
     }
 
-    /// Ensures that this [`CompactStr`]'s capacity is at least `additional` bytes longer than its
-    /// length. The capacity may be increased by more than `additional` bytes if it chooses, to
-    /// prevent frequent reallocations.
+    /// Ensures that this [`CompactString`]'s capacity is at least `additional` bytes longer than
+    /// its length. The capacity may be increased by more than `additional` bytes if it chooses,
+    /// to prevent frequent reallocations.
     ///
     /// # Note
-    /// * A `CompactStr` will always have at least a capacity of `std::mem::size_of::<String>()`
-    /// * Reserving additional bytes may cause the `CompactStr` to become heap allocated
+    /// * A `CompactString` will always have at least a capacity of `std::mem::size_of::<String>()`
+    /// * Reserving additional bytes may cause the `CompactString` to become heap allocated
     ///
     /// # Panics
     /// Panics if the new capacity overflows `usize`
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     ///
     /// const WORD: usize = std::mem::size_of::<usize>();
-    /// let mut compact = CompactStr::default();
+    /// let mut compact = CompactString::default();
     /// assert!(compact.capacity() >= (WORD * 3) - 1);
     ///
     /// compact.reserve(200);
@@ -337,12 +346,12 @@ impl CompactStr {
         self.repr.reserve(additional)
     }
 
-    /// Returns a string slice containing the entire [`CompactStr`].
+    /// Returns a string slice containing the entire [`CompactString`].
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let s = CompactString::new("hello");
     ///
     /// assert_eq!(s.as_str(), "hello");
     /// ```
@@ -351,12 +360,12 @@ impl CompactStr {
         self.repr.as_str()
     }
 
-    /// Returns a byte slice of the [`CompactStr`]'s contents.
+    /// Returns a byte slice of the [`CompactString`]'s contents.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let s = CompactString::new("hello");
     ///
     /// assert_eq!(&[104, 101, 108, 108, 111], s.as_bytes());
     /// ```
@@ -370,13 +379,14 @@ impl CompactStr {
     /// Provides a mutable reference to the underlying buffer of bytes.
     ///
     /// # Safety
-    /// * All Rust strings, including `CompactStr`, must be valid UTF-8. The caller must guarantee
+    /// * All Rust strings, including `CompactString`, must be valid UTF-8. The caller must
+    ///   guarantee
     /// that any modifications made to the underlying buffer are valid UTF-8.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("hello");
     ///
     /// let slice = unsafe { s.as_mut_bytes() };
     /// // copy bytes into our string
@@ -391,12 +401,12 @@ impl CompactStr {
         self.repr.as_mut_slice()
     }
 
-    /// Appends the given [`char`] to the end of this [`CompactStr`].
+    /// Appends the given [`char`] to the end of this [`CompactString`].
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("foo");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("foo");
     ///
     /// s.push('b');
     /// s.push('a');
@@ -409,13 +419,13 @@ impl CompactStr {
         self.repr.push(ch)
     }
 
-    /// Removes the last character from the [`CompactStr`] and returns it.
+    /// Removes the last character from the [`CompactString`] and returns it.
     /// Returns `None` if this `ComapctStr` is empty.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("abc");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("abc");
     ///
     /// assert_eq!(s.pop(), Some('c'));
     /// assert_eq!(s.pop(), Some('b'));
@@ -428,12 +438,12 @@ impl CompactStr {
         self.repr.pop()
     }
 
-    /// Appends a given string slice onto the end of this [`CompactStr`]
+    /// Appends a given string slice onto the end of this [`CompactString`]
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("abc");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("abc");
     ///
     /// s.push_str("123");
     ///
@@ -444,11 +454,11 @@ impl CompactStr {
         self.repr.push_str(s)
     }
 
-    /// Forces the length of the [`CompactStr`] to `new_len`.
+    /// Forces the length of the [`CompactString`] to `new_len`.
     ///
-    /// This is a low-level operation that maintains none of the normal invariants for `CompactStr`.
-    /// If you want to modify the `CompactStr` you should use methods like `push`, `push_str` or
-    /// `pop`.
+    /// This is a low-level operation that maintains none of the normal invariants for
+    /// `CompactString`. If you want to modify the `CompactString` you should use methods like
+    /// `push`, `push_str` or `pop`.
     ///
     /// # Safety
     /// * `new_len` must be less than or equal to `capacity()`
@@ -458,21 +468,21 @@ impl CompactStr {
         self.repr.set_len(new_len)
     }
 
-    /// Returns whether or not the [`CompactStr`] is heap allocated.
+    /// Returns whether or not the [`CompactString`] is heap allocated.
     ///
     /// # Examples
     /// ### Inlined
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let hello = CompactStr::new("hello world");
+    /// # use compact_str::CompactString;
+    /// let hello = CompactString::new("hello world");
     ///
     /// assert!(!hello.is_heap_allocated());
     /// ```
     ///
     /// ### Heap Allocated
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let msg = CompactStr::new("this message will self destruct in 5, 4, 3, 2, 1 💥");
+    /// # use compact_str::CompactString;
+    /// let msg = CompactString::new("this message will self destruct in 5, 4, 3, 2, 1 💥");
     ///
     /// assert!(msg.is_heap_allocated());
     /// ```
@@ -482,14 +492,14 @@ impl CompactStr {
     }
 }
 
-impl Default for CompactStr {
+impl Default for CompactString {
     #[inline]
     fn default() -> Self {
-        CompactStr::new("")
+        CompactString::new("")
     }
 }
 
-impl Deref for CompactStr {
+impl Deref for CompactString {
     type Target = str;
 
     #[inline]
@@ -498,184 +508,184 @@ impl Deref for CompactStr {
     }
 }
 
-impl AsRef<str> for CompactStr {
+impl AsRef<str> for CompactString {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Borrow<str> for CompactStr {
+impl Borrow<str> for CompactString {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Eq for CompactStr {}
+impl Eq for CompactString {}
 
-impl<T: AsRef<str>> PartialEq<T> for CompactStr {
+impl<T: AsRef<str>> PartialEq<T> for CompactString {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
 }
 
-impl PartialEq<CompactStr> for String {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl PartialEq<CompactString> for String {
+    fn eq(&self, other: &CompactString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
-impl PartialEq<CompactStr> for &str {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl PartialEq<CompactString> for &str {
+    fn eq(&self, other: &CompactString) -> bool {
         *self == other.as_str()
     }
 }
 
-impl<'a> PartialEq<CompactStr> for Cow<'a, str> {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl<'a> PartialEq<CompactString> for Cow<'a, str> {
+    fn eq(&self, other: &CompactString) -> bool {
         *self == other.as_str()
     }
 }
 
-impl Ord for CompactStr {
+impl Ord for CompactString {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl PartialOrd for CompactStr {
+impl PartialOrd for CompactString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Hash for CompactStr {
+impl Hash for CompactString {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_str().hash(state)
     }
 }
 
-impl<'a> From<&'a str> for CompactStr {
+impl<'a> From<&'a str> for CompactString {
     fn from(s: &'a str) -> Self {
-        CompactStr::new(s)
+        CompactString::new(s)
     }
 }
 
-impl From<String> for CompactStr {
+impl From<String> for CompactString {
     fn from(s: String) -> Self {
         let repr = Repr::from_string(s);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> From<&'a String> for CompactStr {
+impl<'a> From<&'a String> for CompactString {
     fn from(s: &'a String) -> Self {
-        CompactStr::new(&s)
+        CompactString::new(&s)
     }
 }
 
-impl<'a> From<Cow<'a, str>> for CompactStr {
+impl<'a> From<Cow<'a, str>> for CompactString {
     fn from(s: Cow<'a, str>) -> Self {
-        CompactStr::new(s)
+        CompactString::new(s)
     }
 }
 
-impl From<Box<str>> for CompactStr {
+impl From<Box<str>> for CompactString {
     fn from(b: Box<str>) -> Self {
         let repr = Repr::from_box_str(b);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromStr for CompactStr {
+impl FromStr for CompactString {
     type Err = core::convert::Infallible;
-    fn from_str(s: &str) -> Result<CompactStr, Self::Err> {
-        Ok(CompactStr::from(s))
+    fn from_str(s: &str) -> Result<CompactString, Self::Err> {
+        Ok(CompactString::from(s))
     }
 }
 
-impl fmt::Debug for CompactStr {
+impl fmt::Debug for CompactString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
-impl fmt::Display for CompactStr {
+impl fmt::Display for CompactString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl FromIterator<char> for CompactStr {
+impl FromIterator<char> for CompactString {
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> FromIterator<&'a char> for CompactStr {
+impl<'a> FromIterator<&'a char> for CompactString {
     fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> FromIterator<&'a str> for CompactStr {
+impl<'a> FromIterator<&'a str> for CompactString {
     fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromIterator<Box<str>> for CompactStr {
+impl FromIterator<Box<str>> for CompactString {
     fn from_iter<T: IntoIterator<Item = Box<str>>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromIterator<String> for CompactStr {
+impl FromIterator<String> for CompactString {
     fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl Extend<char> for CompactStr {
+impl Extend<char> for CompactString {
     fn extend<T: IntoIterator<Item = char>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<&'a char> for CompactStr {
+impl<'a> Extend<&'a char> for CompactString {
     fn extend<T: IntoIterator<Item = &'a char>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<&'a str> for CompactStr {
+impl<'a> Extend<&'a str> for CompactString {
     fn extend<T: IntoIterator<Item = &'a str>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl Extend<Box<str>> for CompactStr {
+impl Extend<Box<str>> for CompactString {
     fn extend<T: IntoIterator<Item = Box<str>>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<Cow<'a, str>> for CompactStr {
+impl<'a> Extend<Cow<'a, str>> for CompactString {
     fn extend<T: IntoIterator<Item = Cow<'a, str>>>(&mut self, iter: T) {
         iter.into_iter().for_each(move |s| self.push_str(&s));
     }
 }
 
-impl Extend<String> for CompactStr {
+impl Extend<String> for CompactString {
     fn extend<T: IntoIterator<Item = String>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-crate::asserts::assert_size_eq!(CompactStr, String);
+crate::asserts::assert_size_eq!(CompactString, String);

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -134,7 +134,7 @@ impl BoxString {
     #[inline]
     pub fn from_string(s: String) -> Self {
         match Capacity::new(s.capacity()) {
-            // Note: We should never hit this case when using BoxString with CompactStr
+            // Note: We should never hit this case when using BoxString with CompactString
             Ok(_) if s.capacity() == 0 => BoxString::new(""),
             Ok(cap) => {
                 let len = s.len();
@@ -153,7 +153,7 @@ impl BoxString {
     #[inline]
     pub fn from_box_str(b: Box<str>) -> Self {
         match Capacity::new(b.len()) {
-            // Note: We should never hit this case when using BoxString with CompactStr
+            // Note: We should never hit this case when using BoxString with CompactString
             Ok(_) if b.len() == 0 => BoxString::new(""),
             Ok(cap) => {
                 let len = b.len();

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,4 +1,4 @@
-//! Implementations of the [`FromIterator`] trait to make building `CompactStr`s more ergonomic
+//! Implementations of the [`FromIterator`] trait to make building `CompactString`s more ergonomic
 
 use core::iter::FromIterator;
 use core::mem::ManuallyDrop;

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -129,8 +129,9 @@ impl Repr {
         }
 
         if new_capacity <= MAX_SIZE {
-            // It's possible to have a `CompactStr` that is heap allocated with a capacity less than
-            // MAX_SIZE, if that `CompactStr` was created From a String or Box<str>.
+            // It's possible to have a `CompactString` that is heap allocated with a capacity less
+            // than MAX_SIZE, if that `CompactString` was created From a String or
+            // Box<str>.
             let inline = InlineString::new(self.as_str());
             *self = Repr { inline }
         } else {
@@ -503,7 +504,7 @@ mod tests {
         let word = "abc";
         let new_len = word.len();
 
-        // write bytes into the `CompactStr`
+        // write bytes into the `CompactString`
         slice[..new_len].copy_from_slice(word.as_bytes());
         // set the length
         unsafe { repr.set_len(new_len) }


### PR DESCRIPTION
This PR renames `CompactStr` to `CompactString`

Some feedback I've received is using the "str" suffix isn't great because it suggests that a `CompactStr` doesn't own the underlying string, just like a `&str`. We change the suffix to "String" to fix this and improve the understanding.

We also add a type alias of `CompactStr` so existing crates will continue to work, albeit with a deprecation warning. This breaking change will go out with `v0.4` to prevent suddenly introducing warnings in projects that depend on `compact_str`