### PR TITLE
support no_std

### DIFF
--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -1,0 +1,28 @@
+name: no-std
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  no-std:
+    name: no-std build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        opt: ["", "--release"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --lib --manifest-path compact_str/Cargo.toml --no-default-features ${{ matrix.opt }} --target thumbv6m-none-eabi

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -27,7 +27,10 @@ rkyv = { version = "0.7", optional = true, default-features = false, features = 
 serde = { version = "1", optional = true }
 smallvec = { version = "1", optional = true, features = ["union"] }
 
-castaway = "0.2"
+# TODO: replace with the below version when castaway is updated on crates.io
+castaway = { version = "0.2", default-features = false }
+# castaway = { version = "0.2", default-features = false, features = ["alloc"] }
+
 cfg-if = "1"
 itoa = "1"
 ryu = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -11,6 +11,12 @@ readme = "../README.md"
 keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
+[features]
+default = [
+    "std",
+]
+std = []
+
 [dependencies]
 arbitrary = { version = "1", optional = true, default-features = false }
 bytes = { version = "1", optional = true }

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -70,6 +70,8 @@ impl CompactString {
 #[cfg(test)]
 mod test {
     use std::io::Cursor;
+    use alloc::vec::Vec;
+    use alloc::string::String;
 
     use proptest::prelude::*;
     use test_strategy::proptest;

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -69,9 +69,9 @@ impl CompactString {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
-    use alloc::vec::Vec;
     use alloc::string::String;
+    use alloc::vec::Vec;
+    use std::io::Cursor;
 
     use proptest::prelude::*;
     use test_strategy::proptest;

--- a/compact_str/src/features/bytes.rs
+++ b/compact_str/src/features/bytes.rs
@@ -71,6 +71,7 @@ impl CompactString {
 mod test {
     use alloc::string::String;
     use alloc::vec::Vec;
+    #[cfg(feature = "std")]
     use std::io::Cursor;
 
     use proptest::prelude::*;

--- a/compact_str/src/features/markup.rs
+++ b/compact_str/src/features/markup.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+#[cfg(test)]
+use alloc::string::String;
+
 use markup::Render;
 
 use crate::CompactString;

--- a/compact_str/src/features/markup.rs
+++ b/compact_str/src/features/markup.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 #[cfg(test)]
 use alloc::string::String;
 
@@ -10,7 +8,7 @@ use crate::CompactString;
 #[cfg_attr(docsrs, doc(cfg(feature = "markup")))]
 impl Render for CompactString {
     #[inline]
-    fn render(&self, writer: &mut impl fmt::Write) -> fmt::Result {
+    fn render(&self, writer: &mut impl core::fmt::Write) -> core::fmt::Result {
         self.as_str().render(writer)
     }
 }

--- a/compact_str/src/features/proptest.rs
+++ b/compact_str/src/features/proptest.rs
@@ -10,6 +10,7 @@ use proptest::strategy::{
     Strategy,
 };
 use proptest::string::StringParam;
+use alloc::string::String;
 
 use crate::CompactString;
 
@@ -25,6 +26,7 @@ impl Arbitrary for CompactString {
 
 #[cfg(test)]
 mod test {
+    use alloc::string::String;
     use proptest::prelude::*;
 
     use crate::CompactString;

--- a/compact_str/src/features/proptest.rs
+++ b/compact_str/src/features/proptest.rs
@@ -33,7 +33,7 @@ mod test {
 
     use crate::CompactString;
 
-    const MAX_SIZE: usize = std::mem::size_of::<String>();
+    const MAX_SIZE: usize = core::mem::size_of::<String>();
 
     proptest! {
         #[test]

--- a/compact_str/src/features/proptest.rs
+++ b/compact_str/src/features/proptest.rs
@@ -1,5 +1,7 @@
 //! Implements the [`proptest::arbitrary::Arbitrary`] trait for [`CompactString`]
 
+use alloc::string::String;
+
 use proptest::arbitrary::{
     Arbitrary,
     StrategyFor,
@@ -10,7 +12,6 @@ use proptest::strategy::{
     Strategy,
 };
 use proptest::string::StringParam;
-use alloc::string::String;
 
 use crate::CompactString;
 
@@ -27,6 +28,7 @@ impl Arbitrary for CompactString {
 #[cfg(test)]
 mod test {
     use alloc::string::String;
+
     use proptest::prelude::*;
 
     use crate::CompactString;

--- a/compact_str/src/features/quickcheck.rs
+++ b/compact_str/src/features/quickcheck.rs
@@ -1,5 +1,7 @@
 //! Implements the [`quickcheck::Arbitrary`] trait for [`CompactString`]
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use quickcheck::{
     Arbitrary,
     Gen,
@@ -33,6 +35,7 @@ impl Arbitrary for CompactString {
 
 #[cfg(test)]
 mod test {
+    use alloc::string::String;
     use quickcheck_macros::quickcheck;
 
     use crate::CompactString;

--- a/compact_str/src/features/quickcheck.rs
+++ b/compact_str/src/features/quickcheck.rs
@@ -2,6 +2,7 @@
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+
 use quickcheck::{
     Arbitrary,
     Gen,
@@ -36,6 +37,7 @@ impl Arbitrary for CompactString {
 #[cfg(test)]
 mod test {
     use alloc::string::String;
+
     use quickcheck_macros::quickcheck;
 
     use crate::CompactString;

--- a/compact_str/src/features/quickcheck.rs
+++ b/compact_str/src/features/quickcheck.rs
@@ -52,7 +52,7 @@ mod test {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_inlines_strings(compact: CompactString) {
-        if compact.len() <= std::mem::size_of::<String>() {
+        if compact.len() <= core::mem::size_of::<String>() {
             assert!(!compact.is_heap_allocated())
         } else {
             assert!(compact.is_heap_allocated())

--- a/compact_str/src/features/rkyv.rs
+++ b/compact_str/src/features/rkyv.rs
@@ -62,6 +62,7 @@ impl PartialOrd<CompactString> for ArchivedString {
 #[cfg(test)]
 mod tests {
     use alloc::string::String;
+
     use rkyv::Deserialize;
     use test_strategy::proptest;
 

--- a/compact_str/src/features/rkyv.rs
+++ b/compact_str/src/features/rkyv.rs
@@ -54,7 +54,7 @@ impl PartialEq<CompactString> for ArchivedString {
 
 impl PartialOrd<CompactString> for ArchivedString {
     #[inline]
-    fn partial_cmp(&self, other: &CompactString) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &CompactString) -> Option<core::cmp::Ordering> {
         PartialOrd::partial_cmp(self.as_str(), other.as_str())
     }
 }

--- a/compact_str/src/features/rkyv.rs
+++ b/compact_str/src/features/rkyv.rs
@@ -61,6 +61,7 @@ impl PartialOrd<CompactString> for ArchivedString {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use rkyv::Deserialize;
     use test_strategy::proptest;
 

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -1,6 +1,6 @@
-use std::fmt;
 use alloc::string::String;
 use alloc::vec::Vec;
+use std::fmt;
 
 use serde::de::{
     Deserializer,
@@ -79,8 +79,12 @@ impl<'de> serde::Deserialize<'de> for CompactString {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
+    use alloc::string::{
+        String,
+        ToString,
+    };
     use alloc::vec::Vec;
+
     use serde::{
         Deserialize,
         Serialize,

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -1,6 +1,5 @@
 use alloc::string::String;
 use alloc::vec::Vec;
-use std::fmt;
 
 use serde::de::{
     Deserializer,
@@ -19,7 +18,7 @@ fn compact_string<'de: 'a, 'a, D: Deserializer<'de>>(
     impl<'a> Visitor<'a> for CompactStringVisitor {
         type Value = CompactString;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
             formatter.write_str("a string")
         }
 
@@ -36,14 +35,14 @@ fn compact_string<'de: 'a, 'a, D: Deserializer<'de>>(
         }
 
         fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-            match std::str::from_utf8(v) {
+            match core::str::from_utf8(v) {
                 Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }
         }
 
         fn visit_borrowed_bytes<E: Error>(self, v: &'a [u8]) -> Result<Self::Value, E> {
-            match std::str::from_utf8(v) {
+            match core::str::from_utf8(v) {
                 Ok(s) => Ok(CompactString::from(s)),
                 Err(_) => Err(Error::invalid_value(Unexpected::Bytes(v), &self)),
             }

--- a/compact_str/src/features/serde.rs
+++ b/compact_str/src/features/serde.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use serde::de::{
     Deserializer,
@@ -77,6 +79,8 @@ impl<'de> serde::Deserialize<'de> for CompactString {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
     use serde::{
         Deserialize,
         Serialize,

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -9,8 +9,8 @@ impl CompactString {
     /// This consumes the [`CompactString`] and returns a [`SmallVec`], so we do not need to copy
     /// contents
     ///
-    /// Note: [`SmallVec`] is an inline-able version [`Vec`](alloc::vec::Vec), just like [`CompactString`] is an
-    /// inline-able version of [`String`](alloc::string::String).
+    /// Note: [`SmallVec`] is an inline-able version [`Vec`](alloc::vec::Vec), just like
+    /// [`CompactString`] is an inline-able version of [`String`](alloc::string::String).
     ///
     /// # Example
     /// ```
@@ -30,6 +30,7 @@ impl CompactString {
 #[cfg(test)]
 mod tests {
     use alloc::string::String;
+
     use proptest::prelude::*;
     use test_strategy::proptest;
 

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -29,6 +29,7 @@ impl CompactString {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use proptest::prelude::*;
     use test_strategy::proptest;
 

--- a/compact_str/src/features/smallvec.rs
+++ b/compact_str/src/features/smallvec.rs
@@ -9,8 +9,8 @@ impl CompactString {
     /// This consumes the [`CompactString`] and returns a [`SmallVec`], so we do not need to copy
     /// contents
     ///
-    /// Note: [`SmallVec`] is an inline-able version [`Vec`], just like [`CompactString`] is an
-    /// inline-able version of [`String`].
+    /// Note: [`SmallVec`] is an inline-able version [`Vec`](alloc::vec::Vec), just like [`CompactString`] is an
+    /// inline-able version of [`String`](alloc::string::String).
     ///
     /// # Example
     /// ```

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
 #![no_std]
 
 #[cfg(feature = "std")]
@@ -10,6 +9,9 @@ extern crate std;
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
 
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::string::String;
 #[doc(hidden)]
 pub use core;
 use core::borrow::{
@@ -21,7 +23,10 @@ use core::hash::{
     Hash,
     Hasher,
 };
-use core::iter::FromIterator;
+use core::iter::{
+    FromIterator,
+    FusedIterator,
+};
 use core::ops::{
     Add,
     AddAssign,
@@ -39,11 +44,6 @@ use core::{
     mem,
     slice,
 };
-use alloc::borrow::Cow;
-use alloc::string::String;
-use alloc::boxed::Box;
-use core::iter::FusedIterator;
-
 #[cfg(feature = "std")]
 use std::ffi::OsStr;
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -4,6 +4,7 @@
 #![no_std]
 
 #[cfg(feature = "std")]
+#[macro_use]
 extern crate std;
 
 #[cfg_attr(test, macro_use)]

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1,6 +1,14 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg_attr(test, macro_use)]
+extern crate alloc;
+
 #[doc(hidden)]
 pub use core;
 use core::borrow::{
@@ -30,9 +38,13 @@ use core::{
     mem,
     slice,
 };
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::boxed::Box;
+use core::iter::FusedIterator;
+
+#[cfg(feature = "std")]
 use std::ffi::OsStr;
-use std::iter::FusedIterator;
 
 mod features;
 mod macros;
@@ -396,7 +408,7 @@ impl CompactString {
     pub fn from_utf16_lossy<B: AsRef<[u16]>>(buf: B) -> Self {
         let buf = buf.as_ref();
         let mut ret = CompactString::with_capacity(buf.len());
-        for c in std::char::decode_utf16(buf.iter().copied()) {
+        for c in core::char::decode_utf16(buf.iter().copied()) {
             match c {
                 Ok(c) => ret.push(c),
                 Err(_) => ret.push_str("�"),
@@ -523,7 +535,7 @@ impl CompactString {
     #[inline]
     pub fn as_mut_str(&mut self) -> &mut str {
         let len = self.len();
-        unsafe { std::str::from_utf8_unchecked_mut(&mut self.0.as_mut_buf()[..len]) }
+        unsafe { core::str::from_utf8_unchecked_mut(&mut self.0.as_mut_buf()[..len]) }
     }
 
     unsafe fn spare_capacity_mut(&mut self) -> &mut [mem::MaybeUninit<u8>] {
@@ -960,14 +972,14 @@ impl CompactString {
         unsafe {
             // first move the tail to the new back
             let data = self.as_mut_ptr();
-            std::ptr::copy(
+            core::ptr::copy(
                 data.add(idx),
                 data.add(idx + string.len()),
                 new_len - idx - string.len(),
             );
 
             // then insert the new bytes
-            std::ptr::copy_nonoverlapping(string.as_ptr(), data.add(idx), string.len());
+            core::ptr::copy_nonoverlapping(string.as_ptr(), data.add(idx), string.len());
 
             // and lastly resize the string
             self.set_len(new_len);
@@ -1292,7 +1304,7 @@ impl CompactString {
         let mut iter = v.iter();
         while let Some(s) = next_char(&mut iter, &mut buf) {
             // SAFETY: next_char() only returns valid strings
-            let s = unsafe { std::str::from_utf8_unchecked(s) };
+            let s = unsafe { core::str::from_utf8_unchecked(s) };
             result.push_str(s);
         }
         result
@@ -1319,7 +1331,7 @@ impl CompactString {
         match unsafe { v.align_to::<u16>() } {
             (&[], v, &[]) => {
                 // Input is correcty aligned.
-                for c in std::char::decode_utf16(v.iter().copied().map(from_int)) {
+                for c in core::char::decode_utf16(v.iter().copied().map(from_int)) {
                     result.push(c.map_err(|_| Utf16Error(()))?);
                 }
             }
@@ -1327,7 +1339,7 @@ impl CompactString {
                 // Input's alignment is off.
                 // SAFETY: we can always reinterpret a `[u8; 2*N]` slice as `[[u8; 2]; N]`
                 let v = unsafe { slice::from_raw_parts(v.as_ptr().cast(), v.len() / 2) };
-                for c in std::char::decode_utf16(v.iter().copied().map(from_bytes)) {
+                for c in core::char::decode_utf16(v.iter().copied().map(from_bytes)) {
                     result.push(c.map_err(|_| Utf16Error(()))?);
                 }
             }
@@ -1355,7 +1367,7 @@ impl CompactString {
         match unsafe { v.align_to::<u16>() } {
             (&[], v, &[]) => {
                 // Input is correcty aligned.
-                for c in std::char::decode_utf16(v.iter().copied().map(from_int)) {
+                for c in core::char::decode_utf16(v.iter().copied().map(from_int)) {
                     match c {
                         Ok(c) => result.push(c),
                         Err(_) => result.push_str("�"),
@@ -1366,7 +1378,7 @@ impl CompactString {
                 // Input's alignment is off.
                 // SAFETY: we can always reinterpret a `[u8; 2*N]` slice as `[[u8; 2]; N]`
                 let v = unsafe { slice::from_raw_parts(v.as_ptr().cast(), v.len() / 2) };
-                for c in std::char::decode_utf16(v.iter().copied().map(from_bytes)) {
+                for c in core::char::decode_utf16(v.iter().copied().map(from_bytes)) {
                     match c {
                         Ok(c) => result.push(c),
                         Err(_) => result.push_str("�"),
@@ -1820,6 +1832,7 @@ impl AsRef<str> for CompactString {
     }
 }
 
+#[cfg(feature = "std")]
 impl AsRef<OsStr> for CompactString {
     #[inline]
     fn as_ref(&self) -> &OsStr {
@@ -2160,7 +2173,7 @@ pub struct Drain<'a> {
     compact_string: *mut CompactString,
     start: usize,
     end: usize,
-    chars: std::str::Chars<'a>,
+    chars: core::str::Chars<'a>,
 }
 
 // SAFETY: Drain keeps the lifetime of the CompactString it belongs to.

--- a/compact_str/src/repr/bytes.rs
+++ b/compact_str/src/repr/bytes.rs
@@ -81,6 +81,7 @@ impl Repr {
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "std")]
     use std::io::Cursor;
 
     use test_case::test_case;
@@ -156,7 +157,7 @@ mod test {
             51, 51, 0, 52, 55, 247, 204, 45, 44, 210, 132, 50, 206, 51,
         ];
         let (front, back) = data.split_at(data.len() / 2 + 1);
-        let mut queue = std::collections::VecDeque::with_capacity(data.len());
+        let mut queue = alloc::collections::VecDeque::with_capacity(data.len());
 
         // create a non-contiguous slice of memory in queue
         front.into_iter().copied().for_each(|x| queue.push_back(x));

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -148,7 +148,7 @@ impl HeapBuffer {
                 // * `new_size` will be > 0, we return early if the requested capacity is 0
                 // * Checked above if `new_size` overflowed when rounding to alignment
                 match ptr::NonNull::new(unsafe {
-                    std::alloc::realloc(self.ptr.as_ptr(), cur_layout, new_size)
+                    ::alloc::alloc::realloc(self.ptr.as_ptr(), cur_layout, new_size)
                 }) {
                     Some(ptr) => (new_cap, ptr),
                     None => return Err(()),
@@ -178,7 +178,7 @@ impl HeapBuffer {
                 // * The layout is the same because we checked that the capacity is on the heap
                 // * `new_size` will be > 0, we return early if the requested capacity is 0
                 // * Checked above if `new_size` overflowed when rounding to alignment
-                let cap_ptr = unsafe { std::alloc::realloc(adj_ptr, cur_layout, new_size) };
+                let cap_ptr = unsafe { alloc::alloc::realloc(adj_ptr, cur_layout, new_size) };
                 // Check if reallocation succeeded
                 if cap_ptr.is_null() {
                     return Err(());
@@ -332,7 +332,7 @@ pub fn deallocate_ptr(ptr: ptr::NonNull<u8>, cap: Capacity) {
 
 mod heap_capacity {
     use core::ptr;
-    use std::alloc;
+    use core::alloc;
 
     use super::StrBuffer;
 
@@ -343,13 +343,13 @@ mod heap_capacity {
 
         // SAFETY: `alloc(...)` has undefined behavior if the layout is zero-sized. We know the
         // layout can't be zero-sized though because we're always at least allocating one `usize`
-        let raw_ptr = unsafe { alloc::alloc(layout) };
+        let raw_ptr = unsafe { ::alloc::alloc::alloc(layout) };
 
         // Check to make sure our pointer is non-null, some allocators return null pointers instead
         // of panicking
         match ptr::NonNull::new(raw_ptr) {
             Some(ptr) => ptr,
-            None => alloc::handle_alloc_error(layout),
+            None => ::alloc::alloc::handle_alloc_error(layout),
         }
     }
 
@@ -360,7 +360,7 @@ mod heap_capacity {
     ///   must have `ptr -> [cap<usize> ; string<bytes>]`
     pub unsafe fn dealloc(ptr: ptr::NonNull<u8>, capacity: usize) {
         let layout = layout(capacity);
-        alloc::dealloc(ptr.as_ptr(), layout);
+        ::alloc::alloc::dealloc(ptr.as_ptr(), layout);
     }
 
     #[repr(C)]
@@ -382,7 +382,7 @@ mod heap_capacity {
 
 mod inline_capacity {
     use core::ptr;
-    use std::alloc;
+    use core::alloc;
 
     use super::StrBuffer;
 
@@ -396,13 +396,13 @@ mod inline_capacity {
         // SAFETY: `alloc(...)` has undefined behavior if the layout is zero-sized. We specify that
         // `capacity` must be > 0 as a constraint to uphold the safety of this method. If capacity
         // is greater than 0, then our layout will be non-zero-sized.
-        let raw_ptr = alloc::alloc(layout);
+        let raw_ptr = ::alloc::alloc::alloc(layout);
 
         // Check to make sure our pointer is non-null, some allocators return null pointers instead
         // of panicking
         match ptr::NonNull::new(raw_ptr) {
             Some(ptr) => ptr,
-            None => alloc::handle_alloc_error(layout),
+            None => ::alloc::alloc::handle_alloc_error(layout),
         }
     }
 
@@ -412,7 +412,7 @@ mod inline_capacity {
     /// * `ptr` must point to the start of a `HeapBuffer` whose capacity is on the inline
     pub unsafe fn dealloc(ptr: ptr::NonNull<u8>, capacity: usize) {
         let layout = layout(capacity);
-        alloc::dealloc(ptr.as_ptr(), layout);
+        ::alloc::alloc::dealloc(ptr.as_ptr(), layout);
     }
 
     #[repr(C)]

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -331,8 +331,10 @@ pub fn deallocate_ptr(ptr: ptr::NonNull<u8>, cap: Capacity) {
 }
 
 mod heap_capacity {
-    use core::ptr;
-    use core::alloc;
+    use core::{
+        alloc,
+        ptr,
+    };
 
     use super::StrBuffer;
 
@@ -381,8 +383,10 @@ mod heap_capacity {
 }
 
 mod inline_capacity {
-    use core::ptr;
-    use core::alloc;
+    use core::{
+        alloc,
+        ptr,
+    };
 
     use super::StrBuffer;
 

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -158,6 +158,7 @@ mod tests {
             InlineBuffer,
             MAX_SIZE,
         };
+        use alloc::string::String;
 
         #[test]
         fn test_into_array() {
@@ -196,7 +197,7 @@ mod tests {
             assert!(array[length..].iter().all(|b| *b == 0));
 
             // taking a string slice should give back the same string as the original
-            let ex_s = unsafe { std::str::from_utf8_unchecked(&array[..length]) };
+            let ex_s = unsafe { core::str::from_utf8_unchecked(&array[..length]) };
             assert_eq!(s, ex_s);
         }
     }

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -152,13 +152,14 @@ mod tests {
 
     #[cfg(feature = "smallvec")]
     mod smallvec {
+        use alloc::string::String;
+
         use quickcheck_macros::quickcheck;
 
         use crate::repr::{
             InlineBuffer,
             MAX_SIZE,
         };
-        use alloc::string::String;
 
         #[test]
         fn test_into_array() {

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -174,7 +174,7 @@ mod tests {
             assert!(array[length..].iter().all(|b| *b == 0));
 
             // taking a string slice should give back the same string as the original
-            let ex_s = unsafe { std::str::from_utf8_unchecked(&array[..length]) };
+            let ex_s = unsafe { core::str::from_utf8_unchecked(&array[..length]) };
             assert_eq!(s, ex_s);
         }
 

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,9 +1,9 @@
 //! Implementations of the [`FromIterator`] trait to make building [`Repr`]s more ergonomic
 
-use core::iter::FromIterator;
 use alloc::borrow::Cow;
-use alloc::string::String;
 use alloc::boxed::Box;
+use alloc::string::String;
+use core::iter::FromIterator;
 
 use super::{
     InlineBuffer,
@@ -141,8 +141,9 @@ impl<'a> FromIterator<Cow<'a, str>> for Repr {
 
 #[cfg(test)]
 mod tests {
-    use super::Repr;
     use alloc::string::String;
+
+    use super::Repr;
 
     #[test]
     fn short_char_iter() {

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -1,7 +1,9 @@
 //! Implementations of the [`FromIterator`] trait to make building [`Repr`]s more ergonomic
 
 use core::iter::FromIterator;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::string::String;
+use alloc::boxed::Box;
 
 use super::{
     InlineBuffer,
@@ -140,6 +142,7 @@ impl<'a> FromIterator<Cow<'a, str>> for Repr {
 #[cfg(test)]
 mod tests {
     use super::Repr;
+    use alloc::string::String;
 
     #[test]
     fn short_char_iter() {

--- a/compact_str/src/repr/last_utf8_char.rs
+++ b/compact_str/src/repr/last_utf8_char.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 /// [`LastUtf8Char`] is an unsigned 8-bit integer data type that has a valid range of `[0, 216]`.
 /// Excluding `[217, 255]` allows the Rust compiler to use these values as niches.
 ///
@@ -239,4 +241,4 @@ pub enum LastUtf8Char {
 }
 
 static_assertions::assert_eq_size!(LastUtf8Char, Option<LastUtf8Char>, u8);
-static_assertions::const_assert!(std::mem::size_of::<String>() <= 24);
+static_assertions::const_assert!(core::mem::size_of::<String>() <= 24);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -3,7 +3,8 @@ use core::{
     mem,
     ptr,
 };
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
 
 #[cfg(feature = "bytes")]
 mod bytes;
@@ -22,10 +23,11 @@ use capacity::Capacity;
 use heap::HeapBuffer;
 use inline::InlineBuffer;
 use last_utf8_char::LastUtf8Char;
+use alloc::string::String;
 pub use traits::IntoRepr;
 
 /// The max size of a string we can fit inline
-pub const MAX_SIZE: usize = std::mem::size_of::<String>();
+pub const MAX_SIZE: usize = core::mem::size_of::<String>();
 /// Used as a discriminant to identify different variants
 pub const HEAP_MASK: u8 = LastUtf8Char::Heap as u8;
 /// When our string is stored inline, we represent the length of the string in the last byte, offset
@@ -700,6 +702,9 @@ impl Extend<String> for Repr {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
+
     use quickcheck_macros::quickcheck;
     use test_case::test_case;
 

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -79,7 +79,7 @@ impl Repr {
             let inline = InlineBuffer::new_const(text);
             Repr::from_inline(inline)
         } else {
-            panic!("Inline string was too long, max length is `std::mem::size_of::<CompactString>()` bytes");
+            panic!("Inline string was too long, max length is `core::mem::size_of::<CompactString>()` bytes");
         }
     }
 

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1,10 +1,10 @@
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
 use core::str::Utf8Error;
 use core::{
     mem,
     ptr,
 };
-use alloc::borrow::Cow;
-use alloc::boxed::Box;
 
 #[cfg(feature = "bytes")]
 mod bytes;
@@ -19,11 +19,12 @@ mod last_utf8_char;
 mod num;
 mod traits;
 
+use alloc::string::String;
+
 use capacity::Capacity;
 use heap::HeapBuffer;
 use inline::InlineBuffer;
 use last_utf8_char::LastUtf8Char;
-use alloc::string::String;
 pub use traits::IntoRepr;
 
 /// The max size of a string we can fit inline
@@ -702,7 +703,10 @@ impl Extend<String> for Repr {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::{String, ToString};
+    use alloc::string::{
+        String,
+        ToString,
+    };
     use alloc::vec::Vec;
 
     use quickcheck_macros::quickcheck;

--- a/compact_str/src/repr/num.rs
+++ b/compact_str/src/repr/num.rs
@@ -418,6 +418,7 @@ impl NumChars for isize {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use super::IntoRepr;
 
     #[test]

--- a/compact_str/src/repr/num.rs
+++ b/compact_str/src/repr/num.rs
@@ -419,6 +419,7 @@ impl NumChars for isize {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
+
     use super::IntoRepr;
 
     #[test]

--- a/compact_str/src/repr/traits.rs
+++ b/compact_str/src/repr/traits.rs
@@ -44,6 +44,7 @@ impl IntoRepr for char {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
+
     use quickcheck_macros::quickcheck;
 
     use super::IntoRepr;

--- a/compact_str/src/repr/traits.rs
+++ b/compact_str/src/repr/traits.rs
@@ -43,6 +43,7 @@ impl IntoRepr for char {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use quickcheck_macros::quickcheck;
 
     use super::IntoRepr;

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -315,9 +315,9 @@ fn proptest_from_utf8_unchecked(#[strategy(rand_bytes())] bytes: Vec<u8>) {
 
     // check if we were valid UTF-8, if so, assert the data written into the CompactString is
     // correct
-    let data_is_valid = std::str::from_utf8(&bytes);
-    let compact_is_valid = std::str::from_utf8(compact.as_bytes());
-    let std_str_is_valid = std::str::from_utf8(std_str.as_bytes());
+    let data_is_valid = core::str::from_utf8(&bytes);
+    let compact_is_valid = core::str::from_utf8(compact.as_bytes());
+    let std_str_is_valid = core::str::from_utf8(std_str.as_bytes());
 
     match (data_is_valid, compact_is_valid, std_str_is_valid) {
         (Ok(d), Ok(c), Ok(s)) => {
@@ -1598,5 +1598,8 @@ fn multiple_nieches_test() {
         Unsigned(usize),
         Null,
     }
-    assert_eq!(core::mem::size_of::<Value>(), std::mem::size_of::<String>());
+    assert_eq!(
+        core::mem::size_of::<Value>(),
+        core::mem::size_of::<String>()
+    );
 }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1,7 +1,10 @@
 use core::slice;
-use std::borrow::Cow;
-use std::num;
-use std::str::FromStr;
+use core::num;
+use core::str::FromStr;
+use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::boxed::Box;
 
 use proptest::collection::SizeRange;
 use proptest::prelude::*;
@@ -478,7 +481,6 @@ fn test_from_str_trait() {
 #[cfg_attr(target_pointer_width = "32", ignore)]
 fn test_from_char_iter() {
     let s = "\u{0} 0 \u{0}a𐀀𐀀 𐀀a𐀀";
-    println!("{}", s.len());
     let compact: CompactString = s.chars().into_iter().collect();
 
     assert!(!compact.is_heap_allocated());
@@ -1556,7 +1558,7 @@ fn test_collect() {
 fn test_into_cow() {
     let og = "aaa";
     let compact = CompactString::new(og);
-    let cow: std::borrow::Cow<'_, str> = compact.into();
+    let cow: alloc::borrow::Cow<'_, str> = compact.into();
 
     assert_eq!(og, cow);
 }
@@ -1591,5 +1593,5 @@ fn multiple_nieches_test() {
         Unsigned(usize),
         Null,
     }
-    assert_eq!(std::mem::size_of::<Value>(), std::mem::size_of::<String>());
+    assert_eq!(core::mem::size_of::<Value>(), std::mem::size_of::<String>());
 }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1,10 +1,15 @@
-use core::slice;
-use core::num;
-use core::str::FromStr;
 use alloc::borrow::Cow;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
 use alloc::boxed::Box;
+use alloc::string::{
+    String,
+    ToString,
+};
+use alloc::vec::Vec;
+use core::str::FromStr;
+use core::{
+    num,
+    slice,
+};
 
 use proptest::collection::SizeRange;
 use proptest::prelude::*;

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -3,6 +3,7 @@ use core::fmt::{
     Write,
 };
 use core::num;
+use alloc::string::String;
 
 use castaway::{
     match_type,
@@ -193,6 +194,8 @@ where
 #[cfg(test)]
 mod tests {
     use core::num;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
 
     use proptest::prelude::*;
     use test_strategy::proptest;

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -1,9 +1,9 @@
+use alloc::string::String;
 use core::fmt::{
     self,
     Write,
 };
 use core::num;
-use alloc::string::String;
 
 use castaway::{
     match_type,
@@ -193,9 +193,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::num;
-    use alloc::string::{String, ToString};
+    use alloc::string::{
+        String,
+        ToString,
+    };
     use alloc::vec::Vec;
+    use core::num;
 
     use proptest::prelude::*;
     use test_strategy::proptest;

--- a/compact_str/src/unicode_data.rs
+++ b/compact_str/src/unicode_data.rs
@@ -8,7 +8,7 @@ fn skip_search<const SOR: usize, const OFFSETS: usize>(
     offsets: &[u8; OFFSETS],
 ) -> bool {
     // Note that this *cannot* be past the end of the array, as the last
-    // element is greater than std::char::MAX (the largest possible needle).
+    // element is greater than char::MAX (the largest possible needle).
     //
     // So, we cannot have found it (i.e. Ok(idx) + 1 != length) and the correct
     // location cannot be past it, so Err(idx) != length either.


### PR DESCRIPTION
I have a compiler/interpreter project I'm developing for embedded systems, and this crate looks perfect for saving a ton of heap space and gaining locality for my many symbol tables. The only issue is that it needs to be `no_std` and #29 was closed a long time ago. So I've gone ahead and redone that work here.

It's pretty much all just a switch from `std` to `core` or `alloc` versions of things, plus a new (default) feature flag called `std` that enables a few small things like operations on `OsString` and the like.

The new version passes all test cases in standard mode, successfully builds in no-std mode, and miri has no issues with anything.