### PR TITLE
Implement `drain()`

### DIFF
--- a/fuzz/src/actions.rs
+++ b/fuzz/src/actions.rs
@@ -32,6 +32,8 @@ pub enum Action<'a> {
     Insert(u8, char),
     /// Reduce the length to zero
     Clear,
+    /// Extract a range
+    Drain(u8, u8),
 }
 
 impl Action<'_> {
@@ -174,6 +176,21 @@ impl Action<'_> {
 
                 assert_eq!(control, compact);
                 assert_eq!(control.len(), compact.len());
+            }
+            Drain(start, end) => {
+                let start = to_index(control, start);
+                let end = to_index(control, end);
+                let (start, end) = (start.min(end), start.max(end));
+
+                let compact_capacity = compact.capacity();
+                let control_drain = control.drain(start..end);
+                let compact_drain = compact.drain(start..end);
+
+                assert_eq!(control_drain.as_str(), compact_drain.as_str());
+                drop(control_drain);
+                drop(compact_drain);
+                assert_eq!(control.as_str(), compact.as_str());
+                assert_eq!(compact.capacity(), compact_capacity);
             }
         }
     }


### PR DESCRIPTION
Makes `replace_range()` reusable, and closes #134.