### PR TITLE
cleanup: Exclude `compact_str` from workspace cleanup MSRV workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,12 @@ jobs:
         run: |
           cargo test --all-features --manifest-path=compact_str/Cargo.toml
 
-  example-bytes:
-    name: example - bytes
+  examples:
+    name: example
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ex: ["bytes", "macros", "serde", "traits"] 
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -168,93 +171,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-bytes
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-${{ matrix.ex }}
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
             ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
       - uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path examples/bytes/Cargo.toml
-
-  example-macros:
-    name: example - macros
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-macros
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/macros/Cargo.toml
-
-  example-serde:
-    name: example - serde
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-serde
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/serde/Cargo.toml
-  
-  example-traits:
-    name: example - traits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example-traits
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly-example
-            ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-nightly
-      - uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path examples/traits/Cargo.toml
-
+          args: --manifest-path examples/${{ matrix.ex }}/Cargo.toml

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -20,9 +20,12 @@ env:
   MIRIFAGS: "-Zmiri-tag-raw-pointers -Zmiri-check-number-validity"
 
 jobs:
-  windows:
-    name: Windows
-    runs-on: windows-latest
+  x_plat_os:
+    name: x_plat_os
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         name: Checkout Repo
@@ -41,40 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-windows-v3
-      - uses: actions-rs/cargo@v1
-        name: cargo test
-        with:
-          command: test
-          args: --release --all-features --manifest-path=compact_str/Cargo.toml -- --include-ignored
-      - uses: actions-rs/cargo@v1
-        name: cargo test miri
-        with:
-          command: miri
-          args: test --all-features --manifest-path=compact_str/Cargo.toml
-
-  macos:
-    name: macOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout Repo
-      - uses: actions-rs/toolchain@v1
-        name: Install Rust
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: miri
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-macos-v3
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-${{ matrix.os }}
       - uses: actions-rs/cargo@v1
         name: cargo test
         with:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   msrv:
-    name: cargo test msrv..
+    name: cargo check msrv 1.59..
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,6 +59,7 @@ jobs:
         # deps decide the version since the API should still be semver compatible
         run: |
           cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.59..
+          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec,proptest,arbitrary --manifest-path=compact_str/Cargo.toml --version-range 1.64..
 
   feature_powerset:
     name: cargo check feature-powerset

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/macros",
     "examples/serde",
     "examples/traits",
-    "compact_str",
     "fuzz",
 ]
+
+exclude = ["compact_str"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -33,22 +33,21 @@ castaway = { version = "0.2", default-features = false }
 
 cfg-if = "1"
 itoa = "1"
+rustversion = "1"
 ryu = "1"
 static_assertions = "1"
 
-rustversion = "1"
-
 [dev-dependencies]
 cfg-if = "1"
-proptest = { version = "1.0.*", default-features = false, features = ["std"] }
+proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = { version = "1", default-features = false }
 quickcheck_macros = "1"
-rayon = "1.6.0"
+rayon = "1"
 rkyv = { version = "0.7", default-features = false, features = ["alloc", "size_32"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 test-case = "3"
-test-strategy = "0.2"
+test-strategy = "0.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -107,8 +107,6 @@ impl Capacity {
 
 #[cfg(test)]
 mod tests {
-    use rayon::prelude::*;
-
     use super::Capacity;
 
     #[test]
@@ -147,9 +145,12 @@ mod tests {
         assert_eq!(16777215, after);
     }
 
+    #[rustversion::since(1.63)]
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_all_valid_32bit_values() {
+        use rayon::prelude::*;
+
         #[cfg(target_pointer_width = "32")]
         assert_eq!(16_777_214, super::MAX_VALUE);
 

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -122,11 +122,12 @@ impl InlineBuffer {
 
 #[cfg(test)]
 mod tests {
-    use rayon::prelude::*;
-
+    #[rustversion::since(1.63)]
     #[test]
     #[ignore] // we run this in CI, but unless you're compiling in release, this takes a while
     fn test_unused_utf8_bytes() {
+        use rayon::prelude::*;
+
         // test to validate for all char the first and last bytes are never within a specified range
         // note: according to the UTF-8 spec it shouldn't be, but we double check that here
         (0..u32::MAX).into_par_iter().for_each(|i| {

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1765,6 +1765,9 @@ fn test_from_string_buffer_inlines_on_clone() {
     assert!(!b.is_heap_allocated());
 }
 
+// This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first
+// released in Rust 1.65.
+#[rustversion::since(1.65)]
 #[test]
 fn multiple_nieches_test() {
     #[allow(unused)]


### PR DESCRIPTION
This PR excludes the `compact_str` crate from the workspace to help relax the dependency resolution. It also cleans up the MSRV workflow now that dependency resolution is relaxed.