### PR TITLE
Fix afl jobs in workflow `fuzz`: Do not cache `~/.cargo/bin`

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -76,7 +76,6 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -130,7 +129,6 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/


### PR DESCRIPTION
Just use the `afl` compiled using the nightly toolchain installed.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>