### PR TITLE
smartstring now no longer relies on `String` layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ That being said, uses of unsafe code in this library are quite limited and const
 ### Similar Crates
 Storing strings on the stack is not a new idea, in fact there are a few other crates in the Rust ecosystem that do similar things, an incomplete list:
 1. [`smol_str`](https://crates.io/crates/smol_str) - Can inline 22 bytes, `Clone` is `O(1)`, doesn't adjust for 32-bit archs
-2. [`smartstring`](https://crates.io/crates/smartstring) - Can inline 23 bytes, `Clone` is `O(n)`, is mutable, relies on the memory layout of `String`
+2. [`smartstring`](https://crates.io/crates/smartstring) - Can inline 23 bytes, `Clone` is `O(n)`, is mutable
 
 <br />
 Thanks for readingme!


### PR DESCRIPTION
https://github.com/bodil/smartstring/blob/master/CHANGELOG.md#100---2022-02-24

> ## [1.0.0] - 2022-02-24
> 
> ### CHANGED
> 
> -   `smartstring` now implements its own boxed string type rather than deferring directly to
>     `String`, so it no longer makes assumptions it shouldn't be making about the layout of the
>     `String` struct.
> 
>     This also allows us to organise the boxed struct in a way that will let us rely only on our
>     basic assumption that heap memory is word aligned on both big and little endian architectures.
>     The most immediate consequence of this is that `smartstring` will now compile on 32-bit big
>     endian architectures such as `mips`.
> 
>     We are now also explicitly allocating heap memory aligned for `u16` rather than `u8`, ensuring
>     the assumption about pointer alignment becomes an invariant.
> 
>     In short: `smartstring` no longer relies on undefined behaviour, and should be safe to use
>     anywhere.