### PR TITLE
Copy inline string reversed

### DIFF
--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -41,11 +41,14 @@ impl InlineString {
         // set the length
         buffer[MAX_SIZE - 1] = len as u8 | LENGTH_MASK;
 
-        // Note: for loops aren't allowed in `const fn`, hence the while
-        let mut i = 0;
-        while i < len {
-            buffer[i] = text.as_bytes()[i];
-            i += 1;
+        // Note: for loops aren't allowed in `const fn`, hence the while.
+        // Note: Iterating forward results in badly optimized code, because the compiler tries to
+        //       unroll the loop.
+        let text = text.as_bytes();
+        let mut i = len;
+        while i > 0 {
+            buffer[i - 1] = text[i - 1];
+            i -= 1;
         }
 
         InlineString { buffer }


### PR DESCRIPTION
It seem like some optimization step goes berserk if you copy a byte
slice from start to end. The while-loop is partially unrolled which
results in an excessively long, extremely cache unfriendly code.

If you copy the string in the reverse direction, starting with the last
byte, the optimizer understands the pattern, and uses `memcpy()`, which
is a sane decision.

If you only use `CompactString::new_inline()` in a `const` context, the
difference does not matter. But if you use it for runtime code, the
difference is enormous. Valid use cases for `new_inline()` in a
non-const context include `const` function that may be also useful in a
dynamic context.