### PR TITLE
Tell miri to tag raw pointers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ name: CI
 env:
   RUSTFLAGS: "-D warnings"
   PROPTEST_CASES: 10000
+  MIRIFAGS: "-Zmiri-tag-raw-pointers"
 
 jobs:
   check:

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -11,6 +11,7 @@ env:
   # local default for proptest is 100
   PROPTEST_CASES: 1000
   RUSTFLAGS: "-D warnings"
+  MIRIFAGS: "-Zmiri-tag-raw-pointers"
 
 jobs:
   windows:


### PR DESCRIPTION
Stricter provenance, yo

Basically, tells miri to pay more attention to stacked borrows w.r.t. raw pointers. (Also forbids int2ptr as a side effect, but if we can avoid it, that's a [good thing](https://github.com/rust-lang/rust/issues/95228).)