### PR TITLE
tests: Separate toolchain cache from build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-check-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-check
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -55,7 +57,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-test
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       - name: cargo test
@@ -75,7 +79,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-test-nightly-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       # Install nightly after cargo-nextest is installed, as cargo-nextest failed to compile on nightly
@@ -107,7 +113,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-miri-v2
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test-miri
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - name: Run Miri
         run: |
           cargo miri test --all-features --manifest-path=compact_str/Cargo.toml
@@ -130,7 +139,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-example-bytes
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-bytes
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - uses: actions-rs/cargo@v1
         with:
           command: run
@@ -154,7 +166,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-example-bytes
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-bytes
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - uses: actions-rs/cargo@v1
         with:
           command: run

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,6 +27,18 @@ jobs:
         with:
           crate: cargo-fuzz
           version: latest
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz-libfuzzer
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - name: Set Fuzz Time
         run: |
           if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
@@ -61,6 +73,18 @@ jobs:
         with:
           crate: afl
           version: latest
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz-afl
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - name: AFL++ Build
         run: |
           cd fuzz
@@ -111,7 +135,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-windows-v2
+          key: ${{ runner.os }}-armv7-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz-afl
       - name: Install cargo-afl
         run: |
           cargo +nightly install afl --force

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,16 +20,22 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - uses: actions/cache@v3
+      - name: Toolchain Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup/downloads
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+          key: ${{ runner.os }}-x86_64-rustup
+      - name: Cargo Build Cache
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ~/.rustup/downloads
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
             target/
           key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-hack
       - name: install cargo hack

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -37,7 +37,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-cargo-hack
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-cargo-hack
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
       - name: install cargo hack
         run: cargo install cargo-hack --force
       - name: cargo test msrv..


### PR DESCRIPTION
For the MSRV workflow we separate the toolchain cache from the build cache because we don't need to invalidate the toolchains if our `Cargo.toml` changes, like we do the build cache