### PR TITLE
lint: Run clippy on tests

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,10 +28,15 @@ jobs:
       - run: rustup component add rustfmt
         name: Add rustfmt
       - uses: actions-rs/cargo@v1
-        name: Run rustfmt
+        name: Run rustfmt Workspace
         with:
           command: fmt
           args: --all -- --check
+      - uses: actions-rs/cargo@v1
+        name: Run rustfmt compact_str
+        with:
+          command: fmt
+          args: --all --manifest-path compact_str/Cargo.toml -- --check
 
   clippy:
     name: cargo clippy
@@ -48,9 +53,15 @@ jobs:
       - run: rustup component add clippy
         name: Add clippy
       - uses: actions-rs/cargo@v1
-        name: Run clippy
+        name: Run clippy Workspace
         with:
           command: clippy
+          args: --tests
+      - uses: actions-rs/cargo@v1
+        name: Run clippy compact_str
+        with:
+          command: clippy
+          args: --tests --manifest-path compact_str/Cargo.toml
 
   doc:
     name: cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "examples/traits",
     "fuzz",
 ]
-
 exclude = ["compact_str"]
+
+resolver = "2"

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -536,7 +536,7 @@ mod test {
     #[test]
     fn test_realloc_shrink_heap_to_inline() {
         // TODO: test this case
-        assert!(true)
+        assert_eq!(1, 1);
     }
 
     #[test_case(&[42; 0]; "empty")]

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -138,9 +138,8 @@ mod tests {
                 }
 
                 // check ranges for last byte
-                match buf[c.len_utf8() - 1] {
-                    x @ 192..=255 => panic!("last byte within 192..=255, {}", x),
-                    _ => (),
+                if let x @ 192..=255 = buf[c.len_utf8() - 1] {
+                    panic!("last byte within 192..=255, {}", x)
                 }
             }
         })

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -839,10 +839,7 @@ mod tests {
         assert_eq!(r.len(), s_len);
         assert_eq!(r.as_str(), s_str.as_str());
 
-        if s_cap == 0 {
-            // we should always inline the string, if the length of the source string is 0
-            assert!(!r.is_heap_allocated());
-        } else if try_to_inline && s_len <= MAX_SIZE {
+        if s_cap == 0 || (try_to_inline && s_len <= MAX_SIZE) {
             // we should inline the string, if we were asked to, and the length of the string would
             // fit inline, meaning we would truncate capacity
             assert!(!r.is_heap_allocated());

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -143,9 +143,7 @@ mod test {
 
     #[test]
     fn test_rand() {
-        let mut nums: Vec<_> = (0..10_000)
-            .map(|i| generate_rand_max_num_actions(i))
-            .collect();
+        let mut nums: Vec<_> = (0..10_000).map(generate_rand_max_num_actions).collect();
 
         let min = nums.iter().min().copied().unwrap();
         let max = nums.iter().max().copied().unwrap();


### PR DESCRIPTION
This PR starts running clippy on tests, runs fmt and clippy on `compact_str`, which accidentally regressed when we removed `compact_str` from the workspace.