### PR TITLE
perf: Optimize fmt::Write

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -713,6 +713,16 @@ impl fmt::Write for CompactString {
         self.push_str(s);
         Ok(())
     }
+
+    fn write_fmt(mut self: &mut Self, args: fmt::Arguments<'_>) -> fmt::Result {
+        match args.as_str() {
+            Some(s) => {
+                self.push_str(s);
+                Ok(())
+            }
+            None => fmt::write(&mut self, args),
+        }
+    }
 }
 
 impl Add<Self> for CompactString {

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -425,6 +425,16 @@ impl fmt::Write for Repr {
         self.push_str(s);
         Ok(())
     }
+
+    fn write_fmt(mut self: &mut Self, args: fmt::Arguments<'_>) -> fmt::Result {
+        match args.as_str() {
+            Some(s) => {
+                self.push_str(s);
+                Ok(())
+            }
+            None => fmt::write(&mut self, args),
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
For the naive case, e.g. when there are no arguments to format `write!(&mut compact_string, "hello_world")`, appends the string directly to the referenced `CompactString` to avoid the machinery of `fmt::Arguments`

Original implementation in #76 