### PR TITLE
Improve bench hygeine somewhat

### DIFF
--- a/bench/benches/compact_str.rs
+++ b/bench/benches/compact_str.rs
@@ -2,33 +2,41 @@ use compact_str::CompactStr;
 use criterion::{
     criterion_group,
     criterion_main,
+    BenchmarkId,
     Criterion,
 };
 
-fn empty(c: &mut Criterion) {
-    let word = "";
-    c.bench_function("empty", |b| b.iter(|| CompactStr::new(word)));
+fn bench_new(c: &mut Criterion) {
+    c.bench_with_input(
+        BenchmarkId::new("CompactStr::new", "0 chars"),
+        &"",
+        |b, word| b.iter(|| CompactStr::new(word)),
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("CompactStr::new", "16 chars"),
+        &"im sixteen chars",
+        |b, word| b.iter(|| CompactStr::new(word)),
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("CompactStr::new", "24 chars"),
+        &"i am twenty four chars!!",
+        |b, word| b.iter(|| CompactStr::new(word)),
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("CompactStr::new", "59 chars"),
+        &"I am a very long string that will get allocated on the heap",
+        |b, word| b.iter(|| CompactStr::new(word)),
+    );
+
+    c.bench_with_input(
+        BenchmarkId::new("String::new", "59 chars"),
+        &"I am a very long string that will get allocated on the heap",
+        |b, &word| b.iter(|| String::from(word)),
+    );
 }
 
-fn inline(c: &mut Criterion) {
-    let word = "im sixteen chars";
-    c.bench_function("inline", |b| b.iter(|| CompactStr::new(word)));
-}
-
-fn packed(c: &mut Criterion) {
-    let word = "i am twenty four chars!!";
-    c.bench_function("packed", |b| b.iter(|| CompactStr::new(word)));
-}
-
-fn heap(c: &mut Criterion) {
-    let word = "I am a very long string that will get allocated on the heap";
-    c.bench_function("heap", |b| b.iter(|| CompactStr::new(word)));
-}
-
-fn std_string(c: &mut Criterion) {
-    let word = "I am a very long string that will get allocated on the heap";
-    c.bench_function("std_string", |b| b.iter(|| String::from(word)));
-}
-
-criterion_group!(compact_str, empty, inline, packed, heap, std_string,);
+criterion_group!(compact_str, bench_new);
 criterion_main!(compact_str);


### PR DESCRIPTION
Mainly, this pipes the input through `bench_with_input` so that it gets black box'd and it's a little more likely its not benefiting from being inlined.

Perf is within noise:

```
empty                   time:   [1.4388 ns 1.4422 ns 1.4464 ns]
CompactStr::new/0 chars time:   [1.6753 ns 1.6768 ns 1.6798 ns]

inline                  time:   [10.518 ns 10.521 ns 10.525 ns]
CompactStr::new/16 chars
                        time:   [8.2563 ns 8.2630 ns 8.2706 ns]

packed                  time:   [3.6113 ns 3.6150 ns 3.6203 ns]
CompactStr::new/24 chars
                        time:   [3.5912 ns 3.5919 ns 3.5926 ns]

heap                    time:   [54.525 ns 54.604 ns 54.699 ns]
CompactStr::new/59 chars
                        time:   [53.861 ns 54.034 ns 54.239 ns]
						
std_string              time:   [49.538 ns 49.601 ns 49.673 ns]
String::new/59 chars    time:   [47.855 ns 47.894 ns 47.942 ns]
```