### PR TITLE
Remove branches from `Repr::as_slice()`

### DIFF
--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -419,7 +419,7 @@ impl Repr {
         //
         // Note: We should never add an `else` statement here, keeping the conditional simple allows
         // the compiler to optimize this to a conditional-move instead of a branch
-        if last_byte == HEAP_MASK || last_byte == STATIC_STR_MASK {
+        if last_byte >= HEAP_MASK {
             len = len_heap;
         }
 


### PR DESCRIPTION
This change optimizes `Repr::as_slice()`, which is used e.g. in `CompactStr::as_str()`.

This is done by replacing `last_byte == HEAP_MASK || last_byte == STATIC_STR_MASK` with `last_byte >= HEAP_MASK`, because we know that there can be no other case.

Also is `self.last_byte()` is called multiple times instead of using the "cached" value. This lets the optimzer decide whether to access the same variable again or use a register. And reassigning the variable `pointer` for the `>= HEAP_MASK` case is done immediately. Both changes together reduce the "percived" register pressure of the compiler, so it will be more eager to omit branches.

Generated assembly before:

```asm
0000000000000000 <compact_str::deref_compact_string>:
   0: 48 89 f9             mov    %rdi,%rcx
   3: 8a 47 17             mov    0x17(%rdi),%al
   6: 8d 50 40             lea    0x40(%rax),%edx
   9: 0f b6 f2             movzbl %dl,%esi
   c: 40 80 fe 18          cmp    $0x18,%sil
  10: ba 18 00 00 00       mov    $0x18,%edx
  15: 0f 42 d6             cmovb  %esi,%edx
  18: 24 fe                and    $0xfe,%al
  1a: 3c d8                cmp    $0xd8,%al
  1c: 75 09                jne    27 <compact_str::deref_compact_string+0x27>
  1e: 48 8b 51 08          mov    0x8(%rcx),%rdx
  22: 48 8b 09             mov    (%rcx),%rcx
  25: eb 03                jmp    2a <compact_str::deref_compact_string+0x2a>
  27: 0f b6 d2             movzbl %dl,%edx
  2a: 48 89 c8             mov    %rcx,%rax
  2d: c3                   ret
```

With the change:

```asm
0000000000000000 <compact_str::deref_compact_string>:
   0: 8a 47 17             mov    0x17(%rdi),%al
   3: 8d 48 40             lea    0x40(%rax),%ecx
   6: 0f b6 d1             movzbl %cl,%edx
   9: 80 fa 18             cmp    $0x18,%dl
   c: b9 18 00 00 00       mov    $0x18,%ecx
  11: 0f 42 ca             cmovb  %edx,%ecx
  14: 3c d8                cmp    $0xd8,%al
  16: 48 8b 07             mov    (%rdi),%rax
  19: 0f b6 c9             movzbl %cl,%ecx
  1c: 48 0f 43 4f 08       cmovae 0x8(%rdi),%rcx
  21: 48 0f 42 c7          cmovb  %rdi,%rax
  25: 48 89 ca             mov    %rcx,%rdx
  28: c3                   ret
```

Resolves #268.