### PR TITLE
impl AsRef<[u8]> for CompactString

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1425,6 +1425,13 @@ impl AsRef<OsStr> for CompactString {
     }
 }
 
+impl AsRef<[u8]> for CompactString {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
 impl Borrow<str> for CompactString {
     #[inline]
     fn borrow(&self) -> &str {


### PR DESCRIPTION
Needed this for something earlier tonight and noticed it wasn't implemented - one tiny gap in `CompactString`'s public API compared to std `String`'s