### PR TITLE
examples: Update examples to use compact_str v0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,8 @@ jobs:
           command: run
           args: --manifest-path examples/serde/Cargo.toml
   
-  example-trais:
-    name: example - trais
+  example-traits:
+    name: example - traits
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -227,5 +227,5 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path examples/trais/Cargo.toml
+          args: --manifest-path examples/traits/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,33 @@ jobs:
           command: run
           args: --manifest-path examples/bytes/Cargo.toml
 
+  example-macros:
+    name: example - macros
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-macros
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path examples/macros/Cargo.toml
+
   example-serde:
     name: example - serde
     runs-on: ubuntu-latest
@@ -166,7 +193,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-bytes
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-serde
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
             ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
@@ -174,3 +201,31 @@ jobs:
         with:
           command: run
           args: --manifest-path examples/serde/Cargo.toml
+  
+  example-trais:
+    name: example - trais
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-traits
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path examples/trais/Cargo.toml
+

--- a/examples/bytes/Cargo.toml
+++ b/examples/bytes/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 bytes = "1"
-compact_str = { version = "0.4", features = ["bytes"] }
+compact_str = { version = "0.5", features = ["bytes"] }

--- a/examples/macros/Cargo.toml
+++ b/examples/macros/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { path = "../../compact_str" }
+compact_str = "0.5"

--- a/examples/serde/Cargo.toml
+++ b/examples/serde/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { version = "0.4", features = ["serde"] }
+compact_str = { version = "0.5", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { path = "../../compact_str" }
+compact_str = "0.5"


### PR DESCRIPTION
This PR updates the examples to use `compact_str v0.5`, and updates CI to include the `macros` and `traits` examples