### PR TITLE
fix: make sure suffix data when calling .align_to is empty

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1229,7 +1229,7 @@ impl CompactString {
         // SAFETY: `u8` and `u16` are `Copy`, so if the alignment fits, we can transmute a
         //         `[u8; 2*N]` to `[u16; N]`. `slice::align_to()` checks if the alignment is right.
         match unsafe { v.align_to::<u16>() } {
-            (&[], v, _) => {
+            (&[], v, &[]) => {
                 // Input is correcty aligned.
                 for c in std::char::decode_utf16(v.iter().copied().map(from_int)) {
                     result.push(c.map_err(|_| Utf16Error(()))?);
@@ -1265,7 +1265,7 @@ impl CompactString {
         // SAFETY: `u8` and `u16` are `Copy`, so if the alignment fits, we can transmute a
         //         `[u8; 2*N]` to `[u16; N]`. `slice::align_to()` checks if the alignment is right.
         match unsafe { v.align_to::<u16>() } {
-            (&[], v, _) => {
+            (&[], v, &[]) => {
                 // Input is correcty aligned.
                 for c in std::char::decode_utf16(v.iter().copied().map(from_int)) {
                     match c {


### PR DESCRIPTION
Based on the docs from the stdlib, when calling [`align_to`](https://doc.rust-lang.org/std/primitive.slice.html#method.align_to), it's possible for the entirety of the data to be returned in the prefix, or suffix slices:

> This method splits the slice into three distinct slices: prefix, correctly aligned middle slice of a new type, and the suffix slice. The method may make the middle slice the greatest length possible for a given type and input slice, but only your algorithm’s performance should depend on that, not its correctness. It is permissible for all of the input data to be returned as the prefix or suffix slice.

This PR updates our use of `.align_to` to make sure the both the prefix slice and suffix slice are empty, thus guaranteeing the middle slice contains all of our data