### PR TITLE
branch start, bump version to v0.7

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient string type that transparently stores strings on the stack, when possible"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
This PR just bumps the version of `compact_str` to `0.7`