### PR TITLE
ci: remove proptest from MSRV check

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -49,11 +49,17 @@ jobs:
       - name: install cargo hack
         run: cargo install cargo-hack --force
       - name: cargo test msrv..
-        # note: we exclude `arbitrary` from here since the MSRV of >= 1.1.14 is 1.63. Instead of
-        # pinning to a specific version of of `arbitrary`, we'll let user's deps decide the version
+        # note: we exclude both `arbitrary` and `proptest` from here because their MSRVs were both
+        # bumped on a minor version release:
+        #
+        # - abitrary >= 1.1.14 has an MSRV >= 1.63
+        # - proptest >= 1.1.0 has an MSRV >= 1.60
+        #
+        # Instead of pinning to a specific version of `arbitrary` or `proptest`, we'll let user's 
+        # deps decide the version since the API should still be semver compatible
         run: |
           cd compact_str
-          cargo hack test --features bytes,markup,proptest,quickcheck,rkyv,serde --version-range 1.57..
+          cargo hack test --features bytes,markup,quickcheck,rkyv,serde --version-range 1.57..
 
   feature_powerset:
     name: cargo check feature-powerset

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -28,7 +28,7 @@ static_assertions = "1"
 
 [dev-dependencies]
 cfg-if = "1"
-proptest = { version = "1", default-features = false, features = ["std"] }
+proptest = { version = "<1.1", default-features = false, features = ["std"] }
 quickcheck = "1"
 quickcheck_macros = "1"
 rayon = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -28,7 +28,7 @@ static_assertions = "1"
 
 [dev-dependencies]
 cfg-if = "1"
-proptest = { version = "<1.1", default-features = false, features = ["std"] }
+proptest = { version = "1.0.*", default-features = false, features = ["std"] }
 quickcheck = "1"
 quickcheck_macros = "1"
 rayon = "1"


### PR DESCRIPTION
Recently [`proptest`](https://github.com/proptest-rs/proptest) bumped their version from `1` to `1.1` and included in that change was a new dependency on [`unarray`](https://github.com/cameron1024/unarray) which has an MSRV of `1.60`, which is greater than `compact_str`s MSRV of `1.57`. This caused the MSRV check in CI to fail since we enable the `proptest` feature in the check.

This PR removes `proptest` from the MSRV check with a comment as to why we removed it. Note: we still check for compatibility of the `proptest` feature as part of the `feature_powerset` job

Related to https://github.com/proptest-rs/proptest/issues/300