### PR TITLE
MSRV: Bump to 1.59

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -58,7 +58,7 @@ jobs:
         # Instead of pinning to a specific version of `arbitrary` or `proptest`, we'll let user's 
         # deps decide the version since the API should still be semver compatible
         run: |
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.57..
+          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.59..
 
   feature_powerset:
     name: cargo check feature-powerset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Upcoming
-... all released!
+* Update MSRV to 1.59
 
 # 0.7.0
 ### February 21, 2023

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://crates.io/crates/compact_str">
     <img alt="version on crates.io" src="https://img.shields.io/crates/v/compact_str"/>
   </a>
-  <img alt="Minimum supported Rust Version: 1.57" src="https://img.shields.io/badge/MSRV-1.57-blueviolet">
+  <img alt="Minimum supported Rust Version: 1.59" src="https://img.shields.io/badge/MSRV-1.59-blueviolet">
   <a href="LICENSE">
     <img alt="mit license" src="https://img.shields.io/crates/l/compact_str"/>
   </a>
@@ -139,7 +139,7 @@ Specifically, the last byte on the stack for a `CompactString` has the following
 ### Testing
 Strings and unicode can be quite messy, even further, we're working with things at the bit level. `compact_str` has an _extensive_ test suite comprised of unit testing, property testing, and fuzz testing, to ensure our invariants are upheld. We test across all major OSes (Windows, macOS, and Linux), architectures (64-bit and 32-bit), and endian-ness (big endian and little endian).
 
-Fuzz testing is run with `libFuzzer`, `AFL++`, *and* `honggfuzz`, with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every Rust compiler since `v1.57` to ensure support for our minimum supported Rust version (MSRV).
+Fuzz testing is run with `libFuzzer`, `AFL++`, *and* `honggfuzz`, with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every Rust compiler since `v1.59` to ensure support for our minimum supported Rust version (MSRV).
 
 ### `unsafe` code
 `CompactString` uses a bit of unsafe code because we manually define what variant we are, so unlike an enum, the compiler can't guarantee what value is actually stored.


### PR DESCRIPTION
This PR bumps the MSRV from `1.57` to `1.59`. There are some new features we want to use and given 1.59 was released almost 18 months ago, I think this version is sufficiently old.