### PR TITLE
ci: Disable X-Plat and Fuzz workflow that runs on ARMv7 (Raspberry Pi)

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -84,32 +84,24 @@ jobs:
           command: miri
           args: test --all-features --manifest-path=compact_str/Cargo.toml
 
-  linux_arm7:
-    name: Linux ARMv7
-    runs-on: [self-hosted, linux, ARM]
-    steps:
-      - uses: actions/checkout@v2
-        name: Checkout Repo
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-arm7-v2
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml
+  # DISABLED(ParkMyCar) - until I can restart the Raspberry Pi runner
+  # linux_arm7:
+  #   name: Linux ARMv7
+  #   runs-on: [self-hosted, linux, ARM]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       name: Checkout Repo
+  #     - uses: actions-rs/toolchain@v1
+  #       name: Install Rust
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       name: cargo test
+  #       with:
+  #         command: test
+  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml
 
   linux_32bit:
     name: Linux 32-bit

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -154,57 +154,50 @@ jobs:
           name: Upload Crashes
           path: ./fuzz/afl/out/default/crashes/
 
-  afl_armv7:
-    name: AFL++ [ARMv7]
-    runs-on: [self-hosted, linux, ARM]
-    steps:
-      - uses: actions/checkout@v2
-        name: Checkout compact_str
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: nightly-2022-06-01
-          override: true
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: ${{ runner.os }}-armv7-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz-afl
-      - name: Install cargo-afl
-        run: |
-          cargo +nightly install afl --force
-      - name: AFL++ Build
-        run: |
-          cd fuzz
-          cargo +nightly afl build --bin afl --release --features=afl
-      - name: Set Fuzz Time
-        run: |
-          if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
-            echo "fuzz_time=120" >> $GITHUB_ENV
-          else
-            echo "fuzz_time=1800" >> $GITHUB_ENV
-          fi
-          echo "${{ env.fuzz_time }}"
-      - name: Fuzz!
-        run: |
-          cd fuzz
-          mkdir afl/out
-          cargo +nightly afl fuzz -i afl/in -o afl/out -D -V ${{ env.fuzz_time }} ../target/release/afl
-      - name: Check for Crashes
-        run: |
-          if [ "$(ls -1q ./fuzz/afl/out/default/crashes/ | wc -l)" -ne 0 ]; then exit 1; fi
-      # AFL generates filenames with ":", which upload-artifact fails on, so we need to "detox" them
-      - name: Sanitize Crash Filenames (if present)
-        if: failure()
-        run: |
-          detox -r -v ./fuzz/afl/out/default/crashes/
-      - name: Upload Crashes (if present)
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: Upload Crashes
-          path: ./fuzz/afl/out/default/crashes/
+  # DISABLED(ParkMyCar) - until I can restart the Raspberry Pi runner
+  # afl_armv7:
+  #   name: AFL++ [ARMv7]
+  #   runs-on: [self-hosted, linux, ARM]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       name: Checkout compact_str
+  #     - uses: actions-rs/toolchain@v1
+  #       name: Install Rust
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly-2022-06-01
+  #         override: true
+  #     - name: Install cargo-afl
+  #       run: |
+  #         cargo +nightly install afl --force
+  #     - name: AFL++ Build
+  #       run: |
+  #         cd fuzz
+  #         cargo +nightly afl build --bin afl --release --features=afl
+  #     - name: Set Fuzz Time
+  #       run: |
+  #         if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
+  #           echo "fuzz_time=120" >> $GITHUB_ENV
+  #         else
+  #           echo "fuzz_time=1800" >> $GITHUB_ENV
+  #         fi
+  #         echo "${{ env.fuzz_time }}"
+  #     - name: Fuzz!
+  #       run: |
+  #         cd fuzz
+  #         mkdir afl/out
+  #         cargo +nightly afl fuzz -i afl/in -o afl/out -D -V ${{ env.fuzz_time }} ../target/release/afl
+  #     - name: Check for Crashes
+  #       run: |
+  #         if [ "$(ls -1q ./fuzz/afl/out/default/crashes/ | wc -l)" -ne 0 ]; then exit 1; fi
+  #     # AFL generates filenames with ":", which upload-artifact fails on, so we need to "detox" them
+  #     - name: Sanitize Crash Filenames (if present)
+  #       if: failure()
+  #       run: |
+  #         detox -r -v ./fuzz/afl/out/default/crashes/
+  #     - name: Upload Crashes (if present)
+  #       if: failure()
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: Upload Crashes
+  #         path: ./fuzz/afl/out/default/crashes/


### PR DESCRIPTION
This PR comments out the two jobs that use the ARMv7 self hosted runner. The runner appears to be broken and I can't access it at the moment to fix it. Will re-enable soon