### PR TITLE
fuzz: Reduce the number of actions run for a given Scenario

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,8 @@ cargo-fuzz = true
 arbitrary = { version = "1.1.1", features = ["derive"] }
 bytes = "1"
 compact_str = { path = "../compact_str", features = ["bytes"] }
+rand = { version = "0.8", features = ["small_rng"] }
+rand_distr = "0.4"
 
 # Fuzz with both AFL++ and libFuzzer
 afl = { version = "0.12.1", optional = true }


### PR DESCRIPTION
This PR updates the fuzzing harness to reduce the number of actions run for a given `Scenario`. The idea is that running 3,000 actions isn't any more "interesting" than running 1,000 actions, it just takes 3x longer. Instead if we cap the number of actions that we run, we'll get more of an opportunity to explore the different combinations of creation + actions, which gives us better coverage of the code.

Specifically this PR changes the fuzzing harness so we generate a seed with a `Scenario` and using that seed we pick a random number based on a Skewed Normal distribution, and only run up to that number of actions. Based on testing, the distribution has the approximate metrics:

`min: 0`
`median: 1000`
`max: 3500`

Because the seed is included with a `Scenario`, it allows us to be deterministic.