### PR TITLE
Fix and optimize `Capacity`

### DIFF
--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -3,20 +3,15 @@ use crate::repr::LastUtf8Char;
 // how many bytes a `usize` occupies
 const USIZE_SIZE: usize = core::mem::size_of::<usize>();
 
-/// Used to generate [`CAPACITY_IS_ON_THE_HEAP`]
-#[allow(non_snake_case)]
-const fn CAP_ON_HEAP_FLAG() -> [u8; USIZE_SIZE] {
-    // all bytes 255, with the last being HEAP_MASK
-    let mut flag = [255; USIZE_SIZE];
-    flag[USIZE_SIZE - 1] = LastUtf8Char::Heap as u8;
-    flag
-}
-
 /// State that describes the capacity as being stored on the heap.
 ///
 /// All bytes `255`, with the last being [`LastUtf8Char::Heap`], using the same amount of bytes
 /// as `usize`. Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 216]`
-const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = CAP_ON_HEAP_FLAG();
+const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = {
+    let mut flag = [255; USIZE_SIZE];
+    flag[USIZE_SIZE - 1] = LastUtf8Char::Heap as u8;
+    flag
+};
 
 // how many bytes we can use for capacity
 const SPACE_FOR_CAPACITY: usize = USIZE_SIZE - 1;

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -13,10 +13,12 @@ const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = {
     flag
 };
 
-// how many bytes we can use for capacity
-const SPACE_FOR_CAPACITY: usize = USIZE_SIZE - 1;
 // the maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2
-pub const MAX_VALUE: usize = 2usize.pow(SPACE_FOR_CAPACITY as u32 * 8) - 2;
+pub const MAX_VALUE: usize = {
+    let mut bytes = [255; USIZE_SIZE];
+    bytes[USIZE_SIZE - 1] = 0;
+    usize::from_le_bytes(bytes) - 1
+};
 
 /// An integer type that uses `core::mem::size_of::<usize>() - 1` bytes to store the capacity of
 /// a heap buffer.
@@ -84,7 +86,7 @@ impl Capacity {
         // * `src` is valid for reads of `SPACE_FOR_CAPACITY` because it is less than `USIZE_SIZE`
         // * `dst` is valid for reads of `SPACE_FOR_CAPACITY` because it is less than `USIZE_SIZE`
         // * `src` and `dst` do not overlap because we created `usize_buf`
-        core::ptr::copy_nonoverlapping(self.0.as_ptr(), usize_buf.as_mut_ptr(), SPACE_FOR_CAPACITY);
+        core::ptr::copy_nonoverlapping(self.0.as_ptr(), usize_buf.as_mut_ptr(), USIZE_SIZE - 1);
         usize::from_le_bytes(usize_buf)
     }
 

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -16,10 +16,6 @@ const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = {
 // how many bytes we can use for capacity
 const SPACE_FOR_CAPACITY: usize = USIZE_SIZE - 1;
 // the maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2
-//
-// note: Preferably we'd used usize.pow(..) here, but that's not a `const fn`, so we need to use
-// bitshift operators, and there's a lint against using them in this pattern, which IMO isn't a
-// great lint
 pub const MAX_VALUE: usize = 2usize.pow(SPACE_FOR_CAPACITY as u32 * 8) - 2;
 
 /// An integer type that uses `core::mem::size_of::<usize>() - 1` bytes to store the capacity of

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -7,10 +7,10 @@ const USIZE_SIZE: usize = core::mem::size_of::<usize>();
 ///
 /// All bytes `255`, with the last being [`LastUtf8Char::Heap`], using the same amount of bytes
 /// as `usize`. Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 216]`
-const CAPACITY_IS_ON_THE_HEAP: [u8; USIZE_SIZE] = {
+const CAPACITY_IS_ON_THE_HEAP: Capacity = {
     let mut flag = [255; USIZE_SIZE];
     flag[USIZE_SIZE - 1] = LastUtf8Char::Heap as u8;
-    flag
+    Capacity(flag)
 };
 
 // the maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2
@@ -61,7 +61,7 @@ impl Capacity {
                 if capacity > MAX_VALUE {
                     // if we need the last byte to encode this capacity then we need to put the capacity on
                     // the heap. return an Error so `BoxString` can do the right thing
-                    Capacity(CAPACITY_IS_ON_THE_HEAP)
+                    CAPACITY_IS_ON_THE_HEAP
                 } else {
                     // otherwise, we can store this capacity inline! Set the last byte to be our `LastUtf8Char::Heap as u8`
                     // for our discriminant, using the leading bytes to store the actual value
@@ -93,8 +93,8 @@ impl Capacity {
     /// Returns whether or not this [`Capacity`] has a value that indicates the capacity is being
     /// stored on the heap
     #[inline(always)]
-    pub fn is_heap(&self) -> bool {
-        self.0 == CAPACITY_IS_ON_THE_HEAP
+    pub fn is_heap(self) -> bool {
+        self == CAPACITY_IS_ON_THE_HEAP
     }
 }
 

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use crate::repr::LastUtf8Char;
 
 // how many bytes a `usize` occupies
@@ -47,12 +49,18 @@ pub const MAX_VALUE: usize = {
 /// heap, because with it's impossible to create a string that is 64 petabytes or larger. But for
 /// 32-bit architectures we need to be able to store a capacity larger than 16 megabytes, since a
 /// string larger than 16 megabytes probably isn't that uncommon.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Capacity(usize);
 
 static_assertions::assert_eq_size!(Capacity, usize);
 static_assertions::assert_eq_align!(Capacity, usize);
+
+impl fmt::Debug for Capacity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Capacity(0x{:x})", usize::from_le(self.0))
+    }
+}
 
 impl Capacity {
     #[inline]


### PR DESCRIPTION
In #276 I changed the value of the byte that tells if a string is stored on the heap, but I forgot to update the test for `Capacity`.

The compiler does not quite understand what we are doing in `Capacity::new()` and `Capacity::as_usize()`. Working on `usize` instead of `[u8; _]` allows the compiler to keep everything in registers instead of having to store the value on the stack to modify it.

Before:

```asm
Capacity::new:
	movabsq	$72057594037927935, %rcx
	andq	%rdi, %rcx
	movabsq	$-2882303761517117440, %rax
	orq	%rcx, %rax
	retq

Capacity::as_usize:
	movzwl	4(%rdi), %eax
	movzbl	6(%rdi), %ecx
	shll	$16, %ecx
	orl	%eax, %ecx
	shlq	$32, %rcx
	movl	(%rdi), %eax
	orq	%rcx, %rax
	retq
```

After:

```asm
Capacity::new:
	movabsq	$-2882303761517117440, %rax
	orq	%rdi, %rax
	retq

Capacity::as_usize:
	movabsq	$72057594037927935, %rax
	andq	%rdi, %rax
	retq
```