### PR TITLE
Macro hygiene: use re-exported `format_args!()`

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[doc(hidden)]
+pub use core;
 use core::borrow::{
     Borrow,
     BorrowMut,

--- a/compact_str/src/macros.rs
+++ b/compact_str/src/macros.rs
@@ -26,9 +26,9 @@
 /// `ToCompactString::to_compact_string` never returns an error itself.
 #[macro_export]
 macro_rules! format_compact {
-    ($($arg:tt)*) => {{
-        $crate::ToCompactString::to_compact_string(&format_args!($($arg)*))
-    }}
+    ($($arg:tt)*) => {
+        $crate::ToCompactString::to_compact_string(&$crate::core::format_args!($($arg)*))
+    }
 }
 
 #[cfg(test)]

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -8,6 +8,7 @@ use proptest::strategy::Strategy;
 use test_strategy::proptest;
 
 use crate::{
+    format_compact,
     CompactString,
     ToCompactString,
 };
@@ -772,19 +773,6 @@ fn test_bool_to_compact_string() {
     assert_eq!("false", c);
     assert_eq!(c, s);
     assert!(!c.is_heap_allocated());
-}
-
-macro_rules! format_compact {
-    ( $fmt:expr $(, $args:tt)* ) => {
-        ToCompactString::to_compact_string(
-            &core::format_args!(
-                $fmt,
-                $(
-                    $args,
-                )*
-            )
-        )
-    };
 }
 
 macro_rules! assert_int_MAX_to_compact_string {


### PR DESCRIPTION
So that `format_compact!()` still works if the user shadows
`format_args!()`, or uses the library in a `#![no_implicit_prelude]`
context.