### PR TITLE
Enable "proptest/std" feature

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["encoding", "parsing", "memory-management", "text-processing"]
 arbitrary = { version = "1", optional = true, default-features = false }
 bytes = { version = "1", optional = true }
 markup = { version = "0.13", optional = true, default-features = false }
-proptest = { version = "1", optional = true, default-features = false }
+proptest = { version = "1", optional = true, default-features = false, features = ["std"] }
 quickcheck = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }


### PR DESCRIPTION
The last build on docs.rs failed:
<https://docs.rs/crate/compact_str/0.6.0/builds/615366>.
To use proptest, you have to either enable "std" or "alloc". Because
this project uses features in "std", we can enable "proptest/std". We
know that the support is there.

I cannot tell why the bug does not manifest in the CI, which checks the
documentation creation. On my own system it works without this PR, too.