### PR TITLE
version: 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Upcoming
+
+# 0.6.0
+### August 21, 2022
+* Add `from_utf16_lossy()`, `from_utf16be_lossy()`, and `from_utf16le_lossy()`
+    * Implemented in [`feat: implement from_utf16_lossy API`](https://github.com/ParkMyCar/compact_str/pull/211)
+    * Implemented in [`Implement from_utf16ne_lossy and from_utf16be_lossy`](https://github.com/ParkMyCar/compact_str/pull/210)
 * Add `from_utf16be()` and `from_utf16le()` methods
     * Implemented in [`Implement from_utf16le, from_utf16be, from_utf16ne`](https://github.com/ParkMyCar/compact_str/pull/207)
+* Implement `rkyv::Archive`, `rkyv::Deserialize`, and `rkyv::Serialize` for `CompactString`
+    * Implemented in [`Add rkyv serialization`](https://github.com/ParkMyCar/compact_str/pull/208)
 * Improve performance when counting number of bytes to write into a `CompactString`
     * Implemented in [`Don't format char to determine it's UTF-8 length`](https://github.com/ParkMyCar/compact_str/pull/197)
 * Improve macro hygiene for `format_compact!` macro

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient string type that transparently stores strings on the stack, when possible"
-version = "0.6.0-alpha.6"
+version = "0.6.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Bumps the version of `compact_str` to `v0.6.0`, and updates the CHANLGELOG.md