### PR TITLE
chore: Remove CompactStr type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming
-* Encode `CompactStr` in such a way that `size_of::<CompactStr>() == size_of::<Option<CompactStr>>()`
+* Remove `CompactStr` type alias to prep for `v0.5`, as the deprecation message noted
+    * Implemented in [`#110 chore: Remove CompactStr type alias`](https://github.com/ParkMyCar/compact_str/pull/110)
+* Encode `CompactString` in such a way that `size_of::<CompactString>() == size_of::<Option<CompactString>>()`
     * Implemented in [`#105 perf: Option<CompactString> same size as CompactString`](https://github.com/ParkMyCar/compact_str/pull/105)
     * Implemented in [`#75: smol option`](https://github.com/ParkMyCar/compact_str/pull/75)
     * Implemented in [`#22 draft: Optimize Option<CompactStr> to be the same size as CompactStr`](https://github.com/ParkMyCar/compact_str/pull/22)

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -89,17 +89,6 @@ pub struct CompactString {
     repr: Repr,
 }
 
-/// # DEPRECATED
-/// Renamed `CompactStr` to [`CompactString`]. Using the suffix "String" as opposed to "Str" more
-/// accurately reflects that we own the underlying string.
-///
-/// Type alias `CompactStr` will be removed in v0.5
-#[deprecated(
-    since = "0.4.0",
-    note = "Renamed to CompactString, type alias will be removed in v0.5"
-)]
-pub type CompactStr = CompactString;
-
 impl CompactString {
     /// Creates a new [`CompactString`] from any type that implements `AsRef<str>`.
     /// If the string is short enough, then it will be inlined on the stack!


### PR DESCRIPTION
In `v0.4` we renamed `CompactStr` to `CompactString`, and then added a type alias of `CompactStr` so folks could upgrade to `v0.4` without issue. We marked the type alias as deprecated though, and said it would be removed in `v0.5`. To prep for a `v0.5` release we're removing the type alias here