### PR TITLE
ci: Ignore certain workflows when only README.md or CHANGELOG.md are changed

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -6,9 +6,8 @@ on:
     paths:
       - 'compact_str/**'
       - '.github/workflows/cross_platform.yml'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - '**/README.md'
+      - '!CHANGELOG.md'
+      - '!**/README.md'
   workflow_dispatch:
 
 name: X-Plat

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'compact_str/**'
       - '.github/workflows/cross_platform.yml'
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '**/README.md'
   workflow_dispatch:
 
 name: X-Plat

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,9 +7,8 @@ on:
       - 'compact_str/**'
       - 'fuzz/**'
       - '.github/workflows/fuzz.yml'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - '**/README.md'
+      - '!CHANGELOG.md'
+      - '!**/README.md'
   workflow_dispatch:
   schedule:
     - cron: '0 01,13 * * *'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,9 +4,12 @@ on:
       - main
   pull_request:
     paths:
-        - 'compact_str/**'
-        - 'fuzz/**'
-        - '.github/workflows/fuzz.yml'
+      - 'compact_str/**'
+      - 'fuzz/**'
+      - '.github/workflows/fuzz.yml'
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '**/README.md'
   workflow_dispatch:
   schedule:
     - cron: '0 01,13 * * *'

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'compact_str/**'
       - '.github/workflows/msrv.yml'
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '**/README.md'
   workflow_dispatch:
 
 name: MSRV

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -6,9 +6,8 @@ on:
     paths:
       - 'compact_str/**'
       - '.github/workflows/msrv.yml'
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - '**/README.md'
+      - '!CHANGELOG.md'
+      - '!**/README.md'
   workflow_dispatch:
 
 name: MSRV


### PR DESCRIPTION
Like the title says, don't trigger certain workflows when it's only `README.md` or `CHANGELOG.md` files that change. 