### PR TITLE
api: On Clone, eagerly inline based on length not capacity

### DIFF
--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -536,9 +536,8 @@ impl Clone for Repr {
             let heap = unsafe { &*(this as *const _ as *const HeapBuffer) };
 
             // If the contained string is small enough, we will inline it instead of allocating
-            if heap.capacity() <= MAX_SIZE {
-                // SAFETY: Checked to make sure the capacity is <= MAX_SIZE, which means the length
-                // of the string is also <= MAX_SIZE
+            if heap.len <= MAX_SIZE {
+                // SAFETY: Checked to make sure the length is <= MAX_SIZE
                 let inline = unsafe { InlineBuffer::new(this.as_str()) };
                 // SAFETY: InlineBuffer and Repr have the same layout
                 unsafe { mem::transmute(inline) }

--- a/fuzz/src/actions.rs
+++ b/fuzz/src/actions.rs
@@ -337,7 +337,7 @@ impl Action<'_> {
                 let compact_clone = compact.clone();
                 // when cloning, even if the original CompactString was heap allocated, we should
                 // inline the new one, if possible
-                if compact.capacity() <= super::MAX_INLINE_LENGTH {
+                if compact.len() <= super::MAX_INLINE_LENGTH {
                     assert!(!compact_clone.is_heap_allocated())
                 }
                 let og = std::mem::replace(compact, compact_clone);


### PR DESCRIPTION
In #254 we began inlining `CompactString`s when `Clone`-ing, if the **capacity** of the `CompactString` was less than `MAX_SIZE`. This made sure we retained any additional capacity a user may have allocated.

During some experimentation though, I realized `String` truncates capacity during clone, [example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=65cc3239a32936f17ff7f81cffd44860).

As such this PR updates the eager inlining during `Clone` to instead be based on the source `CompactString`'s **length**, which. This allows us to more frequently inline strings, and follows the same behavior as `String`.