### PR TITLE
refactor: Remove unneeded code

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -58,8 +58,7 @@ jobs:
         # Instead of pinning to a specific version of `arbitrary` or `proptest`, we'll let user's 
         # deps decide the version since the API should still be semver compatible
         run: |
-          cd compact_str
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --version-range 1.57..
+          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.57..
 
   feature_powerset:
     name: cargo check feature-powerset

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 compact_str = { path = "../compact_str" }
 compact_str_6 = { package = "compact_str", version = "0.6" }
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.4", default-features = false }
 iai = "0.1.1"
 smartstring = "1.0.1"
 smol_str = "0.1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -30,7 +30,7 @@ static_assertions = "1"
 [dev-dependencies]
 cfg-if = "1"
 proptest = { version = "1.0.*", default-features = false, features = ["std"] }
-quickcheck = "1"
+quickcheck = { version = "1", default-features = false }
 quickcheck_macros = "1"
 rayon = "1.6.0"
 rkyv = { version = "0.7", default-features = false, features = ["alloc", "size_32"] }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -353,20 +353,17 @@ impl Repr {
         let mut pointer = self as *const Self as *const u8;
         let heap_pointer = self.0 as *const u8;
 
-        let pointer_ref = &mut pointer;
-
         // initially has the value of the stack length, conditionally becomes the heap length
         let mut length = core::cmp::min((last_byte.wrapping_sub(LENGTH_MASK)) as usize, MAX_SIZE);
         let heap_length = self.1;
-        let length_ref = &mut length;
 
         // our discriminant is stored in the last byte and denotes stack vs heap
         //
         // Note: We should never add an `else` statement here, keeping the conditional simple allows
         // the compiler to optimize this to a conditional-move instead of a branch
         if last_byte == HEAP_MASK {
-            *pointer_ref = heap_pointer;
-            *length_ref = heap_length;
+            pointer = heap_pointer;
+            length = heap_length;
         }
 
         // SAFETY: We know the data is valid, aligned, and part of the same contiguous allocated


### PR DESCRIPTION
In the `as_slice()` method, we didn't need to take a ref to `pointer` or `length`.