### PR TITLE
feat: Implement the Arbitrary trait from various crate

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -15,7 +15,7 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  test:
+  msrv:
     name: cargo test msrv..
     runs-on: ubuntu-latest
     steps:
@@ -49,4 +49,32 @@ jobs:
       - name: cargo test msrv..
         run: |
           cd compact_str
-          cargo hack test --feature-powerset --optional-deps --version-range 1.57..
+          cargo hack test --all-features --version-range 1.57..
+
+  feature_powerset:
+    name: cargo check feature-powerset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - name: Cargo Build Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-cargo-hack
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
+      - name: install cargo hack
+        run: cargo install cargo-hack --force
+      - name: cargo test msrv..
+        run: |
+          cd compact_str
+          cargo hack check --feature-powerset --optional-deps

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,10 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [dependencies]
+arbitrary = { version = "1", optional = true, default-features = false }
 bytes = { version = "1", optional = true }
+proptest = { version = "1", optional = true, default-features = false }
+quickcheck = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true }
 
 castaway = "0.2.1"
@@ -21,5 +24,6 @@ ryu = "1"
 
 [dev-dependencies]
 proptest = { version = "1", default-features = false, features = ["std"] }
+quickcheck_macros = "1"
 rayon = "1"
 test-strategy = "0.2"

--- a/compact_str/src/features/arbitrary.rs
+++ b/compact_str/src/features/arbitrary.rs
@@ -1,0 +1,52 @@
+//! Implements the [`arbitrary::Arbitrary`] trait for [`CompactString`]
+
+use arbitrary::{
+    Arbitrary,
+    Result,
+    Unstructured,
+};
+
+use crate::CompactString;
+
+impl<'a> Arbitrary<'a> for CompactString {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        <&str as Arbitrary>::arbitrary(u).map(CompactString::new)
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'a>) -> Result<Self> {
+        <&str as Arbitrary>::arbitrary_take_rest(u).map(CompactString::new)
+    }
+
+    #[inline]
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <&str as Arbitrary>::size_hint(depth)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arbitrary::{
+        Arbitrary,
+        Unstructured,
+    };
+
+    use crate::CompactString;
+
+    #[test]
+    fn arbitrary_sanity() {
+        let mut data = Unstructured::new(&[42; 50]);
+        let compact = CompactString::arbitrary(&mut data).expect("generate a CompactString");
+
+        // we don't really care what the content of the CompactString is, just that one's generated
+        assert!(!compact.is_empty());
+    }
+
+    #[test]
+    fn arbitrary_inlines_strings() {
+        let mut data = Unstructured::new(&[42; 20]);
+        let compact = CompactString::arbitrary(&mut data).expect("generate a CompactString");
+
+        // running this manually, we generate the string "**"
+        assert!(!compact.is_heap_allocated());
+    }
+}

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -1,6 +1,12 @@
 //! A module that contains the implementations for optional features. For example `serde` support
 
+#[cfg(feature = "arbitrary")]
+mod arbitrary;
 #[cfg(feature = "bytes")]
 mod bytes;
+#[cfg(feature = "proptest")]
+mod proptest;
+#[cfg(feature = "quickcheck")]
+mod quickcheck;
 #[cfg(feature = "serde")]
 mod serde;

--- a/compact_str/src/features/proptest.rs
+++ b/compact_str/src/features/proptest.rs
@@ -1,0 +1,52 @@
+//! Implements the [`proptest::arbitrary::Arbitrary`] trait for [`CompactString`]
+
+use proptest::arbitrary::{
+    Arbitrary,
+    StrategyFor,
+};
+use proptest::prelude::*;
+use proptest::strategy::{
+    MapInto,
+    Strategy,
+};
+use proptest::string::StringParam;
+
+use crate::CompactString;
+
+impl Arbitrary for CompactString {
+    type Parameters = StringParam;
+    type Strategy = MapInto<StrategyFor<String>, Self>;
+
+    fn arbitrary_with(a: Self::Parameters) -> Self::Strategy {
+        any_with::<String>(a).prop_map_into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use proptest::prelude::*;
+
+    use crate::CompactString;
+
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn proptest_sanity(compact: CompactString) {
+            let control: String = compact.clone().into();
+            assert_eq!(control, compact);
+        }
+
+        /// We rely on [`proptest`]'s `String` strategy for generating a `CompactString`. When
+        /// converting from a `String` into a `CompactString`, our O(1) converstion kicks in and we
+        /// reuse the buffer, unless empty, and thus all non-empty strings will be heap allocated
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn proptest_does_not_inline_strings(compact: CompactString) {
+            if compact.is_empty() {
+                assert!(!compact.is_heap_allocated());
+            } else {
+                assert!(compact.is_heap_allocated());
+            }
+        }
+    }
+}

--- a/compact_str/src/features/quickcheck.rs
+++ b/compact_str/src/features/quickcheck.rs
@@ -1,0 +1,55 @@
+//! Implements the [`quickcheck::Arbitrary`] trait for [`CompactString`]
+
+use quickcheck::{
+    Arbitrary,
+    Gen,
+};
+
+use crate::CompactString;
+
+impl Arbitrary for CompactString {
+    fn arbitrary(g: &mut Gen) -> CompactString {
+        let max = g.size();
+
+        // pick some value in [0, max]
+        let x = usize::arbitrary(g);
+        let ratio = (x as f64) / (usize::MAX as f64);
+        let size = (ratio * max as f64) as usize;
+
+        (0..size).map(|_| char::arbitrary(g)).collect()
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = CompactString>> {
+        // Shrink a string by shrinking a vector of its characters.
+        let chars: Vec<char> = self.chars().collect();
+        Box::new(
+            chars
+                .shrink()
+                .map(|x| x.into_iter().collect::<CompactString>()),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use quickcheck_macros::quickcheck;
+
+    use crate::CompactString;
+
+    #[quickcheck]
+    #[cfg_attr(miri, ignore)]
+    fn quickcheck_sanity(compact: CompactString) {
+        let control: String = compact.clone().into();
+        assert_eq!(control, compact);
+    }
+
+    #[quickcheck]
+    #[cfg_attr(miri, ignore)]
+    fn quickcheck_inlines_strings(compact: CompactString) {
+        if compact.len() <= std::mem::size_of::<String>() {
+            assert!(!compact.is_heap_allocated())
+        } else {
+            assert!(compact.is_heap_allocated())
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `Arbitrary` trait from the [`arbitrary`](https://github.com/rust-fuzz/arbitrary), [`proptest`](https://github.com/AltSysrq/proptest), and [`quickcheck`](https://github.com/BurntSushi/quickcheck) crates. It then makes those crates optional dependencies.

This makes it easier for folks to include a `CompactString` in their types, and then use randomized testing to cover those types