### PR TITLE
perf: Improve the performance of Repr::Drop for Inlined Variants

### DIFF
--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -261,6 +261,8 @@ impl Clone for Repr {
 impl Drop for Repr {
     #[inline]
     fn drop(&mut self) {
+        // By "outlining" the actual Drop code and only calling it if we're a heap variant, it 
+        // allows dropping an inline variant to be as cheap as possible. 
         if self.is_heap_allocated() {
             outlined_drop(self)
         }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -211,7 +211,7 @@ impl Repr {
 
     #[inline]
     pub fn is_heap_allocated(&self) -> bool {
-        matches!(self.cast(), StrongRepr::Heap(..))
+        matches!(self.discriminant(), Discriminant::Heap)
     }
 
     #[inline(always)]
@@ -259,14 +259,22 @@ impl Clone for Repr {
 }
 
 impl Drop for Repr {
+    #[inline]
     fn drop(&mut self) {
-        match self.discriminant() {
-            Discriminant::Heap => {
-                // SAFETY: We checked the discriminant to make sure the union is `heap`
-                unsafe { ManuallyDrop::drop(&mut self.heap) };
+        if self.is_heap_allocated() {
+            outlined_drop(self)
+        }
+
+        #[inline(never)]
+        fn outlined_drop(this: &mut Repr) {
+            match this.discriminant() {
+                Discriminant::Heap => {
+                    // SAFETY: We checked the discriminant to make sure the union is `heap`
+                    unsafe { ManuallyDrop::drop(&mut this.heap) };
+                }
+                // No-op, the value is on the stack and doesn't need to be explicitly dropped
+                Discriminant::Inline => {}
             }
-            // No-op, the value is on the stack and doesn't need to be explicitly dropped
-            Discriminant::Inline => {}
         }
     }
 }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -261,8 +261,8 @@ impl Clone for Repr {
 impl Drop for Repr {
     #[inline]
     fn drop(&mut self) {
-        // By "outlining" the actual Drop code and only calling it if we're a heap variant, it 
-        // allows dropping an inline variant to be as cheap as possible. 
+        // By "outlining" the actual Drop code and only calling it if we're a heap variant, it
+        // allows dropping an inline variant to be as cheap as possible.
         if self.is_heap_allocated() {
             outlined_drop(self)
         }


### PR DESCRIPTION
This PR is entirely based off of work originally done by @matklad in #7. I opened a new PR so I could make just a couple of tweaks

Here we're improving the performance of `Drop` when we have an inlined string which when running the `compact_str` benches locally I see ~8% improvement!