### PR TITLE
fuzz: Reduce size of strings CollectChars generates

### DIFF
--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -187,7 +187,7 @@ fn proptest_extend_chars_allocated_properly(
 }
 
 #[test]
-fn proptest_const_creation() {
+fn test_const_creation() {
     const EMPTY: CompactString = CompactString::new_inline("");
     const SHORT: CompactString = CompactString::new_inline("rust");
 


### PR DESCRIPTION
This PR changes the `CollectChars` creation step in the fuzzing harness to generate smaller strings, and instead we'll test larger strings with proptest.

Generating large strings in the fuzzing harness reduced our executions per-second from ~3,500 to ~30, which is not great.