### PR TITLE
ci: re-enable the ARMv7 workflows

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -84,24 +84,23 @@ jobs:
           command: miri
           args: test --all-features --manifest-path=compact_str/Cargo.toml
 
-  # DISABLED(ParkMyCar) - until I can restart the Raspberry Pi runner
-  # linux_arm7:
-  #   name: Linux ARMv7
-  #   runs-on: [self-hosted, linux, ARM]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml
+  linux_arm7:
+    name: Linux ARMv7
+    runs-on: [self-hosted, linux, ARM]
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Repo
+      - uses: actions-rs/toolchain@v1
+        name: Install Rust
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          command: test
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml
 
   linux_32bit:
     name: Linux 32-bit

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -154,50 +154,49 @@ jobs:
           name: Upload Crashes
           path: ./fuzz/afl/out/default/crashes/
 
-  # DISABLED(ParkMyCar) - until I can restart the Raspberry Pi runner
-  # afl_armv7:
-  #   name: AFL++ [ARMv7]
-  #   runs-on: [self-hosted, linux, ARM]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       name: Checkout compact_str
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         profile: minimal
-  #         toolchain: nightly-2022-06-01
-  #         override: true
-  #     - name: Install cargo-afl
-  #       run: |
-  #         cargo +nightly install afl --force
-  #     - name: AFL++ Build
-  #       run: |
-  #         cd fuzz
-  #         cargo +nightly afl build --bin afl --release --features=afl
-  #     - name: Set Fuzz Time
-  #       run: |
-  #         if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
-  #           echo "fuzz_time=120" >> $GITHUB_ENV
-  #         else
-  #           echo "fuzz_time=1800" >> $GITHUB_ENV
-  #         fi
-  #         echo "${{ env.fuzz_time }}"
-  #     - name: Fuzz!
-  #       run: |
-  #         cd fuzz
-  #         mkdir afl/out
-  #         cargo +nightly afl fuzz -i afl/in -o afl/out -D -V ${{ env.fuzz_time }} ../target/release/afl
-  #     - name: Check for Crashes
-  #       run: |
-  #         if [ "$(ls -1q ./fuzz/afl/out/default/crashes/ | wc -l)" -ne 0 ]; then exit 1; fi
-  #     # AFL generates filenames with ":", which upload-artifact fails on, so we need to "detox" them
-  #     - name: Sanitize Crash Filenames (if present)
-  #       if: failure()
-  #       run: |
-  #         detox -r -v ./fuzz/afl/out/default/crashes/
-  #     - name: Upload Crashes (if present)
-  #       if: failure()
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: Upload Crashes
-  #         path: ./fuzz/afl/out/default/crashes/
+  afl_armv7:
+    name: AFL++ [ARMv7]
+    runs-on: [self-hosted, linux, ARM]
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout compact_str
+      - uses: actions-rs/toolchain@v1
+        name: Install Rust
+        with:
+          profile: minimal
+          toolchain: nightly-2022-06-01
+          override: true
+      - name: Install cargo-afl
+        run: |
+          cargo +nightly install afl --force
+      - name: AFL++ Build
+        run: |
+          cd fuzz
+          cargo +nightly afl build --bin afl --release --features=afl
+      - name: Set Fuzz Time
+        run: |
+          if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
+            echo "fuzz_time=120" >> $GITHUB_ENV
+          else
+            echo "fuzz_time=1800" >> $GITHUB_ENV
+          fi
+          echo "${{ env.fuzz_time }}"
+      - name: Fuzz!
+        run: |
+          cd fuzz
+          mkdir afl/out
+          cargo +nightly afl fuzz -i afl/in -o afl/out -D -V ${{ env.fuzz_time }} ../target/release/afl
+      - name: Check for Crashes
+        run: |
+          if [ "$(ls -1q ./fuzz/afl/out/default/crashes/ | wc -l)" -ne 0 ]; then exit 1; fi
+      # AFL generates filenames with ":", which upload-artifact fails on, so we need to "detox" them
+      - name: Sanitize Crash Filenames (if present)
+        if: failure()
+        run: |
+          detox -r -v ./fuzz/afl/out/default/crashes/
+      - name: Upload Crashes (if present)
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Upload Crashes
+          path: ./fuzz/afl/out/default/crashes/

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -164,7 +164,7 @@ jobs:
         name: Install Rust
         with:
           profile: minimal
-          toolchain: nightly-2022-06-01
+          toolchain: nightly-2022-07-01
           override: true
       - name: Install cargo-afl
         run: |


### PR DESCRIPTION
this PR re-enables the ARMv7 workflows after I restarted the self hosted runner