### PR TITLE
ci: Only run workflows when certain paths change

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'compact_str/**'
+      - '.github/workflows/cross_platform.yml'
   workflow_dispatch:
 
 name: X-Plat

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+        - 'compact_str/**'
+        - '.github/workflows/fuzz.yml'
   workflow_dispatch:
   schedule:
     - cron: '0 01,13 * * *'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
         - 'compact_str/**'
+        - 'fuzz/**'
         - '.github/workflows/fuzz.yml'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'compact_str/**'
+      - '.github/workflows/msrv.yml'
   workflow_dispatch:
 
 name: MSRV


### PR DESCRIPTION
Today if you change just the `README.md` or `CHANGELOG.md` it kicks off the entire test suite, which is unnecessary. This PR updates the CI workflows so they only trigger when certain paths change