### PR TITLE
api: Add CompactString::into_bytes

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -19,6 +19,7 @@ proptest = { version = "1", optional = true, default-features = false, features 
 quickcheck = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }
+smallvec = { version = "1" }
 
 castaway = "0.2.1"
 cfg-if = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -19,7 +19,7 @@ proptest = { version = "1", optional = true, default-features = false, features 
 quickcheck = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true }
 serde = { version = "1", optional = true }
-smallvec = { version = "1" }
+smallvec = { version = "1", optional = true, features = ["union"] }
 
 castaway = "0.2.1"
 cfg-if = "1"

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -14,3 +14,4 @@ mod quickcheck;
 mod rkyv;
 #[cfg(feature = "serde")]
 mod serde;
+mod smallvec;

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -14,4 +14,5 @@ mod quickcheck;
 mod rkyv;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "smallvec")]
 mod smallvec;

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -1,0 +1,84 @@
+use smallvec::SmallVec;
+
+use crate::repr::MAX_SIZE;
+use crate::CompactString;
+
+impl CompactString {
+    /// Converts a [`CompactString`] into a byte vector
+    ///
+    /// This consumes the [`CompactString`] and returns a [`SmallVec`], so we do not need to copy
+    /// contents
+    ///
+    /// Note: [`SmallVec`] is an inline-able version [`Vec`], just like [`CompactString`] is an
+    /// inline-able version of [`String`].
+    ///
+    /// # Example
+    /// ```
+    /// use compact_str::CompactString;
+    ///
+    /// let c = CompactString::new("hello");
+    /// let bytes = c.into_bytes();
+    ///
+    /// assert_eq!(&[104, 101, 108, 108, 111][..], &bytes[..]);
+    /// ```
+    pub fn into_bytes(self) -> SmallVec<[u8; MAX_SIZE]> {
+        self.0.into_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use test_strategy::proptest;
+
+    use crate::repr::MAX_SIZE;
+    use crate::tests::rand_unicode;
+    use crate::CompactString;
+
+    /// generates random unicode strings, that are at least MAX_SIZE bytes long
+    pub fn rand_long_unicode() -> impl Strategy<Value = String> {
+        proptest::collection::vec(proptest::char::any(), (MAX_SIZE + 1)..80)
+            .prop_map(|v| v.into_iter().collect())
+    }
+
+    #[test]
+    fn test_buffer_reuse() {
+        let mut c = CompactString::from("I am a longer string that will be on the heap");
+        let c_ptr = c.as_ptr();
+
+        let bytes = c.into_bytes();
+        let b_ptr = bytes.as_ptr();
+
+        // Note: inlined CompactStrings also get their buffers re-used, but we can't assert their
+        // re-use the same way we do for longer strings, because the underlying array may move on
+        // the callstack, whereas for longer strings the buffer is not moving on the heap
+
+        // converting into_bytes should _always_ re-use the underlying buffer
+        assert_eq!(c_ptr, b_ptr);
+    }
+
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn proptest_buffer_reuse(#[strategy(rand_long_unicode())] s: String) {
+        let mut c = CompactString::from(s);
+        let c_ptr = c.as_ptr();
+
+        let bytes = c.into_bytes();
+        let b_ptr = bytes.as_ptr();
+
+        // converting into_bytes should _always_ re-use the underlying buffer
+        prop_assert_eq!(c_ptr, b_ptr);
+    }
+
+    #[proptest]
+    #[cfg_attr(miri, ignore)]
+    fn proptest_roundtrip(#[strategy(rand_unicode())] s: String) {
+        let og_compact = CompactString::from(s.clone());
+        prop_assert_eq!(&og_compact, &s);
+
+        let bytes = og_compact.into_bytes();
+
+        let ex_compact = CompactString::from_utf8(bytes).unwrap();
+        prop_assert_eq!(&ex_compact, &s);
+    }
+}

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -21,6 +21,7 @@ impl CompactString {
     ///
     /// assert_eq!(&[104, 101, 108, 108, 111][..], &bytes[..]);
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "smallvec")))]
     pub fn into_bytes(self) -> SmallVec<[u8; MAX_SIZE]> {
         self.0.into_bytes()
     }

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -73,6 +73,30 @@ impl InlineBuffer {
         Self::new_const("")
     }
 
+    /// Consumes the [`InlineBuffer`] returning the entire underlying array and the length of the
+    /// string that it contains
+    #[inline]
+    pub fn into_array(self) -> ([u8; MAX_SIZE], usize) {
+        let mut buffer = self.0;
+
+        let length = core::cmp::min(
+            (buffer[MAX_SIZE - 1].wrapping_sub(LENGTH_MASK)) as usize,
+            MAX_SIZE,
+        );
+
+        let last_byte_ref = &mut buffer[MAX_SIZE - 1];
+
+        // unset the last byte of the buffer if it's just storing the length of the string
+        //
+        // Note: we should never add an `else` statement here, keeping the conditional simple allows
+        // the compiler to optimize this to a conditional-move instead of a branch
+        if length < MAX_SIZE {
+            *last_byte_ref = 0;
+        }
+
+        (buffer, length)
+    }
+
     /// Set's the length of the content for this [`InlineBuffer`]
     ///
     /// # SAFETY:
@@ -97,7 +121,54 @@ impl InlineBuffer {
 
 #[cfg(test)]
 mod tests {
+    use quickcheck_macros::quickcheck;
     use rayon::prelude::*;
+
+    use super::{
+        InlineBuffer,
+        MAX_SIZE,
+    };
+
+    #[test]
+    fn test_into_array() {
+        let s = "hello world!";
+
+        let inline = unsafe { InlineBuffer::new(s) };
+        let (array, length) = inline.into_array();
+        
+        assert_eq!(s.len(), length);
+
+        // all bytes after the length should be 0
+        assert!(array[length..].iter().all(|b| *b == 0));
+
+        // taking a string slice should give back the same string as the original
+        let ex_s = unsafe { std::str::from_utf8_unchecked(&array[..length]) };
+        assert_eq!(s, ex_s);
+    }
+
+    #[quickcheck]
+    #[cfg_attr(miri, ignore)]
+    fn quickcheck_into_array(s: String) {
+        let mut total_length = 0;
+        let s: String = s
+            .chars()
+            .take_while(|c| {
+                total_length += c.len_utf8();
+                total_length < MAX_SIZE
+            })
+            .collect();
+
+        let inline = unsafe { InlineBuffer::new(&s) };
+        let (array, length) = inline.into_array();
+        assert_eq!(s.len(), length);
+
+        // all bytes after the length should be 0
+        assert!(array[length..].iter().all(|b| *b == 0));
+
+        // taking a string slice should give back the same string as the original
+        let ex_s = unsafe { std::str::from_utf8_unchecked(&array[..length]) };
+        assert_eq!(s, ex_s);
+    }
 
     #[test]
     #[ignore] // we run this in CI, but unless you're compiling in release, this takes a while

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -135,7 +135,7 @@ mod tests {
 
         let inline = unsafe { InlineBuffer::new(s) };
         let (array, length) = inline.into_array();
-        
+
         assert_eq!(s.len(), length);
 
         // all bytes after the length should be 0

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -8,6 +8,8 @@ use std::borrow::Cow;
 #[cfg(feature = "bytes")]
 mod bytes;
 
+mod smallvec;
+
 mod capacity;
 mod heap;
 mod inline;

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 
 #[cfg(feature = "bytes")]
 mod bytes;
-
+#[cfg(feature = "smallvec")]
 mod smallvec;
 
 mod capacity;

--- a/compact_str/src/repr/smallvec.rs
+++ b/compact_str/src/repr/smallvec.rs
@@ -1,7 +1,11 @@
 use smallvec::SmallVec;
 
 use super::inline::InlineBuffer;
-use super::{Repr, HEAP_MASK, MAX_SIZE};
+use super::{
+    Repr,
+    HEAP_MASK,
+    MAX_SIZE,
+};
 
 impl Repr {
     /// Consumes the [`Repr`] returning a byte vector in a [`SmallVec`]
@@ -25,8 +29,9 @@ impl Repr {
 
 #[cfg(test)]
 mod tests {
-    use crate::CompactString;
     use test_case::test_case;
+
+    use crate::CompactString;
 
     #[test_case("" ; "empty")]
     #[test_case("abc" ; "short")]

--- a/compact_str/src/repr/smallvec.rs
+++ b/compact_str/src/repr/smallvec.rs
@@ -1,0 +1,43 @@
+use smallvec::SmallVec;
+
+use super::inline::InlineBuffer;
+use super::{Repr, HEAP_MASK, MAX_SIZE};
+
+impl Repr {
+    /// Consumes the [`Repr`] returning a byte vector in a [`SmallVec`]
+    ///
+    /// Note: both for the inlined case and the heap case, the buffers are re-used
+    #[inline]
+    pub fn into_bytes(self) -> SmallVec<[u8; MAX_SIZE]> {
+        let last_byte = self.last_byte();
+
+        if last_byte == HEAP_MASK {
+            let string = self.into_string();
+            let bytes = string.into_bytes();
+            SmallVec::from_vec(bytes)
+        } else {
+            let inline: InlineBuffer = unsafe { std::mem::transmute(self) };
+            let (array, length) = inline.into_array();
+            SmallVec::from_buf_and_len(array, length)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CompactString;
+    use test_case::test_case;
+
+    #[test_case("" ; "empty")]
+    #[test_case("abc" ; "short")]
+    #[test_case("I am a long string 😊😊😊😊😊" ; "long")]
+    fn proptest_roundtrip(s: &'static str) {
+        let og_compact = CompactString::from(s);
+        assert_eq!(og_compact, s);
+
+        let bytes = og_compact.into_bytes();
+
+        let ex_compact = CompactString::from_utf8(bytes).unwrap();
+        assert_eq!(ex_compact, s);
+    }
+}


### PR DESCRIPTION
This PR adds a new API `CompactString::into_bytes` which consumes a `CompactString`, returning a byte vector, just like the [`String::into_bytes`](https://doc.rust-lang.org/std/string/struct.String.html#method.into_bytes) method.

A difference though is `CompactString::into_bytes` returns a [`SmallVec`](https://docs.rs/smallvec/latest/smallvec/struct.SmallVec.html) which allows us to avoid needing to allocate, by re-using the underlying buffer from the `CompactString`