### PR TITLE
ci: Randomize Layout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     name: cargo test -Zrandomize-layout
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS="-Zrandomize-layout"
+      RUSTFLAGS: -Zrandomize-layout
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,34 @@ jobs:
         run: |
           cargo miri test --all-features --manifest-path=compact_str/Cargo.toml
 
+  randomize-layout:
+    name: cargo test -Zrandomize-layout
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS="-Zrandomize-layout"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test-randomize-layout
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
+            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - name: Run Tests with Randomized Layout
+        run: |
+          cargo test --all-features --manifest-path=compact_str/Cargo.toml
+
   example-bytes:
     name: example - bytes
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,7 +17,7 @@ name: Fuzz
 
 env:
   CARGO_TERM_COLOR: "always"
-  RUSTFLAGS: "-D warnings"
+  RUSTFLAGS: "-D warnings -Zrandomize-layout"
 
 jobs:
   libFuzzer_x86_64:


### PR DESCRIPTION
This PR adds a new workflow to CI that runs our tests with the [`randomize-layout`](https://github.com/rust-lang/compiler-team/issues/457) `rustc` flag enabled, and enables the flag for our fuzzing runs