### PR TITLE
test: Add proptest fuzz coverage for repeat

### DIFF
--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1632,6 +1632,15 @@ fn proptest_from_utf16(#[strategy(rand_u16s())] buf: Vec<u16>) {
     }
 }
 
+#[proptest]
+#[cfg_attr(miri, ignore)]
+fn proptest_repeat(n: u16, s: String) {
+    let compact = CompactString::new(&s).repeat(n as usize);
+    let control = s.repeat(n as usize);
+
+    assert_eq!(compact, control);
+}
+
 #[test]
 fn test_from_utf16x() {
     let dancing_men = b"\x3d\xd8\x6f\xdc\x0d\x20\x42\x26\x0f\xfe";

--- a/fuzz/src/creation.rs
+++ b/fuzz/src/creation.rs
@@ -690,7 +690,7 @@ impl Creation<'_> {
             WithCapacity(val) => {
                 // pick some value between [0, 24MB]
                 let ratio: f32 = (val as f32) / (u32::MAX as f32);
-                let num_bytes = ((super::TWENTY_FOUR_MB_AS_BYTES as f32) * ratio) as u32;
+                let num_bytes = ((super::TWENTY_FOUR_MIB_AS_BYTES as f32) * ratio) as u32;
 
                 let compact = CompactString::with_capacity(num_bytes as usize);
                 let std_str = String::with_capacity(num_bytes as usize);

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -21,7 +21,7 @@ use rand_distr::{
 
 const MAX_INLINE_LENGTH: usize = std::mem::size_of::<String>();
 const MIN_HEAP_CAPACITY: usize = std::mem::size_of::<usize>() * 4;
-const TWENTY_FOUR_MB_AS_BYTES: usize = 24 * 1024 * 1024;
+const TWENTY_FOUR_MIB_AS_BYTES: usize = 24 * 1024 * 1024;
 
 mod actions;
 mod creation;


### PR DESCRIPTION
Adds `proptest` and fuzzing coverage for the `repeat(...)` function.

Note: this PR is split into two commits:

1. The implementation of testing
2. Update to the fuzz corpus