### PR TITLE
feat: CompactStringExt trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Upcoming
 * Add `CompactStringExt` which provides methods to join and concatenate collections into a `CompactString`
-    * Implemented in [`#109`]
+    * Implemented in [`#109 feat: CompactStringExt trait`](https://github.com/ParkMyCar/compact_str/pull/109)
 * Encode `CompactStr` in such a way that `size_of::<CompactStr>() == size_of::<Option<CompactStr>>()`
     * Implemented in [`#105 perf: Option<CompactString> same size as CompactString`](https://github.com/ParkMyCar/compact_str/pull/105)
     * Implemented in [`#75: smol option`](https://github.com/ParkMyCar/compact_str/pull/75)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Upcoming
+* Add `CompactStringExt` which provides methods to join and concatenate collections into a `CompactString`
+    * Implemented in [`#109`]
 * Encode `CompactStr` in such a way that `size_of::<CompactStr>() == size_of::<Option<CompactStr>>()`
     * Implemented in [`#105 perf: Option<CompactString> same size as CompactString`](https://github.com/ParkMyCar/compact_str/pull/105)
     * Implemented in [`#75: smol option`](https://github.com/ParkMyCar/compact_str/pull/75)

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -41,7 +41,10 @@ mod repr;
 use repr::Repr;
 
 mod traits;
-pub use traits::ToCompactString;
+pub use traits::{
+    CompactStringExt,
+    ToCompactString,
+};
 
 #[cfg(test)]
 mod tests;

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -200,25 +200,48 @@ mod tests {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
+    use crate::CompactString;
     use super::{
         ToCompactString,
         CompactStringExt,
     };
 
     #[test]
-    fn test_join_slice() {
-        let items = ["hello", "world"];
-        let c = items.join_compact(" ");
-
+    fn test_join() {
+        let slice = ["hello", "world"];
+        let c = slice.join_compact(" ");
         assert_eq!(c, "hello world");
+
+        let vector = vec!["🍎", "🍊", "🍌"];
+        let c = vector.join_compact(",");
+        assert_eq!(c, "🍎,🍊,🍌");
+    }
+
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn proptest_join(items: Vec<String>, seperator: String) {
+        let c: CompactString = items.join_compact(&seperator);
+        let s: String = items.join(&seperator);
+        assert_eq!(c, s);
     }
 
     #[test]
-    fn test_join_vec() {
+    fn test_concat() {
         let items = vec!["hello", "world"];
         let c = items.join_compact(" ");
-    
         assert_eq!(c, "hello world");
+
+        let vector = vec!["🍎", "🍊", "🍌"];
+        let c = vector.concat_compact();
+        assert_eq!(c, "🍎🍊🍌");
+    }
+
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn proptest_concat(items: Vec<String>) {
+        let c: CompactString = items.concat_compact();
+        let s: String = items.concat();
+        assert_eq!(c, s);
     }
 
     #[proptest]

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -114,29 +114,53 @@ impl<T: fmt::Display> ToCompactString for T {
     }
 }
 
-/// A trait that provides convience methods for creating a [`CompactString`] from a collection of 
+/// A trait that provides convience methods for creating a [`CompactString`] from a collection of
 /// items. It is implemented for all types that can be converted into an iterator, and that iterator
 /// yields types that can be converted into a `str`.
-/// 
+///
 /// i.e. `C: IntoIterator<Item = AsRef<str>>`.
-/// 
+///
 /// # Concatenate and Join
 /// Two methods that this trait provides are `concat_compact(...)` and `join_compact(...)`
 /// ```
 /// use compact_str::CompactStringExt;
-/// 
+///
 /// let words = vec!["☀️", "🌕", "🌑", "☀️"];
-/// 
+///
 /// // directly concatenate all the words together
 /// let concat = words.concat_compact();
 /// assert_eq!(concat, "☀️🌕🌑☀️");
-/// 
+///
 /// // join the words, with a seperator
 /// let join = words.join_compact(" ➡️ ");
 /// assert_eq!(join, "☀️ ➡️ 🌕 ➡️ 🌑 ➡️ ☀️");
 /// ```
 pub trait CompactStringExt {
+    /// Concatenates all the items of a collection into a [`CompactString`]
+    ///
+    /// # Example
+    /// ```
+    /// use compact_str::CompactStringExt;
+    ///
+    /// let items = ["hello", " ", "world", "!"];
+    /// let compact = items.concat_compact();
+    ///
+    /// assert_eq!(compact, "hello world!");
+    /// ```
     fn concat_compact(&self) -> CompactString;
+
+    /// Joins all the items of a collection, placing a seperator between them, forming a
+    /// [`CompactString`]
+    ///
+    /// # Example
+    /// ```
+    /// use compact_str::CompactStringExt;
+    ///
+    /// let fruits = vec!["apples", "oranges", "bananas"];
+    /// let compact = fruits.join_compact(", ");
+    ///
+    /// assert_eq!(compact, "apples, oranges, bananas");
+    /// ```
     fn join_compact<S: AsRef<str>>(&self, seperator: S) -> CompactString;
 }
 
@@ -145,17 +169,6 @@ where
     I: AsRef<str>,
     for<'a> &'a C: IntoIterator<Item = &'a I>,
 {
-    /// Concatenates all the items of a collection into a [`CompactString`]
-    /// 
-    /// # Example
-    /// ```
-    /// use compact_str::CompactStringExt;
-    /// 
-    /// let items = ["hello", " ", "world", "!"];
-    /// let compact = items.concat_compact();
-    /// 
-    /// assert_eq!(compact, "hello world!");
-    /// ```
     fn concat_compact(&self) -> CompactString {
         self.into_iter()
             .fold(CompactString::new_inline(""), |mut s, item| {
@@ -164,18 +177,6 @@ where
             })
     }
 
-    /// Joins all the items of a collection, placing a seperator between them, forming a 
-    /// [`CompactString`]
-    /// 
-    /// # Example
-    /// ```
-    /// use compact_str::CompactStringExt;
-    /// 
-    /// let fruits = vec!["apples", "oranges", "bananas"];
-    /// let compact = fruits.join_compact(", ");
-    /// 
-    /// assert_eq!(compact, "apples, oranges, bananas");
-    /// ```
     fn join_compact<S: AsRef<str>>(&self, seperator: S) -> CompactString {
         let mut compact_string = CompactString::new_inline("");
 
@@ -200,11 +201,11 @@ mod tests {
     use proptest::prelude::*;
     use test_strategy::proptest;
 
-    use crate::CompactString;
     use super::{
-        ToCompactString,
         CompactStringExt,
+        ToCompactString,
     };
+    use crate::CompactString;
 
     #[test]
     fn test_join() {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -358,7 +358,7 @@ impl Creation<'_> {
                 assert_properly_allocated(&compact, &word);
 
                 Some((compact, word))
-            },
+            }
             Join(collection, seperator) => {
                 let compact: CompactString = collection.join_compact(seperator);
                 let std_str: String = collection.join(seperator);
@@ -367,7 +367,7 @@ impl Creation<'_> {
                 assert_properly_allocated(&compact, &std_str);
 
                 Some((compact, std_str))
-            },
+            }
             Concat(collection) => {
                 let compact: CompactString = collection.concat_compact();
                 let std_str: String = collection.concat();

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -5,6 +5,7 @@ use std::num;
 use arbitrary::Arbitrary;
 use compact_str::{
     CompactString,
+    CompactStringExt,
     ToCompactString,
 };
 
@@ -63,6 +64,10 @@ pub enum Creation<'a> {
     FromBoxStr(Box<str>),
     /// Create from a type that implements [`ToCompactString`]
     ToCompactString(ToCompactStringArg),
+    /// Create by joining a collection of strings with seperator, using [`CompactStringExt`]
+    Join(Vec<&'a str>, &'a str),
+    /// Create by concatenating a collection of strings, using [`CompactStringExt`]
+    Concat(Vec<&'a str>),
 }
 
 /// Types that we're able to convert to a [`CompactString`]
@@ -353,6 +358,24 @@ impl Creation<'_> {
                 assert_properly_allocated(&compact, &word);
 
                 Some((compact, word))
+            },
+            Join(collection, seperator) => {
+                let compact: CompactString = collection.join_compact(seperator);
+                let std_str: String = collection.join(seperator);
+
+                assert_eq!(compact, std_str);
+                assert_properly_allocated(&compact, &std_str);
+
+                Some((compact, std_str))
+            },
+            Concat(collection) => {
+                let compact: CompactString = collection.concat_compact();
+                let std_str: String = collection.concat();
+
+                assert_eq!(compact, std_str);
+                assert_properly_allocated(&compact, &std_str);
+
+                Some((compact, std_str))
             }
         }
     }


### PR DESCRIPTION
This PR introduces a new trait `CompactStringExt` which provides two methods:
1. `join_compact(seperator: impl AsRef<str>)`
2. `concat_compact()`

And then `CompactStringExt` is implemented for all types that implement `IntoIterartor<Item = AsRef<str>>`. 