### PR TITLE
examples: Update compact_str to 0.4

### DIFF
--- a/examples/bytes/Cargo.toml
+++ b/examples/bytes/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-compact_str = { version = "0.3", features = ["bytes"] }
+compact_str = { version = "0.4", features = ["bytes"] }

--- a/examples/bytes/src/main.rs
+++ b/examples/bytes/src/main.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 fn main() {
     let word = "hello world!";
@@ -8,7 +8,7 @@ fn main() {
     // Cursor<&[u8]> is `bytes::Buf`
     let mut buf = Cursor::new(word.as_bytes());
     // `from_utf8_buf(...)` can fail, if the provided buffer is not valid UTF-8
-    let compact_str = CompactStr::from_utf8_buf(&mut buf).expect("valid utf-8");
+    let compact_str = CompactString::from_utf8_buf(&mut buf).expect("valid utf-8");
 
     assert_eq!(compact_str, word);
 

--- a/examples/serde/Cargo.toml
+++ b/examples/serde/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { version = "0.3", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/serde/src/main.rs
+++ b/examples/serde/src/main.rs
@@ -1,21 +1,21 @@
 // the fields in `Person` and `Address` are unread, hence the dead code warnings
 #![allow(dead_code)]
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 struct Person {
-    name: CompactStr,
+    name: CompactString,
     age: u8,
     address: Address,
-    phones: Vec<CompactStr>,
+    phones: Vec<CompactString>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Address {
-    street: CompactStr,
-    city: CompactStr,
+    street: CompactString,
+    city: CompactString,
 }
 
 fn main() {


### PR DESCRIPTION
This PR updates all of the examples to use `compact_str v0.4`