### PR TITLE
ci: Add the CARGO_TERM_COLOR env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 name: CI
 
 env:
+  CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
   PROPTEST_CASES: 10000
   MIRIFLAGS: "-Zmiri-strict-provenance -Zmiri-check-number-validity"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,6 +8,7 @@ on:
 name: Clippy
 
 env:
+  CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
 
 jobs:

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -11,6 +11,7 @@ on:
 name: X-Plat
 
 env:
+  CARGO_TERM_COLOR: "always"
   # local default for proptest is 100
   PROPTEST_CASES: 1000
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,6 +13,10 @@ on:
 
 name: Fuzz
 
+env:
+  CARGO_TERM_COLOR: "always"
+  RUSTFLAGS: "-D warnings"
+
 jobs:
   libFuzzer_x86_64:
     name: libFuzzer [x86_64]

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -11,6 +11,7 @@ on:
 name: MSRV
 
 env:
+  CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
 
 jobs:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,2 @@
 [build.env]
-# env variables to define number of randomized tests
-passthrough = ["PROPTEST_CASES", "RANDOMIZED_RUNS"]
+passthrough = ["CARGO_TERM_COLOR", "PROPTEST_CASES", "RANDOMIZED_RUNS"]


### PR DESCRIPTION
While looking the Github Actions workflows for [`honggfuzz-rs`](https://github.com/rust-fuzz/honggfuzz-rs/blob/master/.github/workflows/rust.yml) I saw they set the `CARGO_TERM_COLOR` env variable to `always`. Seems like a good idea to make CI a little prettier/easier to read