### PR TITLE
refactor: Change CompactString::as_ptr to take &self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Upcoming
 * Change `as_ptr()` to require only `&self` and not `&mut self`
-  * Implemented in [``]()
+  * Implemented in [`refactor: Change CompactString::as_ptr to take &self`](https://github.com/ParkMyCar/compact_str/pull/262)
 * Add `into_bytes()` method behind the `smallvec` feature which converts a `CompactString` into a byte vector using a [`SmallVec`](https://docs.rs/smallvec/latest/smallvec/)
   * Implemented in [`api: Add CompactString::into_bytes`](https://github.com/ParkMyCar/compact_str/pull/258)
 * Add `from_string_buffer()` method which __always__ re-uses the underlying buffer from `String`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Upcoming
+* Change `as_ptr()` to require only `&self` and not `&mut self`
+  * Implemented in [``]()
 * Add `into_bytes()` method behind the `smallvec` feature which converts a `CompactString` into a byte vector using a [`SmallVec`](https://docs.rs/smallvec/latest/smallvec/)
   * Implemented in [`api: Add CompactString::into_bytes`](https://github.com/ParkMyCar/compact_str/pull/258)
 * Add `from_string_buffer()` method which __always__ re-uses the underlying buffer from `String`

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -44,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_buffer_reuse() {
-        let mut c = CompactString::from("I am a longer string that will be on the heap");
+        let c = CompactString::from("I am a longer string that will be on the heap");
         let c_ptr = c.as_ptr();
 
         let bytes = c.into_bytes();
@@ -61,7 +61,7 @@ mod tests {
     #[proptest]
     #[cfg_attr(miri, ignore)]
     fn proptest_buffer_reuse(#[strategy(rand_long_unicode())] s: String) {
-        let mut c = CompactString::from(s);
+        let c = CompactString::from(s);
         let c_ptr = c.as_ptr();
 
         let bytes = c.into_bytes();

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -880,7 +880,7 @@ impl CompactString {
 
     /// Converts a [`CompactString`] to a raw pointer.
     #[inline]
-    pub fn as_ptr(&mut self) -> *const u8 {
+    pub fn as_ptr(&self) -> *const u8 {
         self.0.as_slice().as_ptr()
     }
 

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -930,7 +930,7 @@ fn test_from_string_buffer_small_string_with_excess_capacity() {
     let str_cap = string.capacity();
 
     // using from_string_buffer should always re-use the underlying buffer
-    let mut compact = CompactString::from_string_buffer(string);
+    let compact = CompactString::from_string_buffer(string);
     assert!(compact.is_heap_allocated());
 
     let cpt_ptr = compact.as_ptr();
@@ -964,7 +964,7 @@ fn test_from_string_buffer_small_string_with_no_excess_capacity() {
     let str_cap = string.capacity();
 
     // using from_string_buffer should always re-use the underlying buffer
-    let mut compact = CompactString::from_string_buffer(string);
+    let compact = CompactString::from_string_buffer(string);
     assert!(compact.is_heap_allocated());
 
     let cpt_ptr = compact.as_ptr();


### PR DESCRIPTION
I realized this recently that `CompactString::as_ptr` took a mutable reference to self (aka `&mut self`), when all it really needs is a normal reference (aka `&self`). This PR updates the API to make that change