### PR TITLE
test: update doc test for CompactString::clear()

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -740,9 +740,13 @@ impl CompactString {
     ///
     /// ```
     /// # use compact_str::CompactString;
-    /// let mut s = CompactString::new("Hello, world!");
+    /// let mut s = CompactString::new("Rust is the most loved language on Stackoverflow!");
+    /// assert_eq!(s.capacity(), 49);
+    ///
     /// s.clear();
+    ///
     /// assert_eq!(s, "");
+    /// assert_eq!(s.capacity(), 49);
     /// ```
     pub fn clear(&mut self) {
         unsafe { self.set_len(0) };


### PR DESCRIPTION
This PR updates the doc test for `CompactString::clear()` to assert capacity doesn't change