### PR TITLE
ci: Disable ARMv7 Workflow

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -86,23 +86,24 @@ jobs:
           command: miri
           args: test --all-features --manifest-path=compact_str/Cargo.toml
 
-  linux_arm7:
-    name: Linux ARMv7
-    runs-on: [self-hosted, linux, ARM]
-    steps:
-      - uses: actions/checkout@v2
-        name: Checkout Repo
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml
+  # TODO(parkmycar) re-enable ARMv7 builds
+  # linux_arm7:
+  #   name: Linux ARMv7
+  #   runs-on: [self-hosted, linux, ARM]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       name: Checkout Repo
+  #     - uses: actions-rs/toolchain@v1
+  #       name: Install Rust
+  #       with:
+  #         profile: minimal
+  #         toolchain: nightly
+  #         override: true
+  #     - uses: actions-rs/cargo@v1
+  #       name: cargo test
+  #       with:
+  #         command: test
+  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml
 
   linux_32bit:
     name: Linux 32-bit


### PR DESCRIPTION
The Raspberry Pi I was using as an ARMv7 runner is currently offline, so for now I'm commenting out any workflows that depend on it