### PR TITLE
version: 0.8.0-beta

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compact_str"
 description = "A memory efficient string type that transparently stores strings on the stack, when possible"
-version = "0.7.1"
+version = "0.8.0-beta"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Given the amount of user facing improvements that have been made to `compact_str` recently, e.g. representing `&'static str` in a `CompactString` and `no_std` support, I want to get a release out. 

Hard blocker before we can release this version:
* https://github.com/ParkMyCar/compact_str/issues/313

But there are a few blockers I want to solve before "promoting" to a full release, specifically:
* https://github.com/ParkMyCar/compact_str/issues/304
* https://github.com/ParkMyCar/compact_str/issues/310
* https://github.com/ParkMyCar/compact_str/issues/311
