### PR TITLE
Optimize fmt::Write for trivial cases

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -683,6 +683,16 @@ impl fmt::Write for CompactStr {
         self.push_str(s);
         Ok(())
     }
+
+    fn write_fmt(mut self: &mut Self, args: fmt::Arguments<'_>) -> fmt::Result {
+        match args.as_str() {
+            Some(s) => {
+                self.push_str(s);
+                Ok(())
+            }
+            None => fmt::write(&mut self, args),
+        }
+    }
 }
 
 crate::asserts::assert_size_eq!(CompactStr, String);


### PR DESCRIPTION
This PR adds an optimization to CompactStr's fmt::Write implementation for invocations like that extend the buffer by a single string, e.g. `write!(s, "example")`