### PR TITLE
Implement fmt::Write for CompactStr

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -678,4 +678,11 @@ impl Extend<String> for CompactStr {
     }
 }
 
+impl fmt::Write for CompactStr {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
 crate::asserts::assert_size_eq!(CompactStr, String);

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -339,3 +339,19 @@ fn test_compact_str_is_send_and_sync() {
     fn is_send_and_sync<T: Send + Sync>() {}
     is_send_and_sync::<CompactStr>();
 }
+
+#[test]
+fn test_fmt_write() {
+    use core::fmt::Write;
+
+    let mut compact = CompactStr::default();
+
+    write!(compact, "test").unwrap();
+    assert_eq!(compact, "test");
+
+    writeln!(compact, "{}", 1234).unwrap();
+    assert_eq!(compact, "test1234\n");
+
+    write!(compact, "{:>8} {} {:<8}", "some", "more", "words").unwrap();
+    assert_eq!(compact, "test1234\n    some more words   ");
+}


### PR DESCRIPTION
This makes it possible to `write!()` into a CompactStr. This is useful if you know that the formatted string will be (most often) shorter than 24 bytes.