### PR TITLE
test: Cleanup test names and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,2 @@
 [workspace]
 members = ["bench", "examples/bytes", "examples/serde", "compact_str", "fuzz"]
-
-[patch.crates-io]
-# there's currently a bug with `arbitrary` that causes panics on 32-bit archs when the provided
-# buffer is >65kb. The fix has been patched but not yet released
-arbitrary = { git = "https://github.com/ParkMyCar/arbitrary.git", branch = "fix/32bit-panic" }
-# we update `test-strategy` to use edition 2018
-test-strategy = { git = "https://github.com/ParkMyCar/test-strategy", branch = "master" }

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -82,7 +82,7 @@ mod test {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_buffers_roundtrip(#[strategy(rand_unicode())] word: String) {
+    fn proptest_buffers_roundtrip(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
         let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
@@ -91,7 +91,7 @@ mod test {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_allocated_properly(#[strategy(rand_unicode())] word: String) {
+    fn proptest_allocated_properly(#[strategy(rand_unicode())] word: String) {
         let mut buf = Cursor::new(word.as_bytes());
         let compact = CompactString::from_utf8_buf(&mut buf).unwrap();
 
@@ -104,7 +104,7 @@ mod test {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_only_accept_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
+    fn proptest_only_accept_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
         let mut buf = Cursor::new(bytes.as_slice());
 
         let compact_result = CompactString::from_utf8_buf(&mut buf);

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -693,14 +693,14 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
+    fn proptest_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
         let box_str = BoxString::from(word.as_str());
         prop_assert_eq!(&word, box_str.as_str());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_from_string(#[strategy(rand_unicode())] word: String) {
+    fn proptest_from_string(#[strategy(rand_unicode())] word: String) {
         let s: String = word.clone();
         let box_str = BoxString::from_string(s);
 

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_roundtrip(#[strategy(rand_unicode_with_max_len(MAX_SIZE))] s: String) {
+    fn proptest_roundtrip(#[strategy(rand_unicode_with_max_len(MAX_SIZE))] s: String) {
         let inline = InlineString::new(&s);
 
         prop_assert_eq!(inline.len(), s.len());

--- a/compact_str/src/repr/traits.rs
+++ b/compact_str/src/repr/traits.rs
@@ -61,7 +61,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_into_repr_char(val: char) {
+    fn proptest_into_repr_char(val: char) {
         let repr = char::into_repr(val);
         prop_assert_eq!(repr.as_str(), val.to_string());
     }
@@ -93,7 +93,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_into_repr_f64(val: f64) {
+    fn proptest_into_repr_f64(val: f64) {
         let repr = f64::into_repr(val);
         let roundtrip = repr.as_str().parse::<f64>().unwrap();
 
@@ -136,7 +136,7 @@ mod tests {
     #[proptest]
     #[cfg_attr(miri, ignore)]
     #[cfg_attr(all(target_arch = "powerpc64", target_pointer_width = "64"), ignore)]
-    fn test_into_repr_f32(val: f32) {
+    fn proptest_into_repr_f32(val: f32) {
         let repr = f32::into_repr(val);
         let roundtrip = repr.as_str().parse::<f32>().unwrap();
 

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -76,7 +76,9 @@ fn proptest_char_iterator_roundtrips(#[strategy(rand_unicode())] word: String) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn proptest_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collection: Vec<String>) {
+fn proptest_string_iterator_roundtrips(
+    #[strategy(rand_unicode_collection())] collection: Vec<String>,
+) {
     let compact: CompactString = collection.clone().into_iter().collect();
     let word: String = collection.into_iter().collect();
     prop_assert_eq!(&word, &compact);

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -55,28 +55,28 @@ fn assert_allocated_properly(compact: &CompactString) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
+fn proptest_strings_roundtrip(#[strategy(rand_unicode())] word: String) {
     let compact = CompactString::new(&word);
     prop_assert_eq!(&word, &compact);
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_strings_allocated_properly(#[strategy(rand_unicode())] word: String) {
+fn proptest_strings_allocated_properly(#[strategy(rand_unicode())] word: String) {
     let compact = CompactString::new(&word);
     assert_allocated_properly(&compact);
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_char_iterator_roundtrips(#[strategy(rand_unicode())] word: String) {
+fn proptest_char_iterator_roundtrips(#[strategy(rand_unicode())] word: String) {
     let compact: CompactString = word.clone().chars().collect();
     prop_assert_eq!(&word, &compact)
 }
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collection: Vec<String>) {
+fn proptest_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collection: Vec<String>) {
     let compact: CompactString = collection.clone().into_iter().collect();
     let word: String = collection.into_iter().collect();
     prop_assert_eq!(&word, &compact);
@@ -84,7 +84,7 @@ fn test_string_iterator_roundtrips(#[strategy(rand_unicode_collection())] collec
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_from_bytes_roundtrips(#[strategy(rand_unicode())] word: String) {
+fn proptest_from_bytes_roundtrips(#[strategy(rand_unicode())] word: String) {
     let bytes = word.into_bytes();
     let compact = CompactString::from_utf8(&bytes).unwrap();
     let word = String::from_utf8(bytes).unwrap();
@@ -94,7 +94,7 @@ fn test_from_bytes_roundtrips(#[strategy(rand_unicode())] word: String) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_from_bytes_only_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
+fn proptest_from_bytes_only_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
     let compact_result = CompactString::from_utf8(&bytes);
     let word_result = String::from_utf8(bytes);
 
@@ -107,7 +107,7 @@ fn test_from_bytes_only_valid_utf8(#[strategy(rand_bytes())] bytes: Vec<u8>) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) {
+fn proptest_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) {
     let cow = String::from_utf8_lossy(&bytes[..]);
     let compact = CompactString::from(cow.clone());
     prop_assert_eq!(cow, compact);
@@ -115,7 +115,7 @@ fn test_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
+fn proptest_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
     let mut compact = CompactString::default();
     prop_assert!(compact.is_empty());
 
@@ -135,7 +135,7 @@ fn test_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode())] word: String) {
+fn proptest_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode())] word: String) {
     let mut compact = CompactString::default();
     prop_assert!(compact.is_empty());
 
@@ -160,7 +160,7 @@ fn test_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode())] w
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn test_extend_chars_allocated_properly(
+fn proptest_extend_chars_allocated_properly(
     #[strategy(rand_unicode())] start: String,
     #[strategy(rand_unicode())] extend: String,
 ) {
@@ -175,7 +175,7 @@ fn test_extend_chars_allocated_properly(
 }
 
 #[test]
-fn test_const_creation() {
+fn proptest_const_creation() {
     const EMPTY: CompactString = CompactString::new_inline("");
     const SHORT: CompactString = CompactString::new_inline("rust");
 

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -247,83 +247,83 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_u8(val: u8) {
+    fn proptest_to_compact_string_u8(val: u8) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_i8(val: i8) {
+    fn proptest_to_compact_string_i8(val: i8) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_u16(val: u16) {
+    fn proptest_to_compact_string_u16(val: u16) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_i16(val: i16) {
+    fn proptest_to_compact_string_i16(val: i16) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_u32(val: u32) {
+    fn proptest_to_compact_string_u32(val: u32) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_i32(val: i32) {
+    fn proptest_to_compact_string_i32(val: i32) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_u64(val: u64) {
+    fn proptest_to_compact_string_u64(val: u64) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_i64(val: i64) {
+    fn proptest_to_compact_string_i64(val: i64) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_usize(val: usize) {
+    fn proptest_to_compact_string_usize(val: usize) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_isize(val: isize) {
+    fn proptest_to_compact_string_isize(val: isize) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_u128(val: u128) {
+    fn proptest_to_compact_string_u128(val: u128) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_i128(val: i128) {
+    fn proptest_to_compact_string_i128(val: i128) {
         let compact = val.to_compact_string();
         prop_assert_eq!(compact.as_str(), val.to_string());
     }
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_u8(
+    fn proptest_to_compact_string_non_zero_u8(
         #[strategy((1..=u8::MAX).prop_map(|x| unsafe { num::NonZeroU8::new_unchecked(x)} ))]
         val: num::NonZeroU8,
     ) {
@@ -333,7 +333,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_u16(
+    fn proptest_to_compact_string_non_zero_u16(
         #[strategy((1..=u16::MAX).prop_map(|x| unsafe { num::NonZeroU16::new_unchecked(x)} ))]
         val: num::NonZeroU16,
     ) {
@@ -343,7 +343,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_u32(
+    fn proptest_to_compact_string_non_zero_u32(
         #[strategy((1..=u32::MAX).prop_map(|x| unsafe { num::NonZeroU32::new_unchecked(x)} ))]
         val: num::NonZeroU32,
     ) {
@@ -353,7 +353,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_u64(
+    fn proptest_to_compact_string_non_zero_u64(
         #[strategy((1..=u64::MAX).prop_map(|x| unsafe { num::NonZeroU64::new_unchecked(x)} ))]
         val: num::NonZeroU64,
     ) {
@@ -363,7 +363,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_u128(
+    fn proptest_to_compact_string_non_zero_u128(
         #[strategy((1..=u128::MAX).prop_map(|x| unsafe { num::NonZeroU128::new_unchecked(x)} ))]
         val: num::NonZeroU128,
     ) {
@@ -373,7 +373,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_usize(
+    fn proptest_to_compact_string_non_zero_usize(
         #[strategy((1..=usize::MAX).prop_map(|x| unsafe { num::NonZeroUsize::new_unchecked(x)} ))]
         val: num::NonZeroUsize,
     ) {
@@ -383,7 +383,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_i8(
+    fn proptest_to_compact_string_non_zero_i8(
         #[strategy((1..=u8::MAX).prop_map(|x| unsafe { num::NonZeroI8::new_unchecked(x as i8)} ))]
         val: num::NonZeroI8,
     ) {
@@ -393,7 +393,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_i16(
+    fn proptest_to_compact_string_non_zero_i16(
         #[strategy((1..=u16::MAX).prop_map(|x| unsafe { num::NonZeroI16::new_unchecked(x as i16)} ))]
         val: num::NonZeroI16,
     ) {
@@ -403,7 +403,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_i32(
+    fn proptest_to_compact_string_non_zero_i32(
         #[strategy((1..=u32::MAX).prop_map(|x| unsafe { num::NonZeroI32::new_unchecked(x as i32)} ))]
         val: num::NonZeroI32,
     ) {
@@ -413,7 +413,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_i64(
+    fn proptest_to_compact_string_non_zero_i64(
         #[strategy((1..=u64::MAX).prop_map(|x| unsafe { num::NonZeroI64::new_unchecked(x as i64)} ))]
         val: num::NonZeroI64,
     ) {
@@ -423,7 +423,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_i128(
+    fn proptest_to_compact_string_non_zero_i128(
         #[strategy((1..=u128::MAX).prop_map(|x| unsafe { num::NonZeroI128::new_unchecked(x as i128)} ))]
         val: num::NonZeroI128,
     ) {
@@ -433,7 +433,7 @@ mod tests {
 
     #[proptest]
     #[cfg_attr(miri, ignore)]
-    fn test_to_compact_string_non_zero_isize(
+    fn proptest_to_compact_string_non_zero_isize(
         #[strategy((1..=usize::MAX).prop_map(|x| unsafe { num::NonZeroIsize::new_unchecked(x as isize)} ))]
         val: num::NonZeroIsize,
     ) {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1.1", features = ["derive"] }
+arbitrary = { version = "1.1.1", features = ["derive"] }
 bytes = "1"
 compact_str = { path = "../compact_str", features = ["bytes"] }
 


### PR DESCRIPTION
This PR renames all tests that use `proptest` from `test_*` to `proptest_*` just to make our naming a bit more explicit.

It also gets rid of our patched dependencies:
1. `arbitrary`, we previously used a patched version to include a fix for fuzzing large input data on 32-bit machines. That fix shipped in `arbitrary 1.1.1`
2. `test-strategy`, we previously used a patched version that was Rust 2018, but now that we bumped the MSRV we can depend on the published crate 