### PR TITLE
Reenable float tests on powerpc64le for `ToCompactStr`

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -45,4 +45,4 @@ jobs:
       - name: cargo test msrv..
         run: |
           cd compact_str
-          cargo hack test --feature-powerset --optional-deps --version-range 1.49..
+          cargo hack check --feature-powerset --optional-deps --version-range 1.49..

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -652,26 +652,22 @@ fn test_to_compact_str() {
     assert_int_MAX_to_compact_str!(isize);
 
     // Test specialisation for f32 and f64 using ryu
-    // TODO: Fix bug in powerpc64, which is a little endian system
-    #[cfg(not(all(target_arch = "powerpc64", target_pointer_width = "64")))]
-    {
-        assert_eq!(
-            (&*3.2_f32.to_string(), &*288888.290028_f64.to_string()),
-            (
-                &*3.2_f32.to_compact_str(),
-                &*288888.290028_f64.to_compact_str()
-            )
-        );
+    assert_eq!(
+        (&*3.2_f32.to_string(), &*288888.290028_f64.to_string()),
+        (
+            &*3.2_f32.to_compact_str(),
+            &*288888.290028_f64.to_compact_str()
+        )
+    );
 
-        assert_eq!("inf", f32::INFINITY.to_compact_str());
-        assert_eq!("-inf", f32::NEG_INFINITY.to_compact_str());
+    assert_eq!("inf", f32::INFINITY.to_compact_str());
+    assert_eq!("-inf", f32::NEG_INFINITY.to_compact_str());
 
-        assert_eq!("inf", f64::INFINITY.to_compact_str());
-        assert_eq!("-inf", f64::NEG_INFINITY.to_compact_str());
+    assert_eq!("inf", f64::INFINITY.to_compact_str());
+    assert_eq!("-inf", f64::NEG_INFINITY.to_compact_str());
 
-        assert_eq!("NaN", f32::NAN.to_compact_str());
-        assert_eq!("NaN", f64::NAN.to_compact_str());
-    }
+    assert_eq!("NaN", f32::NAN.to_compact_str());
+    assert_eq!("NaN", f64::NAN.to_compact_str());
 
     // Test generic Display implementation
     assert_eq!("234", "234".to_compact_str());

--- a/compact_str/src/to_compact_str_specialisation.rs
+++ b/compact_str/src/to_compact_str_specialisation.rs
@@ -17,9 +17,12 @@ const FALSE_COMPACT_STR: CompactStr = CompactStr::new_inline("false");
 
 #[inline(always)]
 pub(super) fn to_compact_str_specialised<T>(val: &T) -> Option<CompactStr> {
+    #[cfg(not(all(target_arch = "powerpc64", target_pointer_width = "64")))]
+    if let Some(compact_str) = float_spec::to_compact_str_specialised(val) {
+        return Some(compact_str);
+    }
+
     if let Some(compact_str) = int_spec::to_compact_str_specialised(val) {
-        Some(compact_str)
-    } else if let Some(compact_str) = float_spec::to_compact_str_specialised(val) {
         Some(compact_str)
     } else if let Ok(boolean) = cast!(val, &bool) {
         Some(if *boolean {
@@ -131,6 +134,7 @@ mod int_spec {
     }
 }
 
+#[cfg(not(all(target_arch = "powerpc64", target_pointer_width = "64")))]
 mod float_spec {
     use ryu::{
         Buffer,


### PR DESCRIPTION
Last time I tried to reproduce the bug on nightly, it is already fixed.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>