### PR TITLE
backport(v0.5): Test case discovered by AFL (#161)

### DIFF
--- a/compact_str/src/repr/boxed/capacity.rs
+++ b/compact_str/src/repr/boxed/capacity.rs
@@ -2,8 +2,21 @@ use crate::repr::HEAP_MASK;
 
 // how many bytes a `usize` occupies
 const USIZE_SIZE: usize = core::mem::size_of::<usize>();
-// state that describes the capacity as being stored on the heap
-const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = [HEAP_MASK; USIZE_SIZE];
+
+/// Used to generate [`CAPACITY_IS_ON_THE_HEAP`]
+#[allow(non_snake_case)]
+const fn CAP_ON_HEAP_FLAG() -> [u8; USIZE_SIZE] {
+    // all bytes 255, with the last
+    let mut flag = [255; USIZE_SIZE];
+    flag[USIZE_SIZE - 1] = HEAP_MASK;
+    flag
+}
+
+/// State that describes the capacity as being stored on the heap.
+///
+/// All bytes `255`, with the last being [`HEAP_MASK`], using the same amount of bytes as `usize`
+/// Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 254]`
+const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = CAP_ON_HEAP_FLAG();
 
 // how many bytes we can use for capacity
 const SPACE_FOR_CAPACITY: usize = USIZE_SIZE - 1;
@@ -101,6 +114,8 @@ impl Capacity {
 
 #[cfg(test)]
 mod tests {
+    use rayon::prelude::*;
+
     use super::Capacity;
 
     #[test]
@@ -145,6 +160,27 @@ mod tests {
     fn test_usize_max_fails() {
         let og = usize::MAX;
         assert!(Capacity::new(og).is_err());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_all_valid_32bit_values() {
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(16_777_214, super::MAX_VALUE);
+
+        (0..=16_777_214)
+            .into_par_iter()
+            .for_each(|i| match Capacity::new(i) {
+                Ok(cap) => match cap.as_usize() {
+                    Ok(val) => assert_eq!(val, i, "value roundtriped to wrong value?"),
+                    Err(_) => panic!("value converted, but failed to roundtrip! val: {}", i),
+                },
+                Err(_) => panic!("failed to convert {}", i),
+            });
+
+        // one above the 32-bit max value
+        #[cfg(target_pointer_width = "32")]
+        assert!(Capacity::new(16_777_215).is_err());
     }
 }
 


### PR DESCRIPTION
* fix: Bug when trying to create a CompactString with capacity of 16711422 on 32-bit arches
* Fixed the underlying bug, which was related to the change in HEAP_MASK
* Add debug.rs binary to repro single failing fuzz cases
* Add unit test with comment to repro the exact failure
* ignore all capacity values test in miri

Backport of: https://github.com/ParkMyCar/compact_str/pull/161