### PR TITLE
ci: Re-add multiple arch workflows

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -56,174 +56,53 @@ jobs:
           command: miri
           args: test --all-features --manifest-path=compact_str/Cargo.toml
 
-  # TODO(parkmycar): Re-enable before release of next version.
-  #
-  # linux_32bit:
-  #   name: Linux 32-bit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         toolchain: nightly
-  #         target: i686-unknown-linux-gnu
-  #         override: true
-  #         components: miri
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-32bit-v2
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         use-cross: true
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test miri
-  #       with:
-  #         command: miri
-  #         args: test --all-features --manifest-path=compact_str/Cargo.toml --target i686-unknown-linux-gnu
-
-  # linux_mips_32bit:
-  #   name: Linux MIPS Big Endian 32-bit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         toolchain: nightly
-  #         target: mips-unknown-linux-gnu
-  #         override: true
-  #         components: miri
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-mips-32bit-v2
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         use-cross: true
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml --target mips-unknown-linux-gnu
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test miri
-  #       with:
-  #         command: miri
-  #         args: test --all-features --manifest-path=compact_str/Cargo.toml --target mips-unknown-linux-gnu
-
-  # linux_mips_le_32bit:
-  #   name: Linux MIPS Little Endian 32-bit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         toolchain: nightly
-  #         target: mipsel-unknown-linux-gnu
-  #         override: true
-  #         components: miri
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-mips-le-32bit-v2
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         use-cross: true
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test miri
-  #       with:
-  #         command: miri
-  #         args: test --all-features --manifest-path=compact_str/Cargo.toml --target mipsel-unknown-linux-gnu
-
-  # linux_powerpc_bit:
-  #   name: Linux PowerPC Big Endian 32-bit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         toolchain: nightly
-  #         target: powerpc-unknown-linux-gnu
-  #         override: true
-  #         components: miri
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-powerpc-32bit-v2
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         use-cross: true
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml --target powerpc-unknown-linux-gnu
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test miri
-  #       with:
-  #         command: miri
-  #         args: test --all-features --manifest-path=compact_str/Cargo.toml --target powerpc-unknown-linux-gnu
-
-  # linux_powerpc_le_64bit:
-  #   name: Linux PowerPC Little Endian 64-bit
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       name: Checkout Repo
-  #     - uses: actions-rs/toolchain@v1
-  #       name: Install Rust
-  #       with:
-  #         toolchain: nightly
-  #         target: powerpc64le-unknown-linux-gnu
-  #         override: true
-  #         components: miri
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cargo/bin/
-  #           ~/.cargo/registry/index/
-  #           ~/.cargo/registry/cache/
-  #           ~/.cargo/git/db/
-  #           target/
-  #         key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-linux-powerpc-le-64bit-v2
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test
-  #       with:
-  #         use-cross: true
-  #         command: test
-  #         args: --release --all-features --manifest-path=compact_str/Cargo.toml --target powerpc64le-unknown-linux-gnu
-  #     - uses: actions-rs/cargo@v1
-  #       name: cargo test miri
-  #       with:
-  #         command: miri
-  #         args: test --all-features --manifest-path=compact_str/Cargo.toml --target powerpc64le-unknown-linux-gnu
+  x_plat_arch:
+    name: x_plat_arch
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          # 32-bit Little Endian
+          "i686-unknown-linux-gnu",
+          "arm-unknown-linux-gnueabihf",
+          "armv7-unknown-linux-gnueabihf",
+          # 32-bit Big Endian
+          "powerpc-unknown-linux-gnu",
+          # 64-bit Little Endian
+          "powerpc64le-unknown-linux-gnu",
+          "aarch64-unknown-linux-gnu",
+          # 64-bit Big Endian
+          "powerpc64-unknown-linux-gnu",
+        ]
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Repo
+      - uses: actions-rs/toolchain@v1
+        name: Install Rust
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: ${{ matrix.target }}
+          override: true
+          components: miri
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-x-plat-${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          use-cross: true
+          command: test
+          args: --release --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}
+      - uses: actions-rs/cargo@v1
+        name: cargo test miri
+        with:
+          command: miri
+          args: test --all-features --manifest-path=compact_str/Cargo.toml --target ${{ matrix.target }}

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -401,7 +401,17 @@ impl Repr {
         // Force the compiler to read the variable, so it won't put the reading in a branch.
         let len_heap = self.1;
         // SAFETY: This assembly instruction is a noop that only affects the instruction ordering.
-        #[cfg(not(miri))]
+        #[cfg(all(
+            not(miri),
+            any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "arm",
+                target_arch = "aarch64",
+                target_arch = "loongarch",
+                target_arch = "riscv",
+            )
+        ))]
         unsafe {
             core::arch::asm!(
                 "/* {len_heap} */",


### PR DESCRIPTION
This PR re-enables the CI workflows that target multiple different architectures using `cross`.