### PR TITLE
feat: Implement CompactString::from_utf16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Upcoming
+* Add `from_utf16()` method
+    * Implemented in [`#170 feat: Implement CompactString::from_utf16`](https://github.com/ParkMyCar/compact_str/pull/170)
 * impl `AddAssign` (`+=`) for `CompactString`
     * Implemented in [`add AddAssign operator`](https://github.com/ParkMyCar/compact_str/pull/159)
 * Implement [`markup::Render`](https://docs.rs/markup/latest/markup/trait.Render.html) trait
@@ -25,7 +27,7 @@
 # 0.5.2
 ### July 24, 2022
 * Fix error when creating `CompactString` with capacity `16711422` on 32-bit archiectures
-    * Implemented in [`#161 fix: Test case discovered by AFL`](https://github.com/ParkMyCar/compact_str/pull/161) 
+    * Implemented in [`#161 fix: Test case discovered by AFL`](https://github.com/ParkMyCar/compact_str/pull/161)
     * Backported in [`#167 backport(v0.5): Test case discovered by AFL`](https://github.com/ParkMyCar/compact_str/pull/167)
 
 # 0.5.1

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient string type that transparently stores strings on the stack, when possible"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -283,7 +283,7 @@ impl CompactString {
 
         let buf = buf.as_ref();
         let mut ret = CompactString::with_capacity(buf.len());
-        for c in core::char::decode_utf16(buf.into_iter().copied()) {
+        for c in core::char::decode_utf16(buf.iter().copied()) {
             if let Ok(c) = c {
                 ret.push(c);
             } else {

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -253,6 +253,46 @@ impl CompactString {
         Ok(CompactString { repr })
     }
 
+    /// Decode a [`UTF-16`](https://en.wikipedia.org/wiki/UTF-16) slice of bytes into a
+    /// [`CompactString`], returning an [`Err`] if the slice contains any invalid data.
+    ///
+    /// # Examples
+    /// ### Valid UTF-16
+    /// ```
+    /// # use compact_str::CompactString;
+    /// let buf: &[u16] = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0x0069, 0x0063];
+    /// let compact = CompactString::from_utf16(buf).unwrap();
+    ///
+    /// assert_eq!(compact, "𝄞music");
+    /// ```
+    ///
+    /// ### Invalid UTF-16
+    /// ```
+    /// # use compact_str::CompactString;
+    /// let buf: &[u16] = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+    /// let res = CompactString::from_utf16(buf);
+    ///
+    /// assert!(res.is_err());
+    /// ```
+    #[inline]
+    pub fn from_utf16<B: AsRef<[u16]>>(buf: B) -> Result<Self, Utf16Error> {
+        // Note: we don't use collect::<Result<_, _>>() because that fails to pre-allocate a buffer,
+        // even though the size of our iterator, `buf`, is known ahead of time.
+        //
+        // rustlang issue #48994 is tracking the fix
+
+        let buf = buf.as_ref();
+        let mut ret = CompactString::with_capacity(buf.len());
+        for c in core::char::decode_utf16(buf.into_iter().copied()) {
+            if let Ok(c) = c {
+                ret.push(c);
+            } else {
+                return Err(Utf16Error(()));
+            }
+        }
+        Ok(ret)
+    }
+
     /// Returns the length of the [`CompactString`] in `bytes`, not [`char`]s or graphemes.
     ///
     /// When using `UTF-8` encoding (which all strings in Rust do) a single character will be 1 to 4
@@ -1058,6 +1098,32 @@ impl Add<&str> for CompactString {
 impl AddAssign<&str> for CompactString {
     fn add_assign(&mut self, rhs: &str) {
         self.push_str(rhs);
+    }
+}
+
+/// A possible error value when converting a [`CompactString`] from a UTF-16 byte slice.
+///
+/// This type is the error type for the [`from_utf16`] method on [`CompactString`].
+///
+/// [`from_utf16`]: CompactString::from_utf16
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// # use compact_str::CompactString;
+/// // 𝄞mu<invalid>ic
+/// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+///           0xD800, 0x0069, 0x0063];
+///
+/// assert!(CompactString::from_utf16(v).is_err());
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Utf16Error(());
+
+impl fmt::Display for Utf16Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt("invalid utf-16: lone surrogate found", f)
     }
 }
 

--- a/fuzz/src/creation.rs
+++ b/fuzz/src/creation.rs
@@ -295,7 +295,7 @@ impl Creation<'_> {
                         assert_eq!(c, s);
                         assert_properly_allocated(&c, &s);
 
-                        Some((c, s.to_string()))
+                        Some((c, s))
                     }
                     // non-valid UTF-16
                     (Err(_), Err(_)) => None,

--- a/fuzz/src/creation.rs
+++ b/fuzz/src/creation.rs
@@ -22,6 +22,8 @@ use crate::MAX_INLINE_LENGTH;
 pub enum Creation<'a> {
     /// Create using [`CompactString::from_utf8`]
     Bytes(&'a [u8]),
+    /// Create using [`CompactString::from_utf16`]
+    BytesUtf16(Vec<u16>),
     /// Create using [`CompactString::from_utf8_buf`]
     Buf(&'a [u8]),
     /// Create using [`CompactString::from_utf8_buf_unchecked`]
@@ -32,6 +34,8 @@ pub enum Creation<'a> {
     IterString(Vec<String>),
     /// Create using [`CompactString::new`]
     Word(String),
+    /// Encode the provided `String` as UTF-16, and the create using [`CompactString::from_utf16`]
+    WordUtf16(String),
     /// Create using [`CompactString::from_utf8_buf`] when the buffer is non-contiguous
     NonContiguousBuf(&'a [u8]),
     /// Create using `From<&str>`, which copies the data from the string slice
@@ -158,6 +162,16 @@ impl Creation<'_> {
 
                 Some((compact, word))
             }
+            WordUtf16(word) => {
+                let utf16_buf: Vec<u16> = word.encode_utf16().collect();
+                let compact =
+                    CompactString::from_utf16(utf16_buf).expect("UTF-16 failed to roundtrip!");
+
+                assert_eq!(compact, word);
+                assert_properly_allocated(&compact, &word);
+
+                Some((compact, word))
+            }
             FromStr(s) => {
                 let compact = CompactString::from(s);
                 let std_str = s.to_string();
@@ -269,6 +283,23 @@ impl Creation<'_> {
                         None
                     }
                     _ => panic!("CompactString and core::str read UTF-8 differently?"),
+                }
+            }
+            BytesUtf16(data) => {
+                let compact = CompactString::from_utf16(&data);
+                let std_str = String::from_utf16(&data);
+
+                match (compact, std_str) {
+                    // valid UTF-16
+                    (Ok(c), Ok(s)) => {
+                        assert_eq!(c, s);
+                        assert_properly_allocated(&c, &s);
+
+                        Some((c, s.to_string()))
+                    }
+                    // non-valid UTF-16
+                    (Err(_), Err(_)) => None,
+                    _ => panic!("CompactString and String read UTF-16 differently?"),
                 }
             }
             Buf(data) => {


### PR DESCRIPTION
Implements from_utf16 for `CompactString` and adds doc tests, unit tests, proptests, and updates our fuzzing harness.

Fixes #135