### PR TITLE
tests: Re-add cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo-test-v3
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
+      - name: Install cargo-nextest
+        run: |
+          which cargo-nextest || cargo install cargo-nextest
+      - name: cargo test
+        run: |
+          cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all
 
   test-nightly:
     name: cargo test nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-check-v3
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -46,7 +55,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo-test-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-v3
       - name: Install cargo-nextest
         run: |
           which cargo-nextest || cargo install cargo-nextest
@@ -67,17 +76,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo-test-nightly-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-nightly-v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
+      - name: Install cargo-nextest
+        run: |
+          which cargo-nextest || cargo install cargo-nextest
+      - name: cargo test
+        run: |
+          cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all
 
   miri:
     name: cargo miri test
@@ -98,7 +108,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo-miri-v2
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-miri-v2
       - name: Run Miri
         run: |
           cargo miri test --all-features --manifest-path=compact_str/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,15 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-example-bytes
       - uses: actions-rs/cargo@v1
         with:
           command: run
@@ -137,6 +146,15 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-example-bytes
       - uses: actions-rs/cargo@v1
         with:
           command: run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,7 @@ jobs:
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-v3
       - name: Install cargo-nextest
-        run: |
-          which cargo-nextest || cargo install cargo-nextest
+        uses: taiki-e/install-action@nextest
       - name: cargo test
         run: |
           cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all
@@ -78,8 +77,7 @@ jobs:
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-nightly-v3
       - name: Install cargo-nextest
-        run: |
-          which cargo-nextest || cargo install cargo-nextest
+        uses: taiki-e/install-action@nextest
       # Install nightly after cargo-nextest is installed, as cargo-nextest failed to compile on nightly
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,15 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-nightly-v3
+      - name: Install cargo-nextest
+        run: |
+          which cargo-nextest || cargo install cargo-nextest
+      # Install nightly after cargo-nextest is installed, as cargo-nextest failed to compile on nightly
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-      - name: Install cargo-nextest
-        run: |
-          which cargo-nextest || cargo install cargo-nextest
       - name: cargo test
         run: |
           cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -27,6 +27,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/.rustup/downloads
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-hack
       - name: install cargo hack

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -30,7 +30,7 @@ jobs:
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-hack
       - name: install cargo hack
-        run: cargo install cargo-hack
+        run: cargo install cargo-hack --force
       - name: cargo test msrv..
         run: |
           cd compact_str

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-hack
       - name: install cargo hack
         run: cargo install cargo-hack
       - name: cargo test msrv..


### PR DESCRIPTION
Removed in #86 because the tests weren't running anything, but solution was commented on that PR so re-adding to CI using the suggested [GitHub Action](https://nexte.st/book/pre-built-binaries.html#using-nextest-in-github-actions). We also add some more caching, specifically for the MSRV workflow, which cuts runtime from ~20 minutes to ~9 minutes