### PR TITLE
Add macro_rules `format_compact!`

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -16,10 +16,19 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt;
-use core::hash::{Hash, Hasher};
+use core::hash::{
+    Hash,
+    Hasher,
+};
 use core::iter::FromIterator;
-use core::ops::{Add, Deref};
-use core::str::{FromStr, Utf8Error};
+use core::ops::{
+    Add,
+    Deref,
+};
+use core::str::{
+    FromStr,
+    Utf8Error,
+};
 use std::borrow::Cow;
 use std::ffi::OsStr;
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -16,24 +16,16 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt;
-use core::hash::{
-    Hash,
-    Hasher,
-};
+use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
-use core::ops::{
-    Add,
-    Deref,
-};
-use core::str::{
-    FromStr,
-    Utf8Error,
-};
+use core::ops::{Add, Deref};
+use core::str::{FromStr, Utf8Error};
 use std::borrow::Cow;
 use std::ffi::OsStr;
 
 mod asserts;
 mod features;
+mod macros;
 mod utility;
 
 mod repr;

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -37,5 +37,8 @@ mod tests {
     fn test_macros() {
         assert_eq!(format_compact!("2"), "2");
         assert_eq!(format_compact!("{}", 2), "2");
+
+        assert!(!format_compact!("2").is_heap_allocated());
+        assert!(!format_compact!("{}", 2).is_heap_allocated());
     }
 }

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -14,8 +14,8 @@
 /// depending on the intended destination of the string.
 ///
 /// To convert a single value to a string, use the
-/// [`ToCompactString::to_compact_string`] method, which uses
-/// the [`Display`] formatting trait.
+/// `ToCompactString::to_compact_string` method, which uses
+/// the [`std::fmt::Display`] formatting trait.
 ///
 /// # Panics
 ///
@@ -23,7 +23,7 @@
 /// an error.
 ///
 /// This indicates an incorrect implementation since
-/// [`ToCompactString::to_compact_string`] never returns an error itself.
+/// `ToCompactString::to_compact_string` never returns an error itself.
 #[macro_export]
 macro_rules! format_compact {
     ($($arg:tt)*) => {{

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -34,7 +34,7 @@ macro_rules! format_compact {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test() {
+    fn test_macros() {
         assert_eq!(format_compact!("2"), "2");
         assert_eq!(format_compact!("{}", 2), "2");
     }

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -26,17 +26,16 @@
 /// [`ToCompactString::to_compact_string`] never returns an error itself.
 #[macro_export]
 macro_rules! format_compact {
-    ($fmt:expr) => {{ $crate::ToCompactString::to_compact_string(&$fmt) }};
-    ($fmt:expr, $($args:tt)*) => {{
-        $crate::ToCompactString::to_compact_string(&format_args!($fmt, $($args)*))
-    }};
+    ($($arg:tt)*) => {{
+        $crate::ToCompactString::to_compact_string(&format_args!($($arg)*))
+    }}
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
     fn test() {
-        assert_eq!(format_compact!(2), "2");
+        assert_eq!(format_compact!("2"), "2");
         assert_eq!(format_compact!("{}", 2), "2");
     }
 }

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -1,3 +1,29 @@
+/// Creates a String using interpolation of runtime expressions.
+///
+/// The first argument `format_compact!` receives is a format string.
+/// This must be a string literal.
+/// The power of the formatting string is in the `{}`s contained.
+///
+/// Additional parameters passed to `format_compact!` replace the `{}`s within
+/// the formatting string in the order given unless named or
+/// positional parameters are used; see [`std::fmt`] for more information.
+///
+/// A common use for `format_compact!` is concatenation and interpolation
+/// of strings.
+/// The same convention is used with [`print!`] and [`write!`] macros,
+/// depending on the intended destination of the string.
+///
+/// To convert a single value to a string, use the
+/// [`ToCompactString::to_compact_string`] method, which uses
+/// the [`Display`] formatting trait.
+///
+/// # Panics
+///
+/// `format_compact!` panics if a formatting trait implementation returns
+/// an error.
+///
+/// This indicates an incorrect implementation since
+/// [`ToCompactString::to_compact_string`] never returns an error itself.
 #[macro_export]
 macro_rules! format_compact {
     ($fmt:expr) => {{ $crate::ToCompactString::to_compact_string(&$fmt) }};

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -1,0 +1,16 @@
+#[macro_export]
+macro_rules! format_compact {
+    ($fmt:expr) => {{ $crate::ToCompactString::to_compact_string(&$fmt) }};
+    ($fmt:expr, $($args:tt)*) => {{
+        $crate::ToCompactString::to_compact_string(&format_args!($fmt, $($args)*))
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test() {
+        assert_eq!(format_compact!(2), "2");
+        assert_eq!(format_compact!("{}", 2), "2");
+    }
+}

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -1,4 +1,4 @@
-/// Creates a String using interpolation of runtime expressions.
+/// Creates a `CompactString` using interpolation of runtime expressions.
 ///
 /// The first argument `format_compact!` receives is a format string.
 /// This must be a string literal.


### PR DESCRIPTION
So that users can format any args into `CompactString` similar to how they can do it using [`std::format!`](https://doc.rust-lang.org/std/macro.format.html).

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>