### PR TITLE
cleanup and examples: Removes bounds check, adds more examples, removes const_panic hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Upcoming
+* Add examples for `CompactStringExt` and `ToCompactString` traits, and `format_compact!(...)` macro
+    * Implemented in [`#114 cleanup and examples: Removes bounds check, adds more examples, removes const_panic hack `](https://github.com/ParkMyCar/compact_str/pull/9)
+* Remove potential bounds check when converting to &str
+    * Implemented in [`#114 cleanup and examples: Removes bounds check, adds more examples, removes const_panic hack `](https://github.com/ParkMyCar/compact_str/pull/9)
+    * Implemented in [`#9 Remove potential bounds check from a hot path`](https://github.com/ParkMyCar/compact_str/pull/9)
 * Remove `CompactStr` type alias to prep for `v0.5`, as the deprecation message noted
     * Implemented in [`#110 chore: Remove CompactStr type alias`](https://github.com/ParkMyCar/compact_str/pull/110)
 * Add `CompactStringExt` which provides methods to join and concatenate collections into a `CompactString`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,10 @@
 [workspace]
-members = ["bench", "examples/bytes", "examples/serde", "compact_str", "fuzz"]
+members = [
+    "bench",
+    "examples/bytes",
+    "examples/macros",
+    "examples/serde",
+    "examples/traits",
+    "compact_str",
+    "fuzz",
+]

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -83,7 +83,7 @@ impl InlineString {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        &self.buffer.as_slice()
+        self.buffer.as_slice()
     }
 
     /// Provides a mutable reference to the underlying buffer

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -73,8 +73,12 @@ impl InlineString {
 
     #[inline]
     pub fn as_str(&self) -> &str {
-        // SAFETY: You can only construct an InlineString via a &str
-        unsafe { ::std::str::from_utf8_unchecked(&self.as_slice()[..self.len()]) }
+        // SAFETY: You can only safely construct an InlineString via a &str which also properly sets
+        // the length of the string
+        unsafe {
+            let slice = self.as_slice().get_unchecked(..self.len());
+            ::std::str::from_utf8_unchecked(slice)
+        }
     }
 
     #[inline]

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -32,12 +32,7 @@ impl InlineString {
     #[inline]
     pub const fn new_const(text: &str) -> Self {
         if text.len() > MAX_SIZE {
-            // HACK: This allows us to make assertions within a `const fn` without requiring
-            // nightly, see unstable `const_panic` feature. This results in a build
-            // failure, not a runtime panic
-            #[allow(clippy::no_effect)]
-            #[allow(unconditional_panic)]
-            ["Provided string has a length greater than MAX_INLINE_SIZE!"][42];
+            panic!("Provided string has a length greater than our MAX_SIZE");
         }
 
         let len = text.len();
@@ -84,7 +79,7 @@ impl InlineString {
 
     #[inline]
     pub fn as_slice(&self) -> &[u8] {
-        &self.buffer[..]
+        &self.buffer.as_slice()
     }
 
     /// Provides a mutable reference to the underlying buffer
@@ -93,7 +88,7 @@ impl InlineString {
     /// * Please see `super::Repr` for all invariants
     #[inline]
     pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        &mut self.buffer[..]
+        self.buffer.as_mut_slice()
     }
 
     #[inline]

--- a/examples/macros/Cargo.toml
+++ b/examples/macros/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+compact_str = { path = "../../compact_str" }

--- a/examples/macros/src/main.rs
+++ b/examples/macros/src/main.rs
@@ -1,0 +1,17 @@
+use compact_str::format_compact;
+
+fn main() {
+    // compact_str provides the format_compact! macro, which can be in place of the format! macro
+
+    let user = "Parker";
+    let msg = format_compact!("Hello {}", user);
+    println!("CompactString: {}", msg);
+
+    // `msg` is only 12 characters, so it can be inlined!
+    assert!(!msg.is_heap_allocated());
+
+    // and it's equaivalent to if we used the format! macro
+    let msg_std = format!("Hello {}", user);
+    assert_eq!(msg, msg_std);
+    println!("std::String: {}", msg);
+}

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "traits"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+compact_str = { path = "../../compact_str" }

--- a/examples/traits/src/main.rs
+++ b/examples/traits/src/main.rs
@@ -1,0 +1,33 @@
+use compact_str::{
+    CompactStringExt,
+    ToCompactString,
+};
+
+fn main() {
+    // CompactStringExt allows you to join collections to create a CompactString
+    let names = ["Joe", "Bob", "Alice"];
+    let compact = names.join_compact(", ");
+
+    assert_eq!(compact, "Joe, Bob, Alice");
+    println!("{}", compact);
+
+    // CompactStringExt also allows you to directly concatenate collections
+    let fruits = ["apple", "orange", "banana"];
+    let compact = fruits.concat_compact();
+
+    assert_eq!(compact, "appleorangebanana");
+    println!("{}", compact);
+
+    // ToCompactString allows you to convert individual types into a CompactString
+    let number = 42;
+    let compact = number.to_compact_string();
+
+    assert_eq!(compact, "42");
+    println!("{}", compact);
+
+    let answer = true;
+    let compact = answer.to_compact_string();
+
+    assert_eq!(compact, "true");
+    println!("{}", compact);
+}


### PR DESCRIPTION
This PR does a number of small things:

1. Removes a bounds check, originally proposed in #9 
2. Adds examples for the `ToCompactString` and `CompactStringExt` traits, and the `format_compact!(...)` macro
3. Cleans up code in `InlineString` now that the MSRV has been bumped to 1.57