### PR TITLE
ci: Re-add ARMv7 Workflow

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -88,7 +88,7 @@ jobs:
 
   linux_arm7:
     name: Linux ARMv7
-    runs-on: [self-hosted, linux, ARM]
+    runs-on: [self-hosted, Linux, ARM]
     steps:
       - uses: actions/checkout@v2
         name: Checkout Repo

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -86,6 +86,24 @@ jobs:
           command: miri
           args: test --all-features --manifest-path=compact_str/Cargo.toml
 
+  linux_arm7:
+    name: Linux ARMv7
+    runs-on: [self-hosted, linux, ARM]
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Repo
+      - uses: actions-rs/toolchain@v1
+        name: Install Rust
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          command: test
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml
+
   linux_32bit:
     name: Linux 32-bit
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR re-adds the ARMv7 CI workflow, which is running on a Raspberry Pi. I recently setup containerized runners with Docker, which should improve reliability