### PR TITLE
deps: Use castaway 0.2

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -20,7 +20,7 @@ quickcheck = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }
 
-castaway = "0.2.1"
+castaway = "0.2"
 cfg-if = "1"
 itoa = "1"
 ryu = "1"


### PR DESCRIPTION
This PR changes the version of castaway we depend on from `0.2.1` to `0.2`. Using `0.2` is more generic and allows us to automatically get patches which theoretically is good :)