### PR TITLE
examples, update to v0.7

### DIFF
--- a/examples/bytes/Cargo.toml
+++ b/examples/bytes/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 bytes = "1"
-compact_str = { version = "0.6", features = ["bytes"] }
+compact_str = { version = "0.7", features = ["bytes"] }

--- a/examples/macros/Cargo.toml
+++ b/examples/macros/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = "0.6"
+compact_str = "0.7"

--- a/examples/serde/Cargo.toml
+++ b/examples/serde/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = { version = "0.6", features = ["serde"] }
+compact_str = { version = "0.7", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-compact_str = "0.6"
+compact_str = "0.7"


### PR DESCRIPTION
This PR just updates the examples to the most recent version of `compact_str`