### PR TITLE
chore: Fix CI, update examples

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -49,9 +49,11 @@ jobs:
       - name: install cargo hack
         run: cargo install cargo-hack --force
       - name: cargo test msrv..
+        # note: we exclude `arbitrary` from here since the MSRV of >= 1.1.14 is 1.63. Instead of
+        # pinning to a specific version of of `arbitrary`, we'll let user's deps decide the version
         run: |
           cd compact_str
-          cargo hack test --all-features --version-range 1.57..
+          cargo hack test --features bytes,markup,proptest,quickcheck,rkyv,serde --version-range 1.57..
 
   feature_powerset:
     name: cargo check feature-powerset

--- a/examples/bytes/Cargo.toml
+++ b/examples/bytes/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 bytes = "1"
-compact_str = { version = "0.5", features = ["bytes"] }
+compact_str = { version = "0.6", features = ["bytes"] }

--- a/examples/macros/Cargo.toml
+++ b/examples/macros/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = "0.5"
+compact_str = "0.6"

--- a/examples/serde/Cargo.toml
+++ b/examples/serde/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { version = "0.5", features = ["serde"] }
+compact_str = { version = "0.6", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = "0.5"
+compact_str = "0.6"


### PR DESCRIPTION
* update MSRV workflow to exclude arbitrary since the MSRV of the latest build version is Rust 1.63
* update the examples to use compact_str v0.6