### PR TITLE
perf: Implement realloc for BoxString

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -24,6 +24,7 @@ itoa = "1"
 ryu = "1"
 
 [dev-dependencies]
+cfg-if = "1"
 proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck_macros = "1"
 rayon = "1"

--- a/compact_str/src/repr/boxed/capacity.rs
+++ b/compact_str/src/repr/boxed/capacity.rs
@@ -56,14 +56,6 @@ impl Capacity {
     }
 
     #[inline]
-    #[cfg(target_pointer_width = "64")]
-    pub const unsafe fn new_unchecked(capacity: usize) -> Self {
-        let mut bytes = capacity.to_le_bytes();
-        bytes[core::mem::size_of::<usize>() - 1] = HEAP_MASK;
-        Capacity { _buf: bytes }
-    }
-
-    #[inline]
     pub fn as_usize(&self) -> Result<usize, ()> {
         if self._buf == CAPACITY_IS_ON_THE_HEAP {
             Err(())
@@ -81,19 +73,6 @@ impl Capacity {
     }
 
     #[inline(always)]
-    #[cfg(target_pointer_width = "64")]
-    pub unsafe fn as_usize_unchecked(&self) -> usize {
-        let mut usize_buf = [0u8; USIZE_SIZE];
-        core::ptr::copy_nonoverlapping(
-            self._buf.as_ptr(),
-            usize_buf.as_mut_ptr(),
-            SPACE_FOR_CAPACITY,
-        );
-        usize::from_le_bytes(usize_buf)
-    }
-
-    #[inline(always)]
-    #[cfg(not(target_pointer_width = "64"))]
     pub fn is_heap(&self) -> bool {
         self._buf == CAPACITY_IS_ON_THE_HEAP
     }

--- a/compact_str/src/repr/boxed/inner.rs
+++ b/compact_str/src/repr/boxed/inner.rs
@@ -1,7 +1,6 @@
 const UNKNOWN: usize = 0;
 pub type StrBuffer = [u8; UNKNOWN];
 
-#[cfg(not(target_pointer_width = "64"))]
 pub mod heap_capacity {
     use core::ptr;
     use std::alloc;
@@ -37,7 +36,7 @@ pub mod heap_capacity {
         buffer: StrBuffer,
     }
 
-    fn layout(capacity: usize) -> alloc::Layout {
+    pub fn layout(capacity: usize) -> alloc::Layout {
         let buffer_layout = alloc::Layout::array::<u8>(capacity).expect("valid capacity");
         alloc::Layout::new::<BoxStringInnerHeapCapacity>()
             .extend(buffer_layout)
@@ -84,7 +83,7 @@ pub mod inline_capacity {
         buffer: StrBuffer,
     }
 
-    fn layout(capacity: usize) -> alloc::Layout {
+    pub fn layout(capacity: usize) -> alloc::Layout {
         let buffer_layout = alloc::Layout::array::<u8>(capacity).expect("valid capacity");
         alloc::Layout::new::<BoxStringInnerInlineCapacity>()
             .extend(buffer_layout)

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -20,6 +20,8 @@ const MIN_SIZE: usize = core::mem::size_of::<usize>() / 2;
 ///
 /// Note: this is different than [`std::string::String`], which grows at a rate of 2x. It's debated
 /// which is better, for now we'll stick with a rate of 1.5x
+/// 
+/// TODO: Handle overflows in the case of __very__ large Strings
 #[inline(always)]
 fn amortized_growth(cur_len: usize, additional: usize) -> usize {
     let required = cur_len + additional;
@@ -704,9 +706,11 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit archs it's still inlined
                 assert!(box_string.cap.as_usize().is_ok());
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // on 32-bit archs the capacity will be stored on the heap
                 assert!(box_string.cap.as_usize().is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -717,10 +721,12 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit archs it's still inlined
                 assert!(box_string.cap.as_usize().is_ok());
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // on 32-bit archs the capacity will still be stored on the heap, since the capacity
                 // hasn't changed
                 assert!(box_string.cap.as_usize().is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -743,9 +749,11 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit archs it's still inlined
                 assert_eq!(box_string.cap.as_usize(), Ok(SIXTEEN_MB - 1));
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // on 32-bit archs the capacity will be stored on the heap
                 assert!(box_string.cap.as_usize().is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -761,9 +769,11 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit archs it's still inlined
                 assert!(box_string.cap.as_usize().is_ok());
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // on 32-bit archs the capacity will be stored on the heap
                 assert!(box_string.cap.as_usize().is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -774,10 +784,12 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit archs it's still inlined
                 assert!(box_string.cap.as_usize().is_ok());
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // on 32-bit archs the capacity will still be stored on the heap, since the capacity
                 // hasn't changed
                 assert!(box_string.cap.as_usize().is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -805,9 +817,11 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // realloc should succeed since on 64-bit platforms
                 assert_eq!(result.unwrap(), SIXTEEN_MB + 128);
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // realloc should fail since we need to go from inline capacity -> heap
                 assert!(result.is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 
@@ -842,9 +856,11 @@ mod tests {
             if #[cfg(target_pointer_width = "64")] {
                 // realloc should succeed since on 64-bit platforms
                 assert_eq!(result.unwrap(), 128);
-            } else {
+            } else if #[cfg(target_pointer_width = "32")] {
                 // realloc should fail since we need to go from inline capacity -> heap
                 assert!(result.is_err());
+            } else {
+                compile_error!("Unsupported target_pointer_width");
             }
         }
 

--- a/compact_str/src/repr/boxed/mod.rs
+++ b/compact_str/src/repr/boxed/mod.rs
@@ -20,7 +20,7 @@ const MIN_SIZE: usize = core::mem::size_of::<usize>() / 2;
 ///
 /// Note: this is different than [`std::string::String`], which grows at a rate of 2x. It's debated
 /// which is better, for now we'll stick with a rate of 1.5x
-/// 
+///
 /// TODO: Handle overflows in the case of __very__ large Strings
 #[inline(always)]
 fn amortized_growth(cur_len: usize, additional: usize) -> usize {


### PR DESCRIPTION
This PR implements `realloc(size)` for `BoxString`, which is the underlying heap representation of a `CompactString`