### PR TITLE
test: Add test to assert CompactStr -> std::borrow::Cow<'_, str>

### DIFF
--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1449,3 +1449,12 @@ fn test_collect() {
         "foobarbaz",
     );
 }
+
+#[test]
+fn test_into_cow() {
+    let og = "aaa";
+    let compact = CompactString::new(og);
+    let cow: std::borrow::Cow<'_, str> = compact.into();
+
+    assert_eq!(og, cow);
+}


### PR DESCRIPTION
Originally fixed in #228, adding a test now to make sure we never regress here

Fixes #226 