### PR TITLE
feat: add impl From<CompactString> for String

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -610,6 +610,12 @@ impl From<Box<str>> for CompactString {
     }
 }
 
+impl From<CompactString> for String {
+    fn from(s: CompactString) -> Self {
+        s.repr.into_string()
+    }
+}
+
 impl FromStr for CompactString {
     type Err = core::convert::Infallible;
     fn from_str(s: &str) -> Result<CompactString, Self::Err> {

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -162,10 +162,7 @@ impl BoxString {
         // * `length` is less than or equal to capacity, due to internal invaraints.
         // * `capacity` is correctly maintained internally.
         // * `BoxString` only ever contains valid UTF-8.
-        // * `BoxString` capacity is always on the heap.
-        unsafe {
-            String::from_raw_parts(this.ptr.as_ptr(), this.len, this.cap.as_usize_unchecked())
-        }
+        unsafe { String::from_raw_parts(this.ptr.as_ptr(), this.len, this.capacity()) }
     }
 
     #[inline]

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -612,8 +612,10 @@ mod tests {
     fn test_32_bit_max_inline_cap() {
         // 65 is the ASCII value of 'A'
         // `SIXTEEN_MB - 2` is the max value we can store for capacity inline, when on 32-bit archs
-        let word_buf = vec![65; SIXTEEN_MB - 2];
-        let string = String::from_utf8(word_buf).unwrap();
+        let word_buf = vec![b'A'; SIXTEEN_MB - 2];
+        // SAFETY: We've just created the vector above, and it contains only ASCII characters.
+        // This speeds up `miri` runs significantly.
+        let string = unsafe { String::from_utf8_unchecked(word_buf) };
 
         let box_string = BoxString::new(&string);
 
@@ -627,8 +629,10 @@ mod tests {
     fn test_32_bit_max_inline_cap_with_modification() {
         // 65 is the ASCII value of 'A'
         // `SIXTEEN_MB - 2` is the max value we can store for capacity inline, when on 32-bit archs
-        let word_buf = vec![65; SIXTEEN_MB - 2];
-        let string = String::from_utf8(word_buf).unwrap();
+        let word_buf = vec![b'A'; SIXTEEN_MB - 2];
+        // SAFETY: We've just created the vector above, and it contains only ASCII characters.
+        // This speeds up `miri` runs significantly.
+        let string = unsafe { String::from_utf8_unchecked(word_buf) };
 
         let mut box_string = BoxString::new(&string);
 
@@ -668,8 +672,10 @@ mod tests {
     fn test_32_bit_min_heap_cap() {
         // 65 is the ASCII value of 'A'
         // `SIXTEEN_MB - 1` is the min value for capacity that gets stored on the heap
-        let word_buf = vec![65; SIXTEEN_MB - 1];
-        let string = String::from_utf8(word_buf).unwrap();
+        let word_buf = vec![b'A'; SIXTEEN_MB - 1];
+        // SAFETY: We've just created the vector above, and it contains only ASCII characters.
+        // This speeds up `miri` runs significantly.
+        let string = unsafe { String::from_utf8_unchecked(word_buf) };
 
         let mut box_string = BoxString::new(&string);
 

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -39,6 +39,11 @@ impl HeapString {
     }
 
     #[inline]
+    pub fn into_string(self) -> String {
+        self.string.into_string()
+    }
+
+    #[inline]
     pub fn from_box_str(b: Box<str>) -> Self {
         let string = BoxString::from_box_str(b);
         HeapString { string }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -127,9 +127,9 @@ impl Repr {
         if self.capacity() == 0 {
             String::new()
         } else {
-            match self.cast_into() {
-                StrongIntoRepr::Inline(inline) => String::from(inline.as_str()),
-                StrongIntoRepr::Heap(heap) => {
+            match self.cast_into_owned() {
+                StrongOwnedRepr::Inline(inline) => String::from(inline.as_str()),
+                StrongOwnedRepr::Heap(heap) => {
                     // `HeapString::into_string()` takes ownership and
                     // is responsible for avoiding a double-free.
                     ManuallyDrop::into_inner(heap).into_string()
@@ -289,15 +289,15 @@ impl Repr {
     }
 
     #[inline(always)]
-    fn cast_into(self) -> StrongIntoRepr {
+    fn cast_into_owned(self) -> StrongOwnedRepr {
         match self.discriminant() {
             Discriminant::Heap => {
                 // SAFETY: We checked the discriminant to make sure the union is `heap`
-                StrongIntoRepr::Heap(unsafe { self.into_union().heap })
+                StrongOwnedRepr::Heap(unsafe { self.into_union().heap })
             }
             Discriminant::Inline => {
                 // SAFETY: We checked the discriminant to make sure the union is `inline`
-                StrongIntoRepr::Inline(unsafe { self.into_union().inline })
+                StrongOwnedRepr::Inline(unsafe { self.into_union().inline })
             }
         }
     }
@@ -538,7 +538,7 @@ impl<'a> MutStrongRepr<'a> {
 }
 
 #[derive(Debug)]
-enum StrongIntoRepr {
+enum StrongOwnedRepr {
     Inline(InlineString),
     Heap(ManuallyDrop<HeapString>),
 }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -162,6 +162,16 @@ fn proptest_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode()
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
+fn proptest_arbitrary_compact_string_converts_to_string(#[strategy(rand_unicode())] word: String) {
+    let compact = CompactString::new(&word);
+    let result = String::from(compact);
+
+    prop_assert_eq!(result.len(), word.len());
+    prop_assert_eq!(result, word);
+}
+
+#[proptest]
+#[cfg_attr(miri, ignore)]
 fn proptest_extend_chars_allocated_properly(
     #[strategy(rand_unicode())] start: String,
     #[strategy(rand_unicode())] extend: String,
@@ -694,4 +704,132 @@ fn test_to_compact_string() {
         "01234567890123456789999999",
         format_compact!("0{}67890123456789{}", "12345", 999999)
     );
+}
+
+#[test]
+fn test_into_string_large_string_with_excess_capacity() {
+    let mut string = String::with_capacity(128);
+    string.push_str("abcdefghijklmnopqrstuvwxyz");
+    let str_addr = string.as_ptr();
+    let str_len = string.len();
+    let str_cap = string.capacity();
+
+    let compact = CompactString::from(string);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    assert_eq!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_cap, new_str_cap);
+}
+
+#[test]
+fn test_into_string_small_string_with_excess_capacity() {
+    let mut string = String::with_capacity(128);
+    string.push_str("abcdef");
+    let str_addr = string.as_ptr();
+    let str_len = string.len();
+    let str_cap = string.capacity();
+
+    let compact = CompactString::from(string);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    // If small boxed strings are eagerly compacted, the address and capacity assertions won't hold.
+    // Compaction is not eager, so these should hold.
+    assert_eq!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_cap, new_str_cap);
+}
+
+#[test]
+fn test_into_string_small_string_with_no_excess_capacity() {
+    let string = String::from("abcdef");
+    let str_addr = string.as_ptr();
+    let str_len = string.len();
+    let str_cap = string.capacity();
+
+    let compact = CompactString::from(string);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    // If small boxed strings are eagerly compacted, the address assertion won't hold.
+    // Compaction is not eager, so these should hold.
+    assert_eq!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_cap, new_str_cap);
+}
+
+#[test]
+fn test_into_string_empty_string() {
+    let string = String::new();
+    let str_addr = string.as_ptr();
+    let str_len = string.len();
+    let str_cap = string.capacity();
+
+    let compact = CompactString::from(string);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    assert_eq!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_cap, new_str_cap);
+}
+
+#[test]
+fn test_into_string_small_str() {
+    let data = "abcdef";
+    let str_addr = data.as_ptr();
+    let str_len = data.len();
+
+    let compact = CompactString::from(data);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    assert_ne!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_len, new_str_cap);
+}
+
+#[test]
+fn test_into_string_long_str() {
+    let data = "abcdefghijklmnopqrstuvwxyz";
+    let str_addr = data.as_ptr();
+    let str_len = data.len();
+
+    let compact = CompactString::from(data);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    assert_ne!(str_addr, new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_len, new_str_cap);
+}
+
+#[test]
+fn test_into_string_empty_str() {
+    let data = "";
+    let str_len = data.len();
+
+    let compact = CompactString::from(data);
+    let new_string = String::from(compact);
+    let new_str_addr = new_string.as_ptr();
+    let new_str_len = new_string.len();
+    let new_str_cap = new_string.capacity();
+
+    assert_eq!(String::new().as_ptr(), new_str_addr);
+    assert_eq!(str_len, new_str_len);
+    assert_eq!(str_len, new_str_cap);
 }


### PR DESCRIPTION
Tests added and run under `miri`. Ensures that no reallocation/copy of already-boxed strings happens in a round-trip, with the address, length, and capacity remaining stable.

Closes #117