### PR TITLE
refactor: Rename CompactStr to CompactString

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@
 <br />
 
 ### About
-A `CompactStr` is a more memory efficient string type, that can store smaller strings on the stack, and transparently stores longer strings on the heap (aka a small string optimization).
+A `CompactString` is a more memory efficient string type, that can store smaller strings on the stack, and transparently stores longer strings on the heap (aka a small string optimization).
 They can mostly be used as a drop in replacement for `String` and are particularly useful in parsing, deserializing, or any other application where you may
 have smaller strings.
 
 ### Properties
-A `CompactStr` specifically has the following properties:
-  * `size_of::<CompactStr>() == size_of::<String>()`
+A `CompactString` specifically has the following properties:
+  * `size_of::<CompactString>() == size_of::<String>()`
   * Stores up to 24 bytes on the stack
     * 12 bytes if running on a 32 bit architecture
   * Strings longer than 24 bytes are stored on the heap
@@ -49,8 +49,8 @@ A `CompactStr` specifically has the following properties:
 
 ### Features
 `compact_str` has the following features:
-1. `serde`, which implements [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) and [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) from the popular [`serde`](https://docs.rs/serde/latest/serde/) crate, for `CompactStr`.
-2. `bytes`, which provides two methods `from_utf8_buf<B: Buf>(buf: &mut B)` and `from_utf8_buf_unchecked<B: Buf>(buf: &mut B)`, which allows for the creation of a `CompactStr` from a [`bytes::Buf`](https://docs.rs/bytes/latest/bytes/trait.Buf.html)
+1. `serde`, which implements [`Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) and [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) from the popular [`serde`](https://docs.rs/serde/latest/serde/) crate, for `CompactString`.
+2. `bytes`, which provides two methods `from_utf8_buf<B: Buf>(buf: &mut B)` and `from_utf8_buf_unchecked<B: Buf>(buf: &mut B)`, which allows for the creation of a `CompactString` from a [`bytes::Buf`](https://docs.rs/bytes/latest/bytes/trait.Buf.html)
 
 ### How it works
 Note: this explanation assumes a 64-bit architecture, for 32-bit architectures generally divide any number by 2.
@@ -65,27 +65,27 @@ e.g. its layout is something like the following:
 
 This results in 24 bytes being stored on the stack, 8 bytes for each field. Then the actual string is stored on the heap, usually with additional memory allocated to prevent re-allocating if the string is mutated.
 
-The idea of `CompactStr` is instead of storing metadata on the stack, just store the string itself. This way for smaller strings we save a bit of memory, and we
-don't have to heap allocate so it's more performant. A `CompactStr` is limited to 24 bytes (aka `size_of::<String>()`) so it won't ever use more memory than a
+The idea of `CompactString` is instead of storing metadata on the stack, just store the string itself. This way for smaller strings we save a bit of memory, and we
+don't have to heap allocate so it's more performant. A `CompactString` is limited to 24 bytes (aka `size_of::<String>()`) so it won't ever use more memory than a
 `String` would.
 
-The memory layout of a `CompactStr` looks something like:
+The memory layout of a `CompactString` looks something like:
 
-`CompactStr: [ buffer<23> | len<1> ]`
+`CompactString: [ buffer<23> | len<1> ]`
 
 #### Memory Layout
-Internally a `CompactStr` has two variants:
+Internally a `CompactString` has two variants:
 1. **Inline**, a string <= 24 bytes long
 2. **Heap** allocated, a string > 24 bytes long
 
 To maximize memory usage, we use a [`union`](https://doc.rust-lang.org/reference/items/unions.html) instead of an `enum`. In Rust an `enum` requires at least 1 byte
-for the discriminant (tracking what variant we are), instead we use a `union` which allows us to manually define the discriminant. `CompactStr` defines the
+for the discriminant (tracking what variant we are), instead we use a `union` which allows us to manually define the discriminant. `CompactString` defines the
 discriminant *within* the last byte, using any extra bits for metadata. Specifically the discriminant has two variants:
 
 1. `0b11111111` - All 1s, indicates **heap** allocated
 2. `0b11XXXXXX` - Two leading 1s, indicates **inline**, with the trailing 6 bits used to store the length
 
-and specifically the overall memory layout of a `CompactStr` is:
+and specifically the overall memory layout of a `CompactString` is:
 
 1. `heap:   { ptr: NonNull<u8>, len: usize, cap: Capacity }`
 2. `inline: { buffer: [u8; 24] }`
@@ -94,21 +94,21 @@ and specifically the overall memory layout of a `CompactStr` is:
 
 For **heap** allocated strings we use a custom `BoxString` which normally stores the capacity of the string on the stack, but also optionally allows us to store it on the heap. Since we use the last byte to track our discriminant, we only have 7 bytes to store the capacity, or 3 bytes on a 32-bit architecture. 7 bytes allows us to store a value up to `2^56`, aka 64 petabytes, while 3 bytes only allows us to store a value up to `2^24`, aka 16 megabytes. 
 
-For 64-bit architectures we always inline the capacity, because we can safely assume our strings will never be larger than 64 petabytes, but on 32-bit architectures, when creating or growing a `CompactStr`, if the text is larger than 16MB then we move the capacity onto the heap. 
+For 64-bit architectures we always inline the capacity, because we can safely assume our strings will never be larger than 64 petabytes, but on 32-bit architectures, when creating or growing a `CompactString`, if the text is larger than 16MB then we move the capacity onto the heap. 
 
 We handle the capacity in this way for two reaons:
 1. Users shouldn't have to pay for what they don't use. Meaning, in the _majority_ of cases the capacity of the buffer could easily fit into 7 or 3 bytes, so the user shouldn't have to pay the memory cost of storing the capacity on the heap, if they don't need to.
-2. Allows us to convert `From<String>` in `O(1)` time, by taking the parts of a `String` (e.g. `ptr`, `len`, and `cap`) and using those to create a `CompactStr`, without having to do any heap allocations. This is important when using `CompactStr` in large codebases where you might have `CompactStr` working alongside of `String`.
+2. Allows us to convert `From<String>` in `O(1)` time, by taking the parts of a `String` (e.g. `ptr`, `len`, and `cap`) and using those to create a `CompactString`, without having to do any heap allocations. This is important when using `CompactString` in large codebases where you might have `CompactString` working alongside of `String`.
 
 For **inline** strings we only have a 24 byte buffer on the stack. This might make you wonder how can we store a 24 byte long string, inline? Don't we also need to store the length somewhere?
 
 To do this, we utilize the fact that the last byte of our string could only ever have a value in the range `[0, 192)`. We know this because all strings in Rust are valid [UTF-8](https://en.wikipedia.org/wiki/UTF-8), and the only valid byte pattern for the last byte of a UTF-8 character (and thus the possible last byte of a string) is `0b0XXXXXXX` aka `[0, 128)` or `0b10XXXXXX` aka `[128, 192)`. This leaves all values in `[192, 255]` as unused in our last byte. Therefore, we can use values in the range of `[192, 215]` to represent a length in the range of `[0, 23]`, and if our last byte has a value `< 192`, we know that's a UTF-8 character, and can interpret the length of our string as `24`.
 
-Specifically, the last byte on the stack for a `CompactStr` has the following uses:
-* `[0, 192)` - Is the last byte of a UTF-8 char, the `CompactStr` is stored on the stack and implicitly has a length of `24`
-* `[192, 215]` - Denotes a length in the range of `[0, 23]`, this `CompactStr` is stored on the stack.
+Specifically, the last byte on the stack for a `CompactString` has the following uses:
+* `[0, 192)` - Is the last byte of a UTF-8 char, the `CompactString` is stored on the stack and implicitly has a length of `24`
+* `[192, 215]` - Denotes a length in the range of `[0, 23]`, this `CompactString` is stored on the stack.
 * `[215, 255)` - Unused
-* `255` - Denotes this `CompactStr` is stored on the heap
+* `255` - Denotes this `CompactString` is stored on the heap
 
 ### Testing
 Strings and unicode can be quite messy, even further, we're working with things at the bit level. `compact_str` has an _extensive_ test suite comprised of unit testing, property testing, and fuzz testing, to ensure our invariants are upheld. We test across all major OSes (Windows, macOS, and Linux), architectures (64-bit and 32-bit), and endian-ness (big endian and little endian).
@@ -116,7 +116,7 @@ Strings and unicode can be quite messy, even further, we're working with things 
 Fuzz testing is run with `libFuzzer` _and_ `AFL++` with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every rust compiler since `v1.49` to ensure support for our minimum supported Rust version (MSRV).
 
 ### `unsafe` code
-`CompactStr` uses a bit of unsafe code because accessing fields from a `union` is inherently unsafe, the compiler can't guarantee what value is actually stored.
+`CompactString` uses a bit of unsafe code because accessing fields from a `union` is inherently unsafe, the compiler can't guarantee what value is actually stored.
 We also have some manually implemented heap data structures, i.e. `BoxString`, and mess with bytes at a bit level.
 That being said, uses of unsafe code in this library are quite limited and constrained to only where absolutely necessary, and always documented with
 `// SAFETY: <reason>`.

--- a/bench/benches/apis.rs
+++ b/bench/benches/apis.rs
@@ -1,8 +1,8 @@
-//! Benchmarks for various APIs to make sure `CompactStr` is at least no slower than `String`
+//! Benchmarks for various APIs to make sure `CompactString` is at least no slower than `String`
 
 use std::time::Instant;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{
     black_box,
     criterion_group,
@@ -12,9 +12,9 @@ use criterion::{
 
 static VERY_LONG_STR: &str = include_str!("../data/moby10b.txt");
 
-fn compact_str_inline_length(c: &mut Criterion) {
+fn compact_string_inline_length(c: &mut Criterion) {
     let word = "i am short";
-    let compact_str = CompactStr::new(word);
+    let compact_str = CompactString::new(word);
     c.bench_function("inline length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -23,9 +23,9 @@ fn compact_str_inline_length(c: &mut Criterion) {
     });
 }
 
-fn compact_str_heap_length(c: &mut Criterion) {
+fn compact_string_heap_length(c: &mut Criterion) {
     let word = "I am a very long string that will get allocated on the heap";
-    let compact_str = CompactStr::new(word);
+    let compact_str = CompactString::new(word);
     c.bench_function("heap length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -34,8 +34,8 @@ fn compact_str_heap_length(c: &mut Criterion) {
     });
 }
 
-fn compact_str_very_big_heap_length(c: &mut Criterion) {
-    let compact_str = CompactStr::new(VERY_LONG_STR);
+fn compact_string_very_big_heap_length(c: &mut Criterion) {
+    let compact_str = CompactString::new(VERY_LONG_STR);
     c.bench_function("very long heap length", |b| {
         b.iter(|| {
             let len = black_box(compact_str.len());
@@ -44,31 +44,31 @@ fn compact_str_very_big_heap_length(c: &mut Criterion) {
     });
 }
 
-fn compact_str_reserve_small(c: &mut Criterion) {
+fn compact_string_reserve_small(c: &mut Criterion) {
     c.bench_function("reserve small", |b| {
         b.iter(|| {
-            let mut compact_str = CompactStr::default();
+            let mut compact_str = CompactString::default();
             black_box(compact_str.reserve(10));
         })
     });
 }
 
-fn compact_str_reserve_large(c: &mut Criterion) {
+fn compact_string_reserve_large(c: &mut Criterion) {
     c.bench_function("reserve large", |b| {
         b.iter(|| {
-            let mut compact_str = CompactStr::default();
+            let mut compact_str = CompactString::default();
             black_box(compact_str.reserve(100));
         })
     });
 }
 
-fn compact_str_clone_small(c: &mut Criterion) {
-    let compact = CompactStr::new("i am short");
+fn compact_string_clone_small(c: &mut Criterion) {
+    let compact = CompactString::new("i am short");
     c.bench_function("clone small", |b| b.iter(|| compact.clone()));
 }
 
-fn compact_str_clone_large_and_modify(c: &mut Criterion) {
-    let compact = CompactStr::new("I am a very long string that will get allocated on the heap");
+fn compact_string_clone_large_and_modify(c: &mut Criterion) {
+    let compact = CompactString::new("I am a very long string that will get allocated on the heap");
     c.bench_function("clone large", |b| {
         b.iter(|| {
             let mut clone = compact.clone();
@@ -79,53 +79,54 @@ fn compact_str_clone_large_and_modify(c: &mut Criterion) {
     });
 }
 
-fn compact_str_extend_chars_empty(c: &mut Criterion) {
+fn compact_string_extend_chars_empty(c: &mut Criterion) {
     c.bench_function("extend chars empty", |b| {
         b.iter(|| {
             let mut compact =
-                CompactStr::new("I am a very long string that will get allocated on the heap");
+                CompactString::new("I am a very long string that will get allocated on the heap");
             compact.extend("".chars());
         })
     });
 }
 
-fn compact_str_extend_chars_short(c: &mut Criterion) {
+fn compact_string_extend_chars_short(c: &mut Criterion) {
     c.bench_function("extend chars short", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("hello");
+            let mut compact = CompactString::new("hello");
             compact.extend((0..10).map(|_| '!'));
         })
     });
 }
 
-fn compact_str_extend_chars_inline_to_heap_20(c: &mut Criterion) {
+fn compact_string_extend_chars_inline_to_heap_20(c: &mut Criterion) {
     c.bench_function("extend chars inline to heap, 20", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("hello world");
+            let mut compact = CompactString::new("hello world");
             compact.extend((0..20).map(|_| '!'));
         })
     });
 }
 
-fn compact_str_extend_chars_heap_20(c: &mut Criterion) {
+fn compact_string_extend_chars_heap_20(c: &mut Criterion) {
     c.bench_function("extend chars heap, 20", |b| {
         b.iter(|| {
-            let mut compact = CompactStr::new("this is a long string that will start on the heap");
+            let mut compact =
+                CompactString::new("this is a long string that will start on the heap");
             compact.extend((0..20).map(|_| '!'));
         })
     });
 }
 
-fn compact_str_from_string_inline(c: &mut Criterion) {
+fn compact_string_from_string_inline(c: &mut Criterion) {
     c.bench_function("compact_str_from_string_inline", |b| {
         b.iter_custom(|iters| {
             let mut durations = vec![];
             for _ in 0..iters {
                 let word = String::from("I am short");
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing
@@ -138,16 +139,16 @@ fn compact_str_from_string_inline(c: &mut Criterion) {
     });
 }
 
-fn compact_str_from_string_heap(c: &mut Criterion) {
+fn compact_string_from_string_heap(c: &mut Criterion) {
     c.bench_function("compact_str_from_string_heap", |b| {
         b.iter_custom(|iters| {
             let mut durations = vec![];
             for _ in 0..iters {
                 let word = String::from("I am a long string, look at me!");
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing
@@ -160,16 +161,16 @@ fn compact_str_from_string_heap(c: &mut Criterion) {
     });
 }
 
-fn compact_str_from_string_heap_long(c: &mut Criterion) {
+fn compact_string_from_string_heap_long(c: &mut Criterion) {
     c.bench_function("compact_str_from_string_heap_long", |b| {
         b.iter_custom(|iters| {
             let mut durations = vec![];
             for _ in 0..iters {
                 let word = String::from(VERY_LONG_STR);
 
-                // only time how long it takes to go from String -> CompactStr
+                // only time how long it takes to go from String -> CompactString
                 let start = Instant::now();
-                let c = CompactStr::from(word);
+                let c = CompactString::from(word);
                 let duration = start.elapsed();
 
                 // explicitly drop _after_ we've finished timing
@@ -278,20 +279,20 @@ fn std_str_str_extend_chars_20(c: &mut Criterion) {
 
 criterion_group!(
     compact_str,
-    compact_str_inline_length,
-    compact_str_heap_length,
-    compact_str_very_big_heap_length,
-    compact_str_reserve_small,
-    compact_str_reserve_large,
-    compact_str_clone_small,
-    compact_str_clone_large_and_modify,
-    compact_str_extend_chars_empty,
-    compact_str_extend_chars_short,
-    compact_str_extend_chars_inline_to_heap_20,
-    compact_str_extend_chars_heap_20,
-    compact_str_from_string_inline,
-    compact_str_from_string_heap,
-    compact_str_from_string_heap_long
+    compact_string_inline_length,
+    compact_string_heap_length,
+    compact_string_very_big_heap_length,
+    compact_string_reserve_small,
+    compact_string_reserve_large,
+    compact_string_clone_small,
+    compact_string_clone_large_and_modify,
+    compact_string_extend_chars_empty,
+    compact_string_extend_chars_short,
+    compact_string_extend_chars_inline_to_heap_20,
+    compact_string_extend_chars_heap_20,
+    compact_string_from_string_inline,
+    compact_string_from_string_heap,
+    compact_string_from_string_heap_long
 );
 criterion_group!(
     std_string,

--- a/bench/benches/compact_str.rs
+++ b/bench/benches/compact_str.rs
@@ -1,6 +1,6 @@
 use compact_str::{
-    CompactStr,
-    ToCompactStr,
+    CompactString,
+    ToCompactString,
 };
 use criterion::{
     criterion_group,
@@ -11,27 +11,27 @@ use criterion::{
 
 fn bench_new(c: &mut Criterion) {
     c.bench_with_input(
-        BenchmarkId::new("CompactStr::new", "0 chars"),
+        BenchmarkId::new("CompactString::new", "0 chars"),
         &"",
-        |b, word| b.iter(|| CompactStr::new(word)),
+        |b, word| b.iter(|| CompactString::new(word)),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("CompactStr::new", "16 chars"),
+        BenchmarkId::new("CompactString::new", "16 chars"),
         &"im sixteen chars",
-        |b, word| b.iter(|| CompactStr::new(word)),
+        |b, word| b.iter(|| CompactString::new(word)),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("CompactStr::new", "24 chars"),
+        BenchmarkId::new("CompactString::new", "24 chars"),
         &"i am twenty four chars!!",
-        |b, word| b.iter(|| CompactStr::new(word)),
+        |b, word| b.iter(|| CompactString::new(word)),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("CompactStr::new", "59 chars"),
+        BenchmarkId::new("CompactString::new", "59 chars"),
         &"I am a very long string that will get allocated on the heap",
-        |b, word| b.iter(|| CompactStr::new(word)),
+        |b, word| b.iter(|| CompactString::new(word)),
     );
 
     c.bench_with_input(
@@ -41,55 +41,55 @@ fn bench_new(c: &mut Criterion) {
     );
 }
 
-fn bench_to_compact_str(c: &mut Criterion) {
+fn bench_to_compact_string(c: &mut Criterion) {
     c.bench_with_input(
-        BenchmarkId::new("u8::to_compact_str", "42"),
+        BenchmarkId::new("u8::to_compact_string", "42"),
         &42_u8,
-        |b, num| b.iter(|| num.to_compact_str()),
+        |b, num| b.iter(|| num.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("u32::to_compact_str", "54321"),
+        BenchmarkId::new("u32::to_compact_string", "54321"),
         &54321_u32,
-        |b, num| b.iter(|| num.to_compact_str()),
+        |b, num| b.iter(|| num.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("isize::to_compact_str", "-9999999"),
+        BenchmarkId::new("isize::to_compact_string", "-9999999"),
         &-9999999_isize,
-        |b, num| b.iter(|| num.to_compact_str()),
+        |b, num| b.iter(|| num.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("u64::to_compact_str", "MAX"),
+        BenchmarkId::new("u64::to_compact_string", "MAX"),
         &u64::MAX,
-        |b, num| b.iter(|| num.to_compact_str()),
+        |b, num| b.iter(|| num.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("u128::to_compact_str", "12345678909876543210123456789"),
+        BenchmarkId::new("u128::to_compact_string", "12345678909876543210123456789"),
         &12345678909876543210123456789_u128,
-        |b, num| b.iter(|| num.to_compact_str()),
+        |b, num| b.iter(|| num.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("bool::to_compact_str", "true"),
+        BenchmarkId::new("bool::to_compact_string", "true"),
         &true,
-        |b, flag| b.iter(|| flag.to_compact_str()),
+        |b, flag| b.iter(|| flag.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("String::to_compact_str", "hello world!"),
+        BenchmarkId::new("String::to_compact_string", "hello world!"),
         &String::from("hello world!"),
-        |b, word| b.iter(|| word.to_compact_str()),
+        |b, word| b.iter(|| word.to_compact_string()),
     );
 
     c.bench_with_input(
-        BenchmarkId::new("char::to_compact_str", "a"),
+        BenchmarkId::new("char::to_compact_string", "a"),
         &'a',
-        |b, c| b.iter(|| c.to_compact_str()),
+        |b, c| b.iter(|| c.to_compact_string()),
     );
 }
 
-criterion_group!(compact_str, bench_new, bench_to_compact_str);
+criterion_group!(compact_str, bench_new, bench_to_compact_string);
 criterion_main!(compact_str);

--- a/bench/benches/comparison.rs
+++ b/bench/benches/comparison.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use criterion::{
     criterion_group,
     criterion_main,
@@ -18,9 +18,9 @@ fn creation(c: &mut Criterion) {
 
     for word in words {
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", word.len()),
+            BenchmarkId::new("CompactString", word.len()),
             &word,
-            |b, word| b.iter(|| CompactStr::new(word)),
+            |b, word| b.iter(|| CompactString::new(word)),
         );
         group.bench_with_input(BenchmarkId::new("SmolStr", word.len()), &word, |b, word| {
             b.iter(|| SmolStr::new(word))
@@ -48,9 +48,9 @@ fn cloning(c: &mut Criterion) {
         .collect();
 
     for word in words {
-        let compact = CompactStr::new(&word);
+        let compact = CompactString::new(&word);
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", compact.len()),
+            BenchmarkId::new("CompactString", compact.len()),
             &compact,
             |b, compact| b.iter(|| compact.clone()),
         );
@@ -86,9 +86,9 @@ fn access(c: &mut Criterion) {
         .collect();
 
     for word in words {
-        let compact = CompactStr::new(&word);
+        let compact = CompactString::new(&word);
         group.bench_with_input(
-            BenchmarkId::new("CompactStr", compact.len()),
+            BenchmarkId::new("CompactString", compact.len()),
             &compact,
             |b, compact| b.iter(|| compact.as_str()),
         );

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -3,65 +3,65 @@ use core::str::Utf8Error;
 use bytes::Buf;
 
 use crate::{
-    CompactStr,
+    CompactString,
     Repr,
 };
 
-impl CompactStr {
-    /// Converts a buffer of bytes to a [`CompactStr`]
+impl CompactString {
+    /// Converts a buffer of bytes to a [`CompactString`]
     ///
     /// # Examples
     /// ### Basic usage
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::collections::VecDeque;
     ///
     /// // `bytes::Buf` is implemented for `VecDeque<u8>`
     /// let mut sparkle_heart = VecDeque::from(vec![240, 159, 146, 150]);
     /// // We know these bytes are valid, so we can `.unwrap()` or `.expect(...)` here
-    /// let compact_str = CompactStr::from_utf8_buf(&mut sparkle_heart).expect("valid utf-8");
+    /// let compact_str = CompactString::from_utf8_buf(&mut sparkle_heart).expect("valid utf-8");
     ///
     /// assert_eq!(compact_str, "💖");
     /// ```
     ///
     /// ### With invalid/non-UTF8 bytes
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::io;
     ///
     /// // `bytes::Buf` is implemented for `std::io::Cursor<&[u8]>`
     /// let mut invalid = io::Cursor::new(&[0, 159]);
     ///
     /// // The provided buffer is invalid, so trying to create a `ComapctStr` will fail
-    /// assert!(CompactStr::from_utf8_buf(&mut invalid).is_err());
+    /// assert!(CompactString::from_utf8_buf(&mut invalid).is_err());
     /// ```
     pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
-        Repr::from_utf8_buf(buf).map(|repr| CompactStr { repr })
+        Repr::from_utf8_buf(buf).map(|repr| CompactString { repr })
     }
 
-    /// Converts a buffer of bytes to a [`CompactStr`], without checking that the provided buffer is
-    /// valid UTF-8.
+    /// Converts a buffer of bytes to a [`CompactString`], without checking that the provided buffer
+    /// is valid UTF-8.
     ///
     /// # Safety
     /// This function is unsafe because it does not check that the provided bytes are valid UTF-8.
     /// If this constraint is violated, it may cause memory safety issues with futures uses of the
-    /// `ComapctStr`, as the rest of the library assumes that `CompactStr`s are valid UTF-8
+    /// `ComapctStr`, as the rest of the library assumes that `CompactString`s are valid UTF-8
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// # use std::io;
     ///
     /// let word = "hello world";
     /// // `bytes::Buf` is implemented for `std::io::Cursor<&[u8]>`
     /// let mut buffer = io::Cursor::new(word.as_bytes());
-    /// let compact_str = unsafe { CompactStr::from_utf8_buf_unchecked(&mut buffer) };
+    /// let compact_str = unsafe { CompactString::from_utf8_buf_unchecked(&mut buffer) };
     ///
     /// assert_eq!(compact_str, word);
     /// ```
     pub unsafe fn from_utf8_buf_unchecked<B: Buf>(buf: &mut B) -> Self {
         let repr = Repr::from_utf8_buf_unchecked(buf);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
@@ -76,7 +76,7 @@ mod test {
         rand_bytes,
         rand_unicode,
     };
-    use crate::CompactStr;
+    use crate::CompactString;
 
     const MAX_SIZE: usize = core::mem::size_of::<String>();
 
@@ -84,7 +84,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn test_buffers_roundtrip(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
-        let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+        let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
         proptest::prop_assert_eq!(&word, &compact);
     }
@@ -93,7 +93,7 @@ mod test {
     #[cfg_attr(miri, ignore)]
     fn test_allocated_properly(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
-        let compact = CompactStr::from_utf8_buf(&mut buf).unwrap();
+        let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
         if word.len() <= MAX_SIZE {
             proptest::prop_assert!(!compact.is_heap_allocated())
@@ -107,13 +107,13 @@ mod test {
     fn test_only_accept_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
         let mut buf = Cursor::new(bytes.as_slice());
 
-        let compact_result = CompactStr::from_utf8_buf(&mut buf);
+        let compact_result = CompactString::from_utf8_buf(&mut buf);
         let str_result = core::str::from_utf8(bytes.as_slice());
 
         match (compact_result, str_result) {
             (Ok(c), Ok(s)) => prop_assert_eq!(c, s),
             (Err(c_err), Err(s_err)) => prop_assert_eq!(c_err, s_err),
-            _ => panic!("CompactStr and core::str read UTF-8 differently?"),
+            _ => panic!("CompactString and core::str read UTF-8 differently?"),
         }
     }
 }

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -32,7 +32,7 @@ impl CompactString {
     /// // `bytes::Buf` is implemented for `std::io::Cursor<&[u8]>`
     /// let mut invalid = io::Cursor::new(&[0, 159]);
     ///
-    /// // The provided buffer is invalid, so trying to create a `ComapctStr` will fail
+    /// // The provided buffer is invalid, so trying to create a `CompactString` will fail
     /// assert!(CompactString::from_utf8_buf(&mut invalid).is_err());
     /// ```
     pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
@@ -45,7 +45,7 @@ impl CompactString {
     /// # Safety
     /// This function is unsafe because it does not check that the provided bytes are valid UTF-8.
     /// If this constraint is violated, it may cause memory safety issues with futures uses of the
-    /// `ComapctStr`, as the rest of the library assumes that `CompactString`s are valid UTF-8
+    /// `CompactString`, as the rest of the library assumes that `CompactString`s are valid UTF-8
     ///
     /// # Examples
     /// ```

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -7,47 +7,49 @@ use serde::de::{
     Visitor,
 };
 
-use crate::CompactStr;
+use crate::CompactString;
 
-fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<CompactStr, D::Error> {
-    struct CompactStrVisitor;
+fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<CompactString, D::Error> {
+    struct CompactStringVisitor;
 
-    impl<'a> Visitor<'a> for CompactStrVisitor {
-        type Value = CompactStr;
+    impl<'a> Visitor<'a> for CompactStringVisitor {
+        type Value = CompactString;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a string")
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_borrowed_str<E: Error>(self, v: &'a str) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
-            Ok(CompactStr::from(v))
+            Ok(CompactString::from(v))
         }
 
         fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
             match std::str::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }
         }
 
         fn visit_borrowed_bytes<E: Error>(self, v: &'a [u8]) -> Result<Self::Value, E> {
             match std::str::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }
         }
 
         fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
             match String::from_utf8(v) {
-                Ok(s) => Ok(CompactStr::from(s)),
+                Ok(s) => Ok(CompactString::from(s)),
                 Err(e) => Err(Error::invalid_value(
                     Unexpected::Bytes(&e.into_bytes()),
                     &self,
@@ -56,16 +58,16 @@ fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(deserializer: D) -> Result<Com
         }
     }
 
-    deserializer.deserialize_str(CompactStrVisitor)
+    deserializer.deserialize_str(CompactStringVisitor)
 }
 
-impl serde::Serialize for CompactStr {
+impl serde::Serialize for CompactString {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.as_str().serialize(serializer)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for CompactStr {
+impl<'de> serde::Deserialize<'de> for CompactString {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         compact_str(deserializer)
     }

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -9,7 +9,7 @@ use serde::de::{
 
 use crate::CompactString;
 
-fn compact_str<'de: 'a, 'a, D: Deserializer<'de>>(
+fn compact_string<'de: 'a, 'a, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<CompactString, D::Error> {
     struct CompactStringVisitor;
@@ -69,6 +69,6 @@ impl serde::Serialize for CompactString {
 
 impl<'de> serde::Deserialize<'de> for CompactString {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        compact_str(deserializer)
+        compact_string(deserializer)
     }
 }

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -349,7 +349,6 @@ impl CompactString {
     /// assert!(compact.is_heap_allocated());
     /// assert!(compact.capacity() >= 200);
     /// ```
-
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.repr.reserve(additional)
@@ -429,7 +428,7 @@ impl CompactString {
     }
 
     /// Removes the last character from the [`CompactString`] and returns it.
-    /// Returns `None` if this `ComapctStr` is empty.
+    /// Returns `None` if this [`CompactString`] is empty.
     ///
     /// # Examples
     /// ```

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,5 +1,5 @@
-//! [`CompactStr`] is a compact string type that stores itself on the stack if possible, otherwise
-//! known as a "small string optimization".
+//! [`CompactString`] is a compact string type that stores itself on the stack if possible,
+//! otherwise known as a "small string optimization".
 //!
 //! ### Memory Layout
 //! Normally strings are stored on the heap, since they're dynamically sized. In Rust a [`String`]
@@ -39,63 +39,74 @@ mod repr;
 use repr::Repr;
 
 mod traits;
-pub use traits::ToCompactStr;
+pub use traits::ToCompactString;
 
 #[cfg(test)]
 mod tests;
 
-/// A [`CompactStr`] is a compact string type that can be used almost anywhere a
+/// A [`CompactString`] is a compact string type that can be used almost anywhere a
 /// [`String`] or [`str`] can be used.
 ///
-/// ## Using `CompactStr`
+/// ## Using `CompactString`
 /// ```
-/// use compact_str::CompactStr;
+/// use compact_str::CompactString;
 /// # use std::collections::HashMap;
 ///
-/// // CompactStr auto derefs into a str so you can use all methods from `str`
+/// // CompactString auto derefs into a str so you can use all methods from `str`
 /// // that take a `&self`
-/// if CompactStr::new("hello world!").is_ascii() {
+/// if CompactString::new("hello world!").is_ascii() {
 ///     println!("we're all ASCII")
 /// }
 ///
-/// // You can use a CompactStr in collections like you would a String or &str
-/// let mut map: HashMap<CompactStr, CompactStr> = HashMap::new();
+/// // You can use a CompactString in collections like you would a String or &str
+/// let mut map: HashMap<CompactString, CompactString> = HashMap::new();
 ///
-/// // directly construct a new `CompactStr`
-/// map.insert(CompactStr::new("nyc"), CompactStr::new("empire state building"));
-/// // create a `CompactStr` from a `&str`
+/// // directly construct a new `CompactString`
+/// map.insert(CompactString::new("nyc"), CompactString::new("empire state building"));
+/// // create a `CompactString` from a `&str`
 /// map.insert("sf".into(), "transamerica pyramid".into());
-/// // create a `CompactStr` from a `String`
+/// // create a `CompactString` from a `String`
 /// map.insert(String::from("sea").into(), String::from("space needle").into());
 ///
 /// fn wrapped_print<T: AsRef<str>>(text: T) {
 ///     println!("{}", text.as_ref());
 /// }
 ///
-/// // CompactStr impls AsRef<str> and Borrow<str>, so it can be used anywhere
+/// // CompactString impls AsRef<str> and Borrow<str>, so it can be used anywhere
 /// // that excepts a generic string
 /// if let Some(building) = map.get("nyc") {
 ///     wrapped_print(building);
 /// }
 ///
-/// // CompactStr can also be directly compared to a String or &str
-/// assert_eq!(CompactStr::new("chicago"), "chicago");
-/// assert_eq!(CompactStr::new("houston"), String::from("houston"));
+/// // CompactString can also be directly compared to a String or &str
+/// assert_eq!(CompactString::new("chicago"), "chicago");
+/// assert_eq!(CompactString::new("houston"), String::from("houston"));
 /// ```
 #[derive(Clone)]
-pub struct CompactStr {
+pub struct CompactString {
     repr: Repr,
 }
 
-impl CompactStr {
-    /// Creates a new [`CompactStr`] from any type that implements `AsRef<str>`.
+/// # DEPRECATED
+/// Renamed `CompactStr` to [`CompactString`]. Using the suffix "String" as opposed to "Str" more
+/// accurately reflects that we own the underlying string.
+///
+/// Type alias `CompactStr` will be removed in v0.5
+#[deprecated(
+    since = "0.4.0",
+    note = "Renamed to CompactString, type alias will be removed in v0.5"
+)]
+pub type CompactStr = CompactString;
+
+impl CompactString {
+    /// Creates a new [`CompactString`] from any type that implements `AsRef<str>`.
     /// If the string is short enough, then it will be inlined on the stack!
     ///
     /// # Examples
     ///
     /// ### Inlined
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// // We can inline strings up to 12 characters long on 32-bit architectures...
     /// #[cfg(target_pointer_width = "32")]
     /// let s = "i'm 12 chars";
@@ -103,7 +114,7 @@ impl CompactStr {
     /// #[cfg(target_pointer_width = "64")]
     /// let s = "i am 24 characters long!";
     ///
-    /// let compact = CompactStr::new(&s);
+    /// let compact = CompactString::new(&s);
     ///
     /// assert_eq!(compact, s);
     /// // we are not allocated on the heap!
@@ -112,10 +123,10 @@ impl CompactStr {
     ///
     /// ### Heap
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// // For longer strings though, we get allocated on the heap
     /// let long = "I am a longer string that will be allocated on the heap";
-    /// let compact = CompactStr::new(long);
+    /// let compact = CompactString::new(long);
     ///
     /// assert_eq!(compact, long);
     /// // we are allocated on the heap!
@@ -124,63 +135,63 @@ impl CompactStr {
     ///
     /// ### Creation
     /// ```
-    /// use compact_str::CompactStr;
+    /// use compact_str::CompactString;
     ///
     /// // Using a `&'static str`
     /// let s = "hello world!";
-    /// let hello = CompactStr::new(&s);
+    /// let hello = CompactString::new(&s);
     ///
     /// // Using a `String`
     /// let u = String::from("🦄🌈");
-    /// let unicorn = CompactStr::new(u);
+    /// let unicorn = CompactString::new(u);
     ///
     /// // Using a `Box<str>`
     /// let b: Box<str> = String::from("📦📦📦").into_boxed_str();
-    /// let boxed = CompactStr::new(&b);
+    /// let boxed = CompactString::new(&b);
     /// ```
     #[inline]
     pub fn new<T: AsRef<str>>(text: T) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::new(text),
         }
     }
 
-    /// Creates a new inline [`CompactStr`] at compile time.
+    /// Creates a new inline [`CompactString`] at compile time.
     ///
     /// # Examples
     /// ```
-    /// use compact_str::CompactStr;
+    /// use compact_str::CompactString;
     ///
-    /// const DEFAULT_NAME: CompactStr = CompactStr::new_inline("untitled");
+    /// const DEFAULT_NAME: CompactString = CompactString::new_inline("untitled");
     /// ```
     ///
     /// Note: Trying to create a long string that can't be inlined, will fail to build.
     /// ```compile_fail
-    /// # use compact_str::CompactStr;
-    /// const LONG: CompactStr = CompactStr::new_inline("this is a long string that can't be stored on the stack");
+    /// # use compact_str::CompactString;
+    /// const LONG: CompactString = CompactString::new_inline("this is a long string that can't be stored on the stack");
     /// ```
     #[inline]
     pub const fn new_inline(text: &str) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::new_const(text),
         }
     }
 
-    /// Creates a new empty [`CompactStr`] with the capacity to fit at least `capacity` bytes.
+    /// Creates a new empty [`CompactString`] with the capacity to fit at least `capacity` bytes.
     ///
-    /// A `CompactStr` will inline strings on the stack, if they're small enough. Specifically, if
-    /// the string has a length less than or equal to `std::mem::size_of::<String>` bytes then it
-    /// will be inlined. This also means that `CompactStr`s have a minimum capacity of
-    /// `std::mem::size_of::<String>`.
+    /// A `CompactString` will inline strings on the stack, if they're small enough. Specifically,
+    /// if the string has a length less than or equal to `std::mem::size_of::<String>` bytes
+    /// then it will be inlined. This also means that `CompactString`s have a minimum capacity
+    /// of `std::mem::size_of::<String>`.
     ///
     /// # Examples
     ///
     /// ### "zero" Capacity
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // Creating a CompactStr with a capacity of 0 will create
+    /// # use compact_str::CompactString;
+    /// // Creating a CompactString with a capacity of 0 will create
     /// // one with capacity of std::mem::size_of::<String>();
-    /// let empty = CompactStr::with_capacity(0);
+    /// let empty = CompactString::with_capacity(0);
     /// let min_size = std::mem::size_of::<String>();
     ///
     /// assert_eq!(empty.capacity(), min_size);
@@ -190,11 +201,11 @@ impl CompactStr {
     ///
     /// ### Max Inline Size
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // Creating a CompactStr with a capacity of std::mem::size_of::<String>()
+    /// # use compact_str::CompactString;
+    /// // Creating a CompactString with a capacity of std::mem::size_of::<String>()
     /// // will not heap allocate.
     /// let str_size = std::mem::size_of::<String>();
-    /// let empty = CompactStr::with_capacity(str_size);
+    /// let empty = CompactString::with_capacity(str_size);
     ///
     /// assert_eq!(empty.capacity(), str_size);
     /// assert!(!empty.is_heap_allocated());
@@ -202,57 +213,57 @@ impl CompactStr {
     ///
     /// ### Heap Allocating
     /// ```
-    /// # use compact_str::CompactStr;
-    /// // If you create a `CompactStr` with a capacity greater than
+    /// # use compact_str::CompactString;
+    /// // If you create a `CompactString` with a capacity greater than
     /// // `std::mem::size_of::<String>`, it will heap allocated
     ///
     /// let heap_size = std::mem::size_of::<String>() + 1;
-    /// let empty = CompactStr::with_capacity(heap_size);
+    /// let empty = CompactString::with_capacity(heap_size);
     ///
     /// assert_eq!(empty.capacity(), heap_size);
     /// assert!(empty.is_heap_allocated());
     /// ```
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        CompactStr {
+        CompactString {
             repr: Repr::with_capacity(capacity),
         }
     }
 
-    /// Convert a slice of bytes into a [`CompactStr`].
+    /// Convert a slice of bytes into a [`CompactString`].
     ///
-    /// A [`CompactStr`] is a contiguous collection of bytes (`u8`s) that is valid [`UTF-8`](https://en.wikipedia.org/wiki/UTF-8).
-    /// This method converts from an arbitrary contiguous collection of bytes into a [`CompactStr`],
-    /// failing if the provided bytes are not `UTF-8`.
+    /// A [`CompactString`] is a contiguous collection of bytes (`u8`s) that is valid [`UTF-8`](https://en.wikipedia.org/wiki/UTF-8).
+    /// This method converts from an arbitrary contiguous collection of bytes into a
+    /// [`CompactString`], failing if the provided bytes are not `UTF-8`.
     ///
-    /// Note: If you want to create a [`CompactStr`] from a non-contiguous collection of bytes,
-    /// enable the `bytes` feature of this crate, and see `CompactStr::from_utf8_buf`
+    /// Note: If you want to create a [`CompactString`] from a non-contiguous collection of bytes,
+    /// enable the `bytes` feature of this crate, and see `CompactString::from_utf8_buf`
     ///
     /// # Examples
     /// ### Valid UTF-8
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let bytes = vec![240, 159, 166, 128, 240, 159, 146, 175];
-    /// let compact = CompactStr::from_utf8(bytes).expect("valid UTF-8");
+    /// let compact = CompactString::from_utf8(bytes).expect("valid UTF-8");
     ///
     /// assert_eq!(compact, "🦀💯");
     /// ```
     ///
     /// ### Invalid UTF-8
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let bytes = vec![255, 255, 255];
-    /// let result = CompactStr::from_utf8(bytes);
+    /// let result = CompactString::from_utf8(bytes);
     ///
     /// assert!(result.is_err());
     /// ```
     #[inline]
     pub fn from_utf8<B: AsRef<[u8]>>(buf: B) -> Result<Self, Utf8Error> {
         let repr = Repr::from_utf8(buf)?;
-        Ok(CompactStr { repr })
+        Ok(CompactString { repr })
     }
 
-    /// Returns the length of the [`CompactStr`] in `bytes`, not [`char`]s or graphemes.
+    /// Returns the length of the [`CompactString`] in `bytes`, not [`char`]s or graphemes.
     ///
     /// When using `UTF-8` encoding (which all strings in Rust do) a single character will be 1 to 4
     /// bytes long, therefore the return value of this method might not be what a human considers
@@ -260,11 +271,11 @@ impl CompactStr {
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let ascii = CompactStr::new("hello world");
+    /// # use compact_str::CompactString;
+    /// let ascii = CompactString::new("hello world");
     /// assert_eq!(ascii.len(), 11);
     ///
-    /// let emoji = CompactStr::new("👱");
+    /// let emoji = CompactString::new("👱");
     /// assert_eq!(emoji.len(), 4);
     /// ```
     #[inline]
@@ -272,12 +283,12 @@ impl CompactStr {
         self.repr.len()
     }
 
-    /// Returns `true` if the [`CompactStr`] has a length of 0, `false` otherwise
+    /// Returns `true` if the [`CompactString`] has a length of 0, `false` otherwise
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut msg = CompactStr::new("");
+    /// # use compact_str::CompactString;
+    /// let mut msg = CompactString::new("");
     /// assert!(msg.is_empty());
     ///
     /// // add some characters
@@ -289,25 +300,25 @@ impl CompactStr {
         self.len() == 0
     }
 
-    /// Returns the capacity of the [`CompactStr`], in bytes.
+    /// Returns the capacity of the [`CompactString`], in bytes.
     ///
     /// # Note
-    /// * A `CompactStr` will always have a capacity of at least `std::mem::size_of::<String>()`
+    /// * A `CompactString` will always have a capacity of at least `std::mem::size_of::<String>()`
     ///
     /// # Examples
     /// ### Minimum Size
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     /// let min_size = std::mem::size_of::<String>();
-    /// let compact = CompactStr::new("");
+    /// let compact = CompactString::new("");
     ///
     /// assert!(compact.capacity() >= min_size);
     /// ```
     ///
     /// ### Heap Allocated
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let compact = CompactStr::with_capacity(128);
+    /// # use compact_str::CompactString;
+    /// let compact = CompactString::with_capacity(128);
     /// assert_eq!(compact.capacity(), 128);
     /// ```
     #[inline]
@@ -315,23 +326,23 @@ impl CompactStr {
         self.repr.capacity()
     }
 
-    /// Ensures that this [`CompactStr`]'s capacity is at least `additional` bytes longer than its
-    /// length. The capacity may be increased by more than `additional` bytes if it chooses, to
-    /// prevent frequent reallocations.
+    /// Ensures that this [`CompactString`]'s capacity is at least `additional` bytes longer than
+    /// its length. The capacity may be increased by more than `additional` bytes if it chooses,
+    /// to prevent frequent reallocations.
     ///
     /// # Note
-    /// * A `CompactStr` will always have at least a capacity of `std::mem::size_of::<String>()`
-    /// * Reserving additional bytes may cause the `CompactStr` to become heap allocated
+    /// * A `CompactString` will always have at least a capacity of `std::mem::size_of::<String>()`
+    /// * Reserving additional bytes may cause the `CompactString` to become heap allocated
     ///
     /// # Panics
     /// Panics if the new capacity overflows `usize`
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
+    /// # use compact_str::CompactString;
     ///
     /// const WORD: usize = std::mem::size_of::<usize>();
-    /// let mut compact = CompactStr::default();
+    /// let mut compact = CompactString::default();
     /// assert!(compact.capacity() >= (WORD * 3) - 1);
     ///
     /// compact.reserve(200);
@@ -344,12 +355,12 @@ impl CompactStr {
         self.repr.reserve(additional)
     }
 
-    /// Returns a string slice containing the entire [`CompactStr`].
+    /// Returns a string slice containing the entire [`CompactString`].
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let s = CompactString::new("hello");
     ///
     /// assert_eq!(s.as_str(), "hello");
     /// ```
@@ -358,12 +369,12 @@ impl CompactStr {
         self.repr.as_str()
     }
 
-    /// Returns a byte slice of the [`CompactStr`]'s contents.
+    /// Returns a byte slice of the [`CompactString`]'s contents.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let s = CompactString::new("hello");
     ///
     /// assert_eq!(&[104, 101, 108, 108, 111], s.as_bytes());
     /// ```
@@ -377,13 +388,14 @@ impl CompactStr {
     /// Provides a mutable reference to the underlying buffer of bytes.
     ///
     /// # Safety
-    /// * All Rust strings, including `CompactStr`, must be valid UTF-8. The caller must guarantee
+    /// * All Rust strings, including `CompactString`, must be valid UTF-8. The caller must
+    ///   guarantee
     /// that any modifications made to the underlying buffer are valid UTF-8.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("hello");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("hello");
     ///
     /// let slice = unsafe { s.as_mut_bytes() };
     /// // copy bytes into our string
@@ -398,12 +410,12 @@ impl CompactStr {
         self.repr.as_mut_slice()
     }
 
-    /// Appends the given [`char`] to the end of this [`CompactStr`].
+    /// Appends the given [`char`] to the end of this [`CompactString`].
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("foo");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("foo");
     ///
     /// s.push('b');
     /// s.push('a');
@@ -416,13 +428,13 @@ impl CompactStr {
         self.repr.push(ch)
     }
 
-    /// Removes the last character from the [`CompactStr`] and returns it.
+    /// Removes the last character from the [`CompactString`] and returns it.
     /// Returns `None` if this `ComapctStr` is empty.
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("abc");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("abc");
     ///
     /// assert_eq!(s.pop(), Some('c'));
     /// assert_eq!(s.pop(), Some('b'));
@@ -435,12 +447,12 @@ impl CompactStr {
         self.repr.pop()
     }
 
-    /// Appends a given string slice onto the end of this [`CompactStr`]
+    /// Appends a given string slice onto the end of this [`CompactString`]
     ///
     /// # Examples
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let mut s = CompactStr::new("abc");
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("abc");
     ///
     /// s.push_str("123");
     ///
@@ -451,11 +463,11 @@ impl CompactStr {
         self.repr.push_str(s)
     }
 
-    /// Forces the length of the [`CompactStr`] to `new_len`.
+    /// Forces the length of the [`CompactString`] to `new_len`.
     ///
-    /// This is a low-level operation that maintains none of the normal invariants for `CompactStr`.
-    /// If you want to modify the `CompactStr` you should use methods like `push`, `push_str` or
-    /// `pop`.
+    /// This is a low-level operation that maintains none of the normal invariants for
+    /// `CompactString`. If you want to modify the `CompactString` you should use methods like
+    /// `push`, `push_str` or `pop`.
     ///
     /// # Safety
     /// * `new_len` must be less than or equal to `capacity()`
@@ -465,21 +477,21 @@ impl CompactStr {
         self.repr.set_len(new_len)
     }
 
-    /// Returns whether or not the [`CompactStr`] is heap allocated.
+    /// Returns whether or not the [`CompactString`] is heap allocated.
     ///
     /// # Examples
     /// ### Inlined
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let hello = CompactStr::new("hello world");
+    /// # use compact_str::CompactString;
+    /// let hello = CompactString::new("hello world");
     ///
     /// assert!(!hello.is_heap_allocated());
     /// ```
     ///
     /// ### Heap Allocated
     /// ```
-    /// # use compact_str::CompactStr;
-    /// let msg = CompactStr::new("this message will self destruct in 5, 4, 3, 2, 1 💥");
+    /// # use compact_str::CompactString;
+    /// let msg = CompactString::new("this message will self destruct in 5, 4, 3, 2, 1 💥");
     ///
     /// assert!(msg.is_heap_allocated());
     /// ```
@@ -489,14 +501,14 @@ impl CompactStr {
     }
 }
 
-impl Default for CompactStr {
+impl Default for CompactString {
     #[inline]
     fn default() -> Self {
-        CompactStr::new("")
+        CompactString::new("")
     }
 }
 
-impl Deref for CompactStr {
+impl Deref for CompactString {
     type Target = str;
 
     #[inline]
@@ -505,84 +517,84 @@ impl Deref for CompactStr {
     }
 }
 
-impl AsRef<str> for CompactStr {
+impl AsRef<str> for CompactString {
     #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Borrow<str> for CompactStr {
+impl Borrow<str> for CompactString {
     #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
-impl Eq for CompactStr {}
+impl Eq for CompactString {}
 
-impl<T: AsRef<str>> PartialEq<T> for CompactStr {
+impl<T: AsRef<str>> PartialEq<T> for CompactString {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
 }
 
-impl PartialEq<CompactStr> for String {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl PartialEq<CompactString> for String {
+    fn eq(&self, other: &CompactString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
-impl PartialEq<CompactStr> for &str {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl PartialEq<CompactString> for &str {
+    fn eq(&self, other: &CompactString) -> bool {
         *self == other.as_str()
     }
 }
 
-impl<'a> PartialEq<CompactStr> for Cow<'a, str> {
-    fn eq(&self, other: &CompactStr) -> bool {
+impl<'a> PartialEq<CompactString> for Cow<'a, str> {
+    fn eq(&self, other: &CompactString) -> bool {
         *self == other.as_str()
     }
 }
 
-impl Ord for CompactStr {
+impl Ord for CompactString {
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
-impl PartialOrd for CompactStr {
+impl PartialOrd for CompactString {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Hash for CompactStr {
+impl Hash for CompactString {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_str().hash(state)
     }
 }
 
-impl<'a> From<&'a str> for CompactStr {
+impl<'a> From<&'a str> for CompactString {
     fn from(s: &'a str) -> Self {
-        CompactStr::new(s)
+        CompactString::new(s)
     }
 }
 
-impl From<String> for CompactStr {
+impl From<String> for CompactString {
     fn from(s: String) -> Self {
         let repr = Repr::from_string(s);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> From<&'a String> for CompactStr {
+impl<'a> From<&'a String> for CompactString {
     fn from(s: &'a String) -> Self {
-        CompactStr::new(&s)
+        CompactString::new(&s)
     }
 }
 
-impl<'a> From<Cow<'a, str>> for CompactStr {
+impl<'a> From<Cow<'a, str>> for CompactString {
     fn from(cow: Cow<'a, str>) -> Self {
         match cow {
             Cow::Borrowed(s) => s.into(),
@@ -591,111 +603,111 @@ impl<'a> From<Cow<'a, str>> for CompactStr {
     }
 }
 
-impl From<Box<str>> for CompactStr {
+impl From<Box<str>> for CompactString {
     fn from(b: Box<str>) -> Self {
         let repr = Repr::from_box_str(b);
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromStr for CompactStr {
+impl FromStr for CompactString {
     type Err = core::convert::Infallible;
-    fn from_str(s: &str) -> Result<CompactStr, Self::Err> {
-        Ok(CompactStr::from(s))
+    fn from_str(s: &str) -> Result<CompactString, Self::Err> {
+        Ok(CompactString::from(s))
     }
 }
 
-impl fmt::Debug for CompactStr {
+impl fmt::Debug for CompactString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
-impl fmt::Display for CompactStr {
+impl fmt::Display for CompactString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl FromIterator<char> for CompactStr {
+impl FromIterator<char> for CompactString {
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> FromIterator<&'a char> for CompactStr {
+impl<'a> FromIterator<&'a char> for CompactString {
     fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl<'a> FromIterator<&'a str> for CompactStr {
+impl<'a> FromIterator<&'a str> for CompactString {
     fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromIterator<Box<str>> for CompactStr {
+impl FromIterator<Box<str>> for CompactString {
     fn from_iter<T: IntoIterator<Item = Box<str>>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl FromIterator<String> for CompactStr {
+impl FromIterator<String> for CompactString {
     fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
         let repr = iter.into_iter().collect();
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
-impl Extend<char> for CompactStr {
+impl Extend<char> for CompactString {
     fn extend<T: IntoIterator<Item = char>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<&'a char> for CompactStr {
+impl<'a> Extend<&'a char> for CompactString {
     fn extend<T: IntoIterator<Item = &'a char>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<&'a str> for CompactStr {
+impl<'a> Extend<&'a str> for CompactString {
     fn extend<T: IntoIterator<Item = &'a str>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl Extend<Box<str>> for CompactStr {
+impl Extend<Box<str>> for CompactString {
     fn extend<T: IntoIterator<Item = Box<str>>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl<'a> Extend<Cow<'a, str>> for CompactStr {
+impl<'a> Extend<Cow<'a, str>> for CompactString {
     fn extend<T: IntoIterator<Item = Cow<'a, str>>>(&mut self, iter: T) {
         iter.into_iter().for_each(move |s| self.push_str(&s));
     }
 }
 
-impl Extend<String> for CompactStr {
+impl Extend<String> for CompactString {
     fn extend<T: IntoIterator<Item = String>>(&mut self, iter: T) {
         self.repr.extend(iter)
     }
 }
 
-impl fmt::Write for CompactStr {
+impl fmt::Write for CompactString {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.push_str(s);
         Ok(())
     }
 }
 
-impl Add<Self> for CompactStr {
+impl Add<Self> for CompactString {
     type Output = Self;
     fn add(mut self, rhs: Self) -> Self::Output {
         self.push_str(&rhs);
@@ -703,7 +715,7 @@ impl Add<Self> for CompactStr {
     }
 }
 
-impl Add<&Self> for CompactStr {
+impl Add<&Self> for CompactString {
     type Output = Self;
     fn add(mut self, rhs: &Self) -> Self::Output {
         self.push_str(rhs);
@@ -711,7 +723,7 @@ impl Add<&Self> for CompactStr {
     }
 }
 
-impl Add<&str> for CompactStr {
+impl Add<&str> for CompactString {
     type Output = Self;
     fn add(mut self, rhs: &str) -> Self::Output {
         self.push_str(rhs);
@@ -719,7 +731,7 @@ impl Add<&str> for CompactStr {
     }
 }
 
-impl Add<&String> for CompactStr {
+impl Add<&String> for CompactString {
     type Output = Self;
     fn add(mut self, rhs: &String) -> Self::Output {
         self.push_str(rhs);
@@ -727,7 +739,7 @@ impl Add<&String> for CompactStr {
     }
 }
 
-impl Add<String> for CompactStr {
+impl Add<String> for CompactString {
     type Output = Self;
     fn add(mut self, rhs: String) -> Self::Output {
         self.push_str(&rhs);
@@ -735,12 +747,12 @@ impl Add<String> for CompactStr {
     }
 }
 
-impl Add<CompactStr> for String {
+impl Add<CompactString> for String {
     type Output = Self;
-    fn add(mut self, rhs: CompactStr) -> Self::Output {
+    fn add(mut self, rhs: CompactString) -> Self::Output {
         self.push_str(&rhs);
         self
     }
 }
 
-crate::asserts::assert_size_eq!(CompactStr, String);
+crate::asserts::assert_size_eq!(CompactString, String);

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -134,7 +134,7 @@ impl BoxString {
     #[inline]
     pub fn from_string(s: String) -> Self {
         match Capacity::new(s.capacity()) {
-            // Note: We should never hit this case when using BoxString with CompactStr
+            // Note: We should never hit this case when using BoxString with CompactString
             Ok(_) if s.capacity() == 0 => BoxString::new(""),
             Ok(cap) => {
                 let len = s.len();
@@ -153,7 +153,7 @@ impl BoxString {
     #[inline]
     pub fn from_box_str(b: Box<str>) -> Self {
         match Capacity::new(b.len()) {
-            // Note: We should never hit this case when using BoxString with CompactStr
+            // Note: We should never hit this case when using BoxString with CompactString
             Ok(_) if b.len() == 0 => BoxString::new(""),
             Ok(cap) => {
                 let len = b.len();

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,4 +1,4 @@
-//! Implementations of the [`FromIterator`] trait to make building `CompactStr`s more ergonomic
+//! Implementations of the [`FromIterator`] trait to make building `CompactString`s more ergonomic
 
 use core::iter::FromIterator;
 use core::mem::ManuallyDrop;

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -133,8 +133,9 @@ impl Repr {
         }
 
         if new_capacity <= MAX_SIZE {
-            // It's possible to have a `CompactStr` that is heap allocated with a capacity less than
-            // MAX_SIZE, if that `CompactStr` was created From a String or Box<str>.
+            // It's possible to have a `CompactString` that is heap allocated with a capacity less
+            // than MAX_SIZE, if that `CompactString` was created From a String or
+            // Box<str>.
             let inline = InlineString::new(self.as_str());
             *self = Repr { inline }
         } else {
@@ -524,7 +525,7 @@ mod tests {
         let word = "abc";
         let new_len = word.len();
 
-        // write bytes into the `CompactStr`
+        // write bytes into the `CompactString`
         slice[..new_len].copy_from_slice(word.as_bytes());
         // set the length
         unsafe { repr.set_len(new_len) }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -6,8 +6,8 @@ use proptest::strategy::Strategy;
 use test_strategy::proptest;
 
 use crate::{
-    CompactStr,
-    ToCompactStr,
+    CompactString,
+    ToCompactString,
 };
 
 #[cfg(target_pointer_width = "64")]
@@ -44,8 +44,8 @@ fn rand_unicode_collection() -> impl Strategy<Value = Vec<String>> {
     proptest::collection::vec(rand_unicode(), 0..40)
 }
 
-/// Asserts a [`CompactStr`] is allocated properly
-fn assert_allocated_properly(compact: &CompactStr) {
+/// Asserts a [`CompactString`] is allocated properly
+fn assert_allocated_properly(compact: &CompactString) {
     if compact.len() <= MAX_SIZE {
         assert!(!compact.is_heap_allocated())
     } else {
@@ -56,28 +56,28 @@ fn assert_allocated_properly(compact: &CompactStr) {
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
-    let compact = CompactStr::new(&word);
+    let compact = CompactString::new(&word);
     prop_assert_eq!(&word, &compact);
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_strings_allocated_properly(#[strategy(rand_unicode())] word: String) {
-    let compact = CompactStr::new(&word);
+    let compact = CompactString::new(&word);
     assert_allocated_properly(&compact);
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_char_iterator_roundtrips(#[strategy(rand_unicode())] word: String) {
-    let compact: CompactStr = word.clone().chars().collect();
+    let compact: CompactString = word.clone().chars().collect();
     prop_assert_eq!(&word, &compact)
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collection: Vec<String>) {
-    let compact: CompactStr = collection.clone().into_iter().collect();
+    let compact: CompactString = collection.clone().into_iter().collect();
     let word: String = collection.into_iter().collect();
     prop_assert_eq!(&word, &compact);
 }
@@ -86,7 +86,7 @@ fn test_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collec
 #[cfg_attr(miri, ignore)]
 fn test_from_bytes_roundtrips(#[strategy(rand_unicode())] word: String) {
     let bytes = word.into_bytes();
-    let compact = CompactStr::from_utf8(&bytes).unwrap();
+    let compact = CompactString::from_utf8(&bytes).unwrap();
     let word = String::from_utf8(bytes).unwrap();
 
     prop_assert_eq!(compact, word);
@@ -95,13 +95,13 @@ fn test_from_bytes_roundtrips(#[strategy(rand_unicode())] word: String) {
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_from_bytes_only_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
-    let compact_result = CompactStr::from_utf8(&bytes);
+    let compact_result = CompactString::from_utf8(&bytes);
     let word_result = String::from_utf8(bytes);
 
     match (compact_result, word_result) {
         (Ok(c), Ok(s)) => prop_assert_eq!(c, s),
         (Err(c_err), Err(s_err)) => prop_assert_eq!(c_err, s_err.utf8_error()),
-        _ => panic!("CompactStr and core::str read UTF-8 differently?"),
+        _ => panic!("CompactString and core::str read UTF-8 differently?"),
     }
 }
 
@@ -109,14 +109,14 @@ fn test_from_bytes_only_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
 #[cfg_attr(miri, ignore)]
 fn test_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) {
     let cow = String::from_utf8_lossy(&bytes[..]);
-    let compact = CompactStr::from(cow.clone());
+    let compact = CompactString::from(cow.clone());
     prop_assert_eq!(cow, compact);
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
-    let mut compact = CompactStr::default();
+    let mut compact = CompactString::default();
     prop_assert!(compact.is_empty());
 
     // reserve enough space to write our bytes
@@ -136,7 +136,7 @@ fn test_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn test_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode())] word: String) {
-    let mut compact = CompactStr::default();
+    let mut compact = CompactString::default();
     prop_assert!(compact.is_empty());
 
     // reserve enough space to write our bytes
@@ -164,7 +164,7 @@ fn test_extend_chars_allocated_properly(
     #[strategy(rand_unicode())] start: String,
     #[strategy(rand_unicode())] extend: String,
 ) {
-    let mut compact = CompactStr::new(&start);
+    let mut compact = CompactString::new(&start);
     compact.extend(extend.chars());
 
     let mut control = start.clone();
@@ -176,21 +176,21 @@ fn test_extend_chars_allocated_properly(
 
 #[test]
 fn test_const_creation() {
-    const EMPTY: CompactStr = CompactStr::new_inline("");
-    const SHORT: CompactStr = CompactStr::new_inline("rust");
+    const EMPTY: CompactString = CompactString::new_inline("");
+    const SHORT: CompactString = CompactString::new_inline("rust");
 
     #[cfg(target_pointer_width = "64")]
-    const PACKED: CompactStr = CompactStr::new_inline("i am 24 characters long!");
+    const PACKED: CompactString = CompactString::new_inline("i am 24 characters long!");
     #[cfg(target_pointer_width = "32")]
-    const PACKED: CompactStr = CompactStr::new_inline("i am 12 char");
+    const PACKED: CompactString = CompactString::new_inline("i am 12 char");
 
-    assert_eq!(EMPTY, CompactStr::new(""));
-    assert_eq!(SHORT, CompactStr::new("rust"));
+    assert_eq!(EMPTY, CompactString::new(""));
+    assert_eq!(SHORT, CompactString::new("rust"));
 
     #[cfg(target_pointer_width = "64")]
-    assert_eq!(PACKED, CompactStr::new("i am 24 characters long!"));
+    assert_eq!(PACKED, CompactString::new("i am 24 characters long!"));
     #[cfg(target_pointer_width = "32")]
-    assert_eq!(PACKED, CompactStr::new("i am 12 char"));
+    assert_eq!(PACKED, CompactString::new("i am 12 char"));
 }
 
 #[test]
@@ -199,7 +199,7 @@ fn test_short_ascii() {
     let strs = vec!["nyc", "statue", "liberty", "img_1234.png"];
 
     for s in strs {
-        let compact = CompactStr::new(s);
+        let compact = CompactString::new(s);
         assert_eq!(compact, s);
         assert_eq!(s, compact);
         assert_eq!(compact.is_heap_allocated(), false);
@@ -216,7 +216,7 @@ fn test_short_unicode() {
     ];
 
     for (s, is_heap) in strs {
-        let compact = CompactStr::new(s);
+        let compact = CompactString::new(s);
         assert_eq!(compact, s);
         assert_eq!(s, compact);
         assert_eq!(compact.is_heap_allocated(), is_heap);
@@ -233,7 +233,7 @@ fn test_medium_ascii() {
     ];
 
     for s in strs {
-        let compact = CompactStr::new(s);
+        let compact = CompactString::new(s);
         assert_eq!(compact, s);
         assert_eq!(s, compact);
 
@@ -255,7 +255,7 @@ fn test_medium_unicode() {
 
     #[allow(unused_variables)]
     for (s, is_heap) in strs {
-        let compact = CompactStr::new(s);
+        let compact = CompactString::new(s);
         assert_eq!(compact, s);
         assert_eq!(s, compact);
 
@@ -273,7 +273,7 @@ fn test_from_str_trait() {
     let s = "hello_world";
 
     // Until the never type `!` is stabilized, we have to unwrap here
-    let c = CompactStr::from_str(s).unwrap();
+    let c = CompactString::from_str(s).unwrap();
 
     assert_eq!(s, c);
 }
@@ -283,7 +283,7 @@ fn test_from_str_trait() {
 fn test_from_char_iter() {
     let s = "\u{0} 0 \u{0}a𐀀𐀀 𐀀a𐀀";
     println!("{}", s.len());
-    let compact: CompactStr = s.chars().into_iter().collect();
+    let compact: CompactString = s.chars().into_iter().collect();
 
     assert!(!compact.is_heap_allocated());
     assert_eq!(s, compact);
@@ -294,7 +294,7 @@ fn test_from_char_iter() {
 fn test_extend_packed_from_empty() {
     let s = "  0\u{80}A\u{0}𐀀 𐀀¡a𐀀0";
 
-    let mut compact = CompactStr::new(s);
+    let mut compact = CompactString::new(s);
     assert!(!compact.is_heap_allocated());
 
     // extend from an empty iterator
@@ -307,7 +307,7 @@ fn test_extend_packed_from_empty() {
 #[test]
 fn test_pop_empty() {
     let num_pops = 256;
-    let mut compact = CompactStr::from("");
+    let mut compact = CompactString::from("");
 
     (0..num_pops).for_each(|_| {
         let ch = compact.pop();
@@ -323,7 +323,7 @@ fn test_extend_from_empty_strs() {
         "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
         "", "",
     ];
-    let compact: CompactStr = strs.clone().into_iter().collect();
+    let compact: CompactString = strs.clone().into_iter().collect();
 
     assert_eq!(compact, "");
     assert!(compact.is_empty());
@@ -333,14 +333,14 @@ fn test_extend_from_empty_strs() {
 #[test]
 fn test_compact_str_is_send_and_sync() {
     fn is_send_and_sync<T: Send + Sync>() {}
-    is_send_and_sync::<CompactStr>();
+    is_send_and_sync::<CompactString>();
 }
 
 #[test]
 fn test_fmt_write() {
     use core::fmt::Write;
 
-    let mut compact = CompactStr::default();
+    let mut compact = CompactString::default();
 
     write!(compact, "test").unwrap();
     assert_eq!(compact, "test");
@@ -354,20 +354,20 @@ fn test_fmt_write() {
 
 #[test]
 fn test_plus_operator() {
-    assert_eq!(CompactStr::from("a") + CompactStr::from("b"), "ab");
-    assert_eq!(CompactStr::from("a") + &CompactStr::from("b"), "ab");
-    assert_eq!(CompactStr::from("a") + "b", "ab");
-    assert_eq!(CompactStr::from("a") + &String::from("b"), "ab");
-    assert_eq!(CompactStr::from("a") + String::from("b"), "ab");
-    assert_eq!(String::from("a") + CompactStr::from("b"), "ab");
+    assert_eq!(CompactString::from("a") + CompactString::from("b"), "ab");
+    assert_eq!(CompactString::from("a") + &CompactString::from("b"), "ab");
+    assert_eq!(CompactString::from("a") + "b", "ab");
+    assert_eq!(CompactString::from("a") + &String::from("b"), "ab");
+    assert_eq!(CompactString::from("a") + String::from("b"), "ab");
+    assert_eq!(String::from("a") + CompactString::from("b"), "ab");
 }
 
 #[test]
-fn test_u8_to_compact_str() {
+fn test_u8_to_compact_string() {
     let vals = [u8::MIN, 1, 42, u8::MAX - 2, u8::MAX - 1, u8::MAX];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -376,7 +376,7 @@ fn test_u8_to_compact_str() {
 }
 
 #[test]
-fn test_i8_to_compact_str() {
+fn test_i8_to_compact_string() {
     let vals = [
         i8::MIN,
         i8::MIN + 1,
@@ -391,7 +391,7 @@ fn test_i8_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -400,11 +400,11 @@ fn test_i8_to_compact_str() {
 }
 
 #[test]
-fn test_u16_to_compact_str() {
+fn test_u16_to_compact_string() {
     let vals = [u16::MIN, 1, 42, 999, u16::MAX - 2, u16::MAX - 1, u16::MAX];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -413,7 +413,7 @@ fn test_u16_to_compact_str() {
 }
 
 #[test]
-fn test_i16_to_compact_str() {
+fn test_i16_to_compact_string() {
     let vals = [
         i16::MIN,
         i16::MIN + 1,
@@ -430,7 +430,7 @@ fn test_i16_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -439,7 +439,7 @@ fn test_i16_to_compact_str() {
 }
 
 #[test]
-fn test_u32_to_compact_str() {
+fn test_u32_to_compact_string() {
     let vals = [
         u32::MIN,
         1,
@@ -452,7 +452,7 @@ fn test_u32_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -461,7 +461,7 @@ fn test_u32_to_compact_str() {
 }
 
 #[test]
-fn test_i32_to_compact_str() {
+fn test_i32_to_compact_string() {
     let vals = [
         i32::MIN,
         i32::MIN + 2,
@@ -479,7 +479,7 @@ fn test_i32_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -488,7 +488,7 @@ fn test_i32_to_compact_str() {
 }
 
 #[test]
-fn test_u64_to_compact_str() {
+fn test_u64_to_compact_string() {
     let vals = [
         u64::MIN,
         1,
@@ -501,7 +501,7 @@ fn test_u64_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -513,7 +513,7 @@ fn test_u64_to_compact_str() {
 }
 
 #[test]
-fn test_i64_to_compact_str() {
+fn test_i64_to_compact_string() {
     let vals = [
         i64::MIN,
         i64::MIN + 1,
@@ -530,7 +530,7 @@ fn test_i64_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -542,7 +542,7 @@ fn test_i64_to_compact_str() {
 }
 
 #[test]
-fn test_u128_to_compact_str() {
+fn test_u128_to_compact_string() {
     let vals = [
         u128::MIN,
         1,
@@ -554,7 +554,7 @@ fn test_u128_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -562,7 +562,7 @@ fn test_u128_to_compact_str() {
 }
 
 #[test]
-fn test_i128_to_compact_str() {
+fn test_i128_to_compact_string() {
     let vals = [
         i128::MIN,
         i128::MIN + 1,
@@ -579,7 +579,7 @@ fn test_i128_to_compact_str() {
     ];
 
     for x in &vals {
-        let c = x.to_compact_str();
+        let c = x.to_compact_string();
         let s = x.to_string();
 
         assert_eq!(c, s);
@@ -587,15 +587,15 @@ fn test_i128_to_compact_str() {
 }
 
 #[test]
-fn test_bool_to_compact_str() {
-    let c = true.to_compact_str();
+fn test_bool_to_compact_string() {
+    let c = true.to_compact_string();
     let s = true.to_string();
 
     assert_eq!("true", c);
     assert_eq!(c, s);
     assert!(!c.is_heap_allocated());
 
-    let c = false.to_compact_str();
+    let c = false.to_compact_string();
     let s = false.to_string();
 
     assert_eq!("false", c);
@@ -605,7 +605,7 @@ fn test_bool_to_compact_str() {
 
 macro_rules! format_compact {
     ( $fmt:expr $(, $args:tt)* ) => {
-        ToCompactStr::to_compact_str(
+        ToCompactString::to_compact_string(
             &core::format_args!(
                 $fmt,
                 $(
@@ -616,40 +616,43 @@ macro_rules! format_compact {
     };
 }
 
-macro_rules! assert_int_MAX_to_compact_str {
+macro_rules! assert_int_MAX_to_compact_string {
     ($int: ty) => {
-        assert_eq!(&*<$int>::MAX.to_string(), &*<$int>::MAX.to_compact_str());
+        assert_eq!(&*<$int>::MAX.to_string(), &*<$int>::MAX.to_compact_string());
     };
 }
 
 #[test]
-fn test_to_compact_str() {
+fn test_to_compact_string() {
     // Test specialisation for bool, char and String
-    assert_eq!(&*true.to_string(), "true".to_compact_str());
-    assert_eq!(&*false.to_string(), "false".to_compact_str());
+    assert_eq!(&*true.to_string(), "true".to_compact_string());
+    assert_eq!(&*false.to_string(), "false".to_compact_string());
 
-    assert_eq!("1", '1'.to_compact_str());
-    assert_eq!("2333", "2333".to_string().to_compact_str());
-    assert_eq!("2333", "2333".to_compact_str().to_compact_str());
+    assert_eq!("1", '1'.to_compact_string());
+    assert_eq!("2333", "2333".to_string().to_compact_string());
+    assert_eq!("2333", "2333".to_compact_string().to_compact_string());
 
     // Test specialisation for int and nonzero_int using itoa
-    assert_eq!("234", 234.to_compact_str());
-    assert_eq!("234", num::NonZeroU64::new(234).unwrap().to_compact_str());
+    assert_eq!("234", 234.to_compact_string());
+    assert_eq!(
+        "234",
+        num::NonZeroU64::new(234).unwrap().to_compact_string()
+    );
 
-    assert_int_MAX_to_compact_str!(u8);
-    assert_int_MAX_to_compact_str!(i8);
+    assert_int_MAX_to_compact_string!(u8);
+    assert_int_MAX_to_compact_string!(i8);
 
-    assert_int_MAX_to_compact_str!(u16);
-    assert_int_MAX_to_compact_str!(i16);
+    assert_int_MAX_to_compact_string!(u16);
+    assert_int_MAX_to_compact_string!(i16);
 
-    assert_int_MAX_to_compact_str!(u32);
-    assert_int_MAX_to_compact_str!(i32);
+    assert_int_MAX_to_compact_string!(u32);
+    assert_int_MAX_to_compact_string!(i32);
 
-    assert_int_MAX_to_compact_str!(u64);
-    assert_int_MAX_to_compact_str!(i64);
+    assert_int_MAX_to_compact_string!(u64);
+    assert_int_MAX_to_compact_string!(i64);
 
-    assert_int_MAX_to_compact_str!(usize);
-    assert_int_MAX_to_compact_str!(isize);
+    assert_int_MAX_to_compact_string!(usize);
+    assert_int_MAX_to_compact_string!(isize);
 
     // Test specialisation for f32 and f64 using ryu
     // TODO: Fix bug in powerpc64, which is a little endian system
@@ -658,23 +661,23 @@ fn test_to_compact_str() {
         assert_eq!(
             (&*3.2_f32.to_string(), &*288888.290028_f64.to_string()),
             (
-                &*3.2_f32.to_compact_str(),
-                &*288888.290028_f64.to_compact_str()
+                &*3.2_f32.to_compact_string(),
+                &*288888.290028_f64.to_compact_string()
             )
         );
 
-        assert_eq!("inf", f32::INFINITY.to_compact_str());
-        assert_eq!("-inf", f32::NEG_INFINITY.to_compact_str());
+        assert_eq!("inf", f32::INFINITY.to_compact_string());
+        assert_eq!("-inf", f32::NEG_INFINITY.to_compact_string());
 
-        assert_eq!("inf", f64::INFINITY.to_compact_str());
-        assert_eq!("-inf", f64::NEG_INFINITY.to_compact_str());
+        assert_eq!("inf", f64::INFINITY.to_compact_string());
+        assert_eq!("-inf", f64::NEG_INFINITY.to_compact_string());
 
-        assert_eq!("NaN", f32::NAN.to_compact_str());
-        assert_eq!("NaN", f64::NAN.to_compact_str());
+        assert_eq!("NaN", f32::NAN.to_compact_string());
+        assert_eq!("NaN", f64::NAN.to_compact_string());
     }
 
     // Test generic Display implementation
-    assert_eq!("234", "234".to_compact_str());
+    assert_eq!("234", "234".to_compact_string());
     assert_eq!("12345", format_compact!("{}", "12345"));
     assert_eq!("112345", format_compact!("1{}", "12345"));
     assert_eq!("1123452", format_compact!("1{}{}", "12345", 2));

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -14,46 +14,46 @@ use super::repr::{
     Repr,
 };
 use super::utility::count;
-use crate::CompactStr;
+use crate::CompactString;
 
-/// A trait for converting a value to a `CompactStr`.
+/// A trait for converting a value to a `CompactString`.
 ///
 /// This trait is automatically implemented for any type which implements the
-/// [`fmt::Display`] trait. As such, `ToCompactStr` shouldn't be implemented directly:
-/// [`fmt::Display`] should be implemented instead, and you get the `ToCompactStr`
+/// [`fmt::Display`] trait. As such, `ToCompactString` shouldn't be implemented directly:
+/// [`fmt::Display`] should be implemented instead, and you get the `ToCompactString`
 /// implementation for free.
-pub trait ToCompactStr {
-    /// Converts the given value to a `CompactStr`.
+pub trait ToCompactString {
+    /// Converts the given value to a `CompactString`.
     ///
     /// # Examples
     ///
     /// Basic usage:
     ///
     /// ```
-    /// use compact_str::ToCompactStr;
-    /// # use compact_str::CompactStr;
+    /// use compact_str::ToCompactString;
+    /// # use compact_str::CompactString;
     ///
     /// let i = 5;
-    /// let five = CompactStr::new("5");
+    /// let five = CompactString::new("5");
     ///
-    /// assert_eq!(i.to_compact_str(), five);
+    /// assert_eq!(i.to_compact_string(), five);
     /// ```
-    fn to_compact_str(&self) -> CompactStr;
+    fn to_compact_string(&self) -> CompactString;
 }
 
 /// # Safety
 ///
-/// * CompactStr does not contain any lifetime
-/// * CompactStr is 'static
-/// * CompactStr is a container to `u8`, which is `LifetimeFree`.
-unsafe impl LifetimeFree for CompactStr {}
+/// * CompactString does not contain any lifetime
+/// * CompactString is 'static
+/// * CompactString is a container to `u8`, which is `LifetimeFree`.
+unsafe impl LifetimeFree for CompactString {}
 unsafe impl LifetimeFree for Repr {}
 
 /// # Panics
 ///
-/// In this implementation, the `to_compact_str` method panics if the `Display` implementation
+/// In this implementation, the `to_compact_string` method panics if the `Display` implementation
 /// returns an error. This indicates an incorrect `Display` implementation since
-/// `std::fmt::Write for CompactStr` never returns an error itself.
+/// `std::fmt::Write for CompactString` never returns an error itself.
 ///
 /// # Note
 ///
@@ -63,12 +63,12 @@ unsafe impl LifetimeFree for Repr {}
 /// * `NonZeroU*`, `NonZeroI*`
 /// * `bool`
 /// * `char`
-/// * `String`, `CompactStr`
+/// * `String`, `CompactString`
 /// * `f32`, `f64`
 ///     * For floats we use [`ryu`] crate which sometimes provides different formatting than [`std`]
-impl<T: fmt::Display> ToCompactStr for T {
+impl<T: fmt::Display> ToCompactString for T {
     #[inline]
-    fn to_compact_str(&self) -> CompactStr {
+    fn to_compact_string(&self) -> CompactString {
         let repr = match_type!(self, {
             &u8 as s => s.into_repr(),
             &i8 as s => s.into_repr(),
@@ -87,7 +87,7 @@ impl<T: fmt::Display> ToCompactStr for T {
             &bool as s => s.into_repr(),
             &char as s => s.into_repr(),
             &String as s => Repr::new(&*s),
-            &CompactStr as s => Repr::new(s),
+            &CompactString as s => Repr::new(s),
             &num::NonZeroU8 as s => s.into_repr(),
             &num::NonZeroI8 as s => s.into_repr(),
             &num::NonZeroU16 as s => s.into_repr(),
@@ -110,7 +110,7 @@ impl<T: fmt::Display> ToCompactStr for T {
             }
         });
 
-        CompactStr { repr }
+        CompactString { repr }
     }
 }
 
@@ -121,201 +121,201 @@ mod tests {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
-    use super::ToCompactStr;
+    use super::ToCompactString;
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_u8(val: u8) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_i8(val: i8) {
-        let compact = val.to_compact_str();
+    fn test_to_compact_string_u8(val: u8) {
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_u16(val: u16) {
-        let compact = val.to_compact_str();
+    fn test_to_compact_string_i8(val: i8) {
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_i16(val: i16) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_u32(val: u32) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_i32(val: i32) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_u64(val: u64) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_i64(val: i64) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_usize(val: usize) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_isize(val: isize) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_u128(val: u128) {
-        let compact = val.to_compact_str();
-        prop_assert_eq!(compact.as_str(), val.to_string());
-    }
-    #[proptest]
-    #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_i128(val: i128) {
-        let compact = val.to_compact_str();
+    fn test_to_compact_string_u16(val: u16) {
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_u8(
+    fn test_to_compact_string_i16(val: i16) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_u32(val: u32) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_i32(val: i32) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_u64(val: u64) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_i64(val: i64) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_usize(val: usize) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_isize(val: isize) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_u128(val: u128) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_i128(val: i128) {
+        let compact = val.to_compact_string();
+        prop_assert_eq!(compact.as_str(), val.to_string());
+    }
+
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn test_to_compact_string_non_zero_u8(
         #[strategy((1..=u8::MAX).prop_map(|x| unsafe { num::NonZeroU8::new_unchecked(x)} ))]
         val: num::NonZeroU8,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_u16(
+    fn test_to_compact_string_non_zero_u16(
         #[strategy((1..=u16::MAX).prop_map(|x| unsafe { num::NonZeroU16::new_unchecked(x)} ))]
         val: num::NonZeroU16,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_u32(
+    fn test_to_compact_string_non_zero_u32(
         #[strategy((1..=u32::MAX).prop_map(|x| unsafe { num::NonZeroU32::new_unchecked(x)} ))]
         val: num::NonZeroU32,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_u64(
+    fn test_to_compact_string_non_zero_u64(
         #[strategy((1..=u64::MAX).prop_map(|x| unsafe { num::NonZeroU64::new_unchecked(x)} ))]
         val: num::NonZeroU64,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_u128(
+    fn test_to_compact_string_non_zero_u128(
         #[strategy((1..=u128::MAX).prop_map(|x| unsafe { num::NonZeroU128::new_unchecked(x)} ))]
         val: num::NonZeroU128,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_usize(
+    fn test_to_compact_string_non_zero_usize(
         #[strategy((1..=usize::MAX).prop_map(|x| unsafe { num::NonZeroUsize::new_unchecked(x)} ))]
         val: num::NonZeroUsize,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_i8(
+    fn test_to_compact_string_non_zero_i8(
         #[strategy((1..=u8::MAX).prop_map(|x| unsafe { num::NonZeroI8::new_unchecked(x as i8)} ))]
         val: num::NonZeroI8,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_i16(
+    fn test_to_compact_string_non_zero_i16(
         #[strategy((1..=u16::MAX).prop_map(|x| unsafe { num::NonZeroI16::new_unchecked(x as i16)} ))]
         val: num::NonZeroI16,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_i32(
+    fn test_to_compact_string_non_zero_i32(
         #[strategy((1..=u32::MAX).prop_map(|x| unsafe { num::NonZeroI32::new_unchecked(x as i32)} ))]
         val: num::NonZeroI32,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_i64(
+    fn test_to_compact_string_non_zero_i64(
         #[strategy((1..=u64::MAX).prop_map(|x| unsafe { num::NonZeroI64::new_unchecked(x as i64)} ))]
         val: num::NonZeroI64,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_i128(
+    fn test_to_compact_string_non_zero_i128(
         #[strategy((1..=u128::MAX).prop_map(|x| unsafe { num::NonZeroI128::new_unchecked(x as i128)} ))]
         val: num::NonZeroI128,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_str_non_zero_isize(
+    fn test_to_compact_string_non_zero_isize(
         #[strategy((1..=usize::MAX).prop_map(|x| unsafe { num::NonZeroIsize::new_unchecked(x as isize)} ))]
         val: num::NonZeroIsize,
     ) {
-        let compact = val.to_compact_str();
+        let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 }

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -46,7 +46,6 @@ pub trait ToCompactString {
 /// * [`CompactString`] does not contain any lifetime
 /// * [`CompactString`] is 'static
 /// * [`CompactString`] is a container to `u8`, which is `LifetimeFree`.
-/// 
 unsafe impl LifetimeFree for CompactString {}
 unsafe impl LifetimeFree for Repr {}
 
@@ -67,7 +66,6 @@ unsafe impl LifetimeFree for Repr {}
 /// * `String`, `CompactString`
 /// * `f32`, `f64`
 ///     * For floats we use [`ryu`] crate which sometimes provides different formatting than [`std`]
-/// 
 impl<T: fmt::Display> ToCompactString for T {
     #[inline]
     fn to_compact_string(&self) -> CompactString {

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -19,11 +19,11 @@ use crate::CompactString;
 /// A trait for converting a value to a `CompactString`.
 ///
 /// This trait is automatically implemented for any type which implements the
-/// [`fmt::Display`] trait. As such, `ToCompactString` shouldn't be implemented directly:
-/// [`fmt::Display`] should be implemented instead, and you get the `ToCompactString`
+/// [`fmt::Display`] trait. As such, [`ToCompactString`] shouldn't be implemented directly:
+/// [`fmt::Display`] should be implemented instead, and you get the [`ToCompactString`]
 /// implementation for free.
 pub trait ToCompactString {
-    /// Converts the given value to a `CompactString`.
+    /// Converts the given value to a [`CompactString`].
     ///
     /// # Examples
     ///
@@ -43,9 +43,10 @@ pub trait ToCompactString {
 
 /// # Safety
 ///
-/// * CompactString does not contain any lifetime
-/// * CompactString is 'static
-/// * CompactString is a container to `u8`, which is `LifetimeFree`.
+/// * [`CompactString`] does not contain any lifetime
+/// * [`CompactString`] is 'static
+/// * [`CompactString`] is a container to `u8`, which is `LifetimeFree`.
+/// 
 unsafe impl LifetimeFree for CompactString {}
 unsafe impl LifetimeFree for Repr {}
 
@@ -66,6 +67,7 @@ unsafe impl LifetimeFree for Repr {}
 /// * `String`, `CompactString`
 /// * `f32`, `f64`
 ///     * For floats we use [`ryu`] crate which sometimes provides different formatting than [`std`]
+/// 
 impl<T: fmt::Display> ToCompactString for T {
     #[inline]
     fn to_compact_string(&self) -> CompactString {


### PR DESCRIPTION


This PR renames `CompactStr` to `CompactString`

Some feedback I've received is using the "str" suffix isn't great because it suggests that a `CompactStr` doesn't own the underlying string, just like a `&str`. We change the suffix to "String" to fix this and improve the understanding.

We also add a type alias of `CompactStr` so existing crates will continue to work, albeit with a deprecation warning. This breaking change will go out with v0.4 to prevent suddenly introducing warnings in projects that depend on `compact_str`
