### PR TITLE
Improve CI: Rm use of deprecated actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,12 +12,11 @@ jobs:
     name: cargo bench
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: bench
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --no-self-update --profile minimal
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Benchmark
+        run: cargo bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,109 +18,60 @@ jobs:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-check
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --tests --all-features
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --no-self-update --profile minimal
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check
+        run: cargo check --tests --all-features
 
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - toolchain: stable
+          - toolchain: nightly
+
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-test
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-      - name: cargo test
-        run: |
-          cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all
+      - uses: actions/checkout@v4
 
-  test-nightly:
-    name: cargo test nightly
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal
+          rustup override set ${{ matrix.toolchain }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
-      # Install nightly after cargo-nextest is installed, as cargo-nextest failed to compile on nightly
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo test
         run: |
           cargo nextest run --release --all-features --manifest-path=compact_str/Cargo.toml --run-ignored=all
+          cargo test --doc --release --all-features --manifest-path=compact_str/Cargo.toml
 
   miri:
     name: cargo miri test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: miri
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test-miri
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal --component miri
+          rustup override set nightly
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+
       - name: Run Miri
         run: |
-          cargo miri test --all-features --manifest-path=compact_str/Cargo.toml
+          cargo miri nextest run --all-features --manifest-path=compact_str/Cargo.toml
+          cargo miri test --doc --all-features --manifest-path=compact_str/Cargo.toml
 
   randomize-layout:
     name: cargo test -Zrandomize-layout
@@ -128,54 +79,38 @@ jobs:
     env:
       RUSTFLAGS: -Zrandomize-layout
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test-randomize-layout
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-test
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set nightly
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+
       - name: Run Tests with Randomized Layout
         run: |
-          cargo test --all-features --manifest-path=compact_str/Cargo.toml
+          cargo nextest run --all-features --manifest-path=compact_str/Cargo.toml
+          cargo test --doc --all-features --manifest-path=compact_str/Cargo.toml
 
   examples:
-    name: example
+    name: example - ${{ matrix.ex }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ex: ["bytes", "macros", "serde", "traits"] 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set nightly
+      - uses: Swatinem/rust-cache@v2
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-${{ matrix.ex }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/${{ matrix.ex }}/Cargo.toml
+          key: ${{ matrix.ex }}
+
+      - name: Run example-bytes
+        run: cargo run --manifest-path examples/${{ matrix.ex }}/Cargo.toml

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,52 +16,37 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout compact_str
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          # We currently use some unstable features in rustfmt, hence the nightly toolchain
-          toolchain: nightly
-          override: true
-      - run: rustup component add rustfmt
-        name: Add rustfmt
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt Workspace
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        name: Run rustfmt compact_str
-        with:
-          command: fmt
-          args: --all --manifest-path compact_str/Cargo.toml -- --check
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal --component rustfmt
+          rustup override set nightly
+
+      - name: Run rustfmt Workspace
+        run: cargo fmt --all -- --check
+      - name: Run rustfmt compact_str
+        run: cargo fmt --all --manifest-path compact_str/Cargo.toml -- --check
 
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout compact_str
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-        name: Add clippy
-      - uses: actions-rs/cargo@v1
-        name: Run clippy Workspace
-        with:
-          command: clippy
-          args: --tests
-      - uses: actions-rs/cargo@v1
-        name: Run clippy compact_str
-        with:
-          command: clippy
-          args: --tests --manifest-path compact_str/Cargo.toml
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal --component clippy
+          rustup override set nightly
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy Workspace
+        run: cargo clippy --no-deps --tests
+
+      - name: Run clippy compact_str
+        run: cargo clippy --no-deps --tests --manifest-path compact_str/Cargo.toml
 
   doc:
     name: cargo doc
@@ -69,17 +54,14 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings --cfg docsrs"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout compact_str
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          # docs.rs uses a nightly toolchain
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: Run rustdoc
-        with:
-          command: doc
-          args: --all-features --no-deps --manifest-path compact_str/Cargo.toml
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set nightly
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run rustdoc
+        run: cargo doc --all-features --no-deps --manifest-path compact_str/Cargo.toml

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -20,89 +20,60 @@ env:
   MIRIFAGS: "-Zmiri-tag-raw-pointers -Zmiri-check-number-validity"
 
 jobs:
-  x_plat_os:
-    name: x_plat_os
-    strategy:
-      matrix:
-        os: [windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout Repo
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: miri
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-${{ matrix.os }}
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
-      - uses: actions-rs/cargo@v1
-        name: cargo test miri
-        with:
-          command: miri
-          args: test --all-features --manifest-path=compact_str/Cargo.toml
-
-  x_plat_arch:
-    name: x_plat_arch
-    runs-on: ubuntu-latest
+  cross-test:
     strategy:
       fail-fast: false
       matrix:
-        target: [
-          # 32-bit Little Endian
-          "i686-unknown-linux-gnu",
-          "arm-unknown-linux-gnueabihf",
-          "armv7-unknown-linux-gnueabihf",
-          # 32-bit Big Endian
-          "powerpc-unknown-linux-gnu",
-          # 64-bit Little Endian
-          "powerpc64le-unknown-linux-gnu",
-          "aarch64-unknown-linux-gnu",
-          # 64-bit Big Endian
-          "powerpc64-unknown-linux-gnu",
-        ]
+        include:
+          - name: macos
+            OS: macos-latest
+            target: x86_64-apple-darwin
+          - name: Windows
+            OS: windows-latest
+            target: x86_64-pc-windows-msvc
+          - name: Linux 32-bit
+            OS: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            cross: true
+          - name: Linux MIPS Big Endian 32-bit
+            OS: ubuntu-latest
+            target: mips-unknown-linux-gnu
+            cross: true
+          - name: Linux MIPS Little Endian 32-bit
+            OS: ubuntu-latest
+            target: mipsel-unknown-linux-gnu
+            cross: true
+          - name: Linux PowerPC Big Endian 32-bit
+            OS: ubuntu-latest
+            target: powerpc-unknown-linux-gnu
+            cross: true
+          - name: Linux PowerPC Little Endian 64-bit
+            OS: ubuntu-latest
+            target: powerpc64le-unknown-linux-gnu
+            cross: true
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.OS }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Repo
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
+
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal --component miri --target ${{ matrix.target }}
+          rustup override set nightly
+      - name: Install cross
+        if: "matrix.cross"
+        uses: taiki-e/install-action@cross
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          profile: minimal
-          toolchain: nightly
-          target: ${{ matrix.target }}
-          override: true
-          components: miri
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-${{ matrix.target }}
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          use-cross: true
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}
-      - uses: actions-rs/cargo@v1
-        name: cargo test miri
-        with:
-          command: miri
-          args: test --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}
+          key: ${{ matrix.target }}
+
+      - name: cargo test
+        if: "! matrix.cross"
+        run: cargo test --release --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }} -- --include-ignored
+      - name: cargo test
+        if: "matrix.cross"
+        run: cross test --release --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}
+      - name: cargo test miri
+        run: cargo miri test --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -24,31 +24,20 @@ jobs:
     name: libFuzzer [x86_64]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout compact_str
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
+          
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set nightly
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/install@v0.1
-        name: Install cargo-fuzz
-        with:
-          crate: cargo-fuzz
-          version: latest
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz-libfuzzer
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-fuzz
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
+          tool: cargo-fuzz
+      - uses: Swatinem/rust-cache@v2
+
+
       - name: Set Fuzz Time
         run: |
           if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
@@ -57,11 +46,8 @@ jobs:
             echo "fuzz_time=1800" >> $GITHUB_ENV
           fi
           echo "${{ env.fuzz_time }}"
-      - uses: actions-rs/cargo@v1
-        name: Fuzz!
-        with:
-          command: fuzz
-          args: run --features=libfuzzer-sys --debug-assertions compact_str -- -max_total_time=${{ env.fuzz_time }}
+      - name: Fuzz!
+        run: cargo fuzz run --features=libfuzzer-sys --debug-assertions compact_str -- -max_total_time=${{ env.fuzz_time }}
       - name: File Issue (if failure found)
         if: failure()
         uses: JasonEtco/create-an-issue@v2.9

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -21,33 +21,14 @@ jobs:
     name: cargo check msrv 1.59..
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - name: Toolchain Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.rustup/downloads
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-          key: ${{ runner.os }}-x86_64-rustup
-      - name: Cargo Build Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-cargo-hack
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
-      - name: install cargo hack
-        run: cargo install cargo-hack --force
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --no-self-update --profile minimal
+      - name: Install cargo hack
+        uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo test msrv..
         # note: we exclude both `arbitrary` and `proptest` from here because their MSRVs were both
         # bumped on a minor version release:
@@ -65,25 +46,14 @@ jobs:
     name: cargo check feature-powerset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - name: Cargo Build Cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable-cargo-hack
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-stable
-      - name: install cargo hack
-        run: cargo install cargo-hack --force
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --no-self-update --profile minimal
+      - name: Install cargo hack
+        uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo test msrv..
         run: |
           cd compact_str

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         opt: ["", "--release"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain
+        run: rustup toolchain install stable --no-self-update --profile minimal --target thumbv6m-none-eabi
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --lib --manifest-path compact_str/Cargo.toml --no-default-features ${{ matrix.opt }} --target thumbv6m-none-eabi
+          key: ${{ matrix.opt }}
+
+      - run: |
+          cargo check --lib --manifest-path compact_str/Cargo.toml --no-default-features ${{ matrix.opt }} --target thumbv6m-none-eabi


### PR DESCRIPTION
Fixed #280 and fixed #279

also:
 - Bump `actions/checkout` to v4
 - use `taiki-e/install-action` to install any binary crates
 - use `Swatinem/rust-cache@v2` for caching
 - use `strategy` to avoid similar/duplicate jobs
 - pass `--no-deps` to `cargo-clippy`
 - Use `cargo-nextest` for `randomize-layout`
 - Run doc test in job `test`
 - Use `cargo-nextest` to speedup `miri`
 - Run `cargo-check` instead of `cross-build` in `nostd.yml` since
   there's no need for `cross`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>