### PR TITLE
Make (re)allocations fallible

### DIFF
--- a/compact_str/src/repr/bytes.rs
+++ b/compact_str/src/repr/bytes.rs
@@ -53,12 +53,12 @@ impl Repr {
                 // If we hit the edge case, reserve additional space to make the repr becomes heap
                 // allocated, which prevents us from writing this last byte inline
                 if last_byte >= 0b11000000 {
-                    repr.reserve(MAX_SIZE + 1);
+                    repr.reserve(MAX_SIZE + 1).unwrap();
                 }
             }
 
             // reserve at least enough space to fit this chunk
-            repr.reserve(chunk_len);
+            repr.reserve(chunk_len).unwrap();
 
             // SAFETY: The caller is responsible for making sure the provided buffer is UTF-8. This
             // invariant is documented in the public API

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -1,3 +1,4 @@
+use core::alloc::Layout;
 use core::{
     cmp,
     mem,
@@ -9,6 +10,7 @@ use super::{
     Repr,
     MAX_SIZE,
 };
+use crate::ReserveError;
 
 /// The minimum size we'll allocate on the heap is one usize larger than our max inline size
 const MIN_HEAP_SIZE: usize = MAX_SIZE + mem::size_of::<usize>();
@@ -38,9 +40,9 @@ static_assertions::assert_eq_size!(HeapBuffer, Repr);
 impl HeapBuffer {
     /// Create a [`HeapBuffer`] with the provided text
     #[inline]
-    pub fn new(text: &str) -> Self {
+    pub fn new(text: &str) -> Result<Self, ReserveError> {
         let len = text.len();
-        let (cap, ptr) = allocate_ptr(len);
+        let (cap, ptr) = allocate_ptr(len)?;
 
         // copy our string into the buffer we just allocated
         //
@@ -49,16 +51,16 @@ impl HeapBuffer {
         // length. We also know they're non-overlapping because `dest` is newly allocated
         unsafe { ptr.as_ptr().copy_from_nonoverlapping(text.as_ptr(), len) };
 
-        HeapBuffer { ptr, len, cap }
+        Ok(HeapBuffer { ptr, len, cap })
     }
 
     /// Create an empty [`HeapBuffer`] with a specific capacity
     #[inline]
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Result<Self, ReserveError> {
         let len = 0;
-        let (cap, ptr) = allocate_ptr(capacity);
+        let (cap, ptr) = allocate_ptr(capacity)?;
 
-        HeapBuffer { ptr, len, cap }
+        Ok(HeapBuffer { ptr, len, cap })
     }
 
     /// Create a [`HeapBuffer`] with `text` that has _at least_ `additional` bytes of capacity
@@ -66,10 +68,10 @@ impl HeapBuffer {
     /// To prevent frequent re-allocations, this method will create a [`HeapBuffer`] with a capacity
     /// of `text.len() + additional` or `text.len() * 1.5`, whichever is greater
     #[inline]
-    pub fn with_additional(text: &str, additional: usize) -> Self {
+    pub fn with_additional(text: &str, additional: usize) -> Result<Self, ReserveError> {
         let len = text.len();
         let new_capacity = amortized_growth(len, additional);
-        let (cap, ptr) = allocate_ptr(new_capacity);
+        let (cap, ptr) = allocate_ptr(new_capacity)?;
 
         // copy our string into the buffer we just allocated
         //
@@ -78,7 +80,7 @@ impl HeapBuffer {
         // length. We also know they're non-overlapping because `dest` is newly allocated
         unsafe { ptr.as_ptr().copy_from_nonoverlapping(text.as_ptr(), len) };
 
-        HeapBuffer { ptr, len, cap }
+        Ok(HeapBuffer { ptr, len, cap })
     }
 
     /// Return the capacity of the [`HeapBuffer`]
@@ -235,7 +237,7 @@ impl HeapBuffer {
 impl Clone for HeapBuffer {
     fn clone(&self) -> Self {
         // Create a new HeapBuffer with the same capacity as the original
-        let mut new = Self::with_capacity(self.capacity());
+        let mut new = Self::with_capacity(self.capacity()).unwrap();
 
         // SAFETY:
         // * `src` and `dst` don't overlap because we just created `dst`
@@ -265,7 +267,7 @@ impl Drop for HeapBuffer {
 /// Returns a [`Capacity`] that either indicates the capacity is stored on the heap, or is stored
 /// in the `Capacity` itself.
 #[inline]
-pub fn allocate_ptr(capacity: usize) -> (Capacity, ptr::NonNull<u8>) {
+pub fn allocate_ptr(capacity: usize) -> Result<(Capacity, ptr::NonNull<u8>), ReserveError> {
     // We allocate at least MIN_HEAP_SIZE bytes because we need to allocate at least one byte
     let capacity = capacity.max(MIN_HEAP_SIZE);
     let cap = Capacity::new(capacity);
@@ -275,9 +277,10 @@ pub fn allocate_ptr(capacity: usize) -> (Capacity, ptr::NonNull<u8>) {
     debug_assert!(capacity > 0);
 
     #[cold]
-    fn allocate_with_capacity_on_heap(capacity: usize) -> ptr::NonNull<u8> {
+    fn allocate_with_capacity_on_heap(capacity: usize) -> Result<ptr::NonNull<u8>, ReserveError> {
         // write our capacity onto the heap
-        let ptr = heap_capacity::alloc(capacity);
+        // SAFETY: we know that the capacity is not zero
+        let ptr = unsafe { heap_capacity::alloc(capacity)? };
         // SAFETY:
         // * `src` and `dst` don't overlap and are both valid for `usize` bytes
         unsafe {
@@ -289,7 +292,7 @@ pub fn allocate_ptr(capacity: usize) -> (Capacity, ptr::NonNull<u8>) {
         };
         let raw_ptr = ptr.as_ptr().wrapping_add(core::mem::size_of::<usize>());
         // SAFETY: We know `raw_ptr` is non-null because we just created it
-        unsafe { ptr::NonNull::new_unchecked(raw_ptr) }
+        Ok(unsafe { ptr::NonNull::new_unchecked(raw_ptr) })
     }
 
     let ptr = if cap.is_heap() {
@@ -298,7 +301,7 @@ pub fn allocate_ptr(capacity: usize) -> (Capacity, ptr::NonNull<u8>) {
         unsafe { inline_capacity::alloc(capacity) }
     };
 
-    (cap, ptr)
+    Ok((cap, ptr?))
 }
 
 /// Deallocates a buffer on the heap, handling when the capacity is also stored on the heap
@@ -330,29 +333,39 @@ pub fn deallocate_ptr(ptr: ptr::NonNull<u8>, cap: Capacity) {
     }
 }
 
+/// SAFETY: `layout` must not be zero sized
+#[inline]
+pub unsafe fn do_alloc(layout: Layout) -> Result<ptr::NonNull<u8>, ReserveError> {
+    debug_assert!(layout.size() > 0);
+
+    // SAFETY: `alloc(...)` has undefined behavior if the layout is zero-sized. We specify that
+    // `capacity` must be > 0 as a constraint to uphold the safety of this method. If capacity
+    // is greater than 0, then our layout will be non-zero-sized.
+    let raw_ptr = ::alloc::alloc::alloc(layout);
+
+    // Check to make sure our pointer is non-null.
+    // Implementations are encouraged to return null on memory exhaustion rather than aborting.
+    match ptr::NonNull::new(raw_ptr) {
+        Some(ptr) => Ok(ptr),
+        None => Err(ReserveError(())),
+    }
+}
+
 mod heap_capacity {
     use core::{
         alloc,
         ptr,
     };
 
-    use super::StrBuffer;
+    use super::{
+        do_alloc,
+        StrBuffer,
+    };
+    use crate::ReserveError;
 
-    #[inline]
-    pub fn alloc(capacity: usize) -> ptr::NonNull<u8> {
-        let layout = layout(capacity);
-        debug_assert!(layout.size() > 0);
-
-        // SAFETY: `alloc(...)` has undefined behavior if the layout is zero-sized. We know the
-        // layout can't be zero-sized though because we're always at least allocating one `usize`
-        let raw_ptr = unsafe { ::alloc::alloc::alloc(layout) };
-
-        // Check to make sure our pointer is non-null, some allocators return null pointers instead
-        // of panicking
-        match ptr::NonNull::new(raw_ptr) {
-            Some(ptr) => ptr,
-            None => ::alloc::alloc::handle_alloc_error(layout),
-        }
+    /// SAFETY: `capacity` must not be zero
+    pub unsafe fn alloc(capacity: usize) -> Result<ptr::NonNull<u8>, ReserveError> {
+        do_alloc(layout(capacity))
     }
 
     /// Deallocates a pointer which references a `HeapBuffer` whose capacity is on the heap
@@ -388,26 +401,16 @@ mod inline_capacity {
         ptr,
     };
 
-    use super::StrBuffer;
+    use super::{
+        do_alloc,
+        StrBuffer,
+    };
+    use crate::ReserveError;
 
     /// # SAFETY:
     /// * `capacity` must be > 0
-    #[inline]
-    pub unsafe fn alloc(capacity: usize) -> ptr::NonNull<u8> {
-        let layout = layout(capacity);
-        debug_assert!(layout.size() > 0);
-
-        // SAFETY: `alloc(...)` has undefined behavior if the layout is zero-sized. We specify that
-        // `capacity` must be > 0 as a constraint to uphold the safety of this method. If capacity
-        // is greater than 0, then our layout will be non-zero-sized.
-        let raw_ptr = ::alloc::alloc::alloc(layout);
-
-        // Check to make sure our pointer is non-null, some allocators return null pointers instead
-        // of panicking
-        match ptr::NonNull::new(raw_ptr) {
-            Some(ptr) => ptr,
-            None => ::alloc::alloc::handle_alloc_error(layout),
-        }
+    pub unsafe fn alloc(capacity: usize) -> Result<ptr::NonNull<u8>, ReserveError> {
+        do_alloc(layout(capacity))
     }
 
     /// Deallocates a pointer which references a `HeapBuffer` whose capacity is stored inline
@@ -448,7 +451,7 @@ mod test {
 
     #[test]
     fn test_min_capacity() {
-        let h = HeapBuffer::new("short");
+        let h = HeapBuffer::new("short").unwrap();
         assert_eq!(h.capacity(), MIN_HEAP_SIZE);
     }
 
@@ -458,7 +461,7 @@ mod test {
     fn test_capacity(buf: &[u8]) {
         // we know the buffer is valid UTF-8
         let s = unsafe { core::str::from_utf8_unchecked(buf) };
-        let h = HeapBuffer::new(s);
+        let h = HeapBuffer::new(s).unwrap();
 
         assert_eq!(h.capacity(), core::cmp::max(s.len(), MIN_HEAP_SIZE));
     }
@@ -471,7 +474,7 @@ mod test {
     fn test_realloc(buf: &[u8], realloc: usize, result: Result<usize, usize>) {
         // we know the buffer is valid UTF-8
         let s = unsafe { core::str::from_utf8_unchecked(buf) };
-        let mut h = HeapBuffer::new(s);
+        let mut h = HeapBuffer::new(s).unwrap();
 
         // reallocate, asserting our result
         let expected_cap = match result {
@@ -486,7 +489,7 @@ mod test {
     fn test_realloc_inline_to_heap() {
         // we know the buffer is valid UTF-8
         let s = unsafe { core::str::from_utf8_unchecked(&[42; 128]) };
-        let mut h = HeapBuffer::new(s);
+        let mut h = HeapBuffer::new(s).unwrap();
 
         cfg_if::cfg_if! {
             if #[cfg(target_pointer_width = "64")] {
@@ -514,7 +517,7 @@ mod test {
     ) {
         // we know the buffer is valid UTF-8
         let s = unsafe { core::str::from_utf8_unchecked(buf) };
-        let mut h = HeapBuffer::new(s);
+        let mut h = HeapBuffer::new(s).unwrap();
 
         assert!(
             realloc_one > realloc_two,
@@ -545,7 +548,7 @@ mod test {
     #[test_case(&[42; EIGHTEEN_MB]; "huge")]
     fn test_clone(buf: &[u8]) {
         let s = unsafe { core::str::from_utf8_unchecked(buf) };
-        let h_a = HeapBuffer::new(s);
+        let h_a = HeapBuffer::new(s).unwrap();
         let h_b = h_a.clone();
 
         assert_eq!(h_a.capacity(), h_b.capacity());

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -347,7 +347,7 @@ pub unsafe fn do_alloc(layout: Layout) -> Result<ptr::NonNull<u8>, ReserveError>
     // Implementations are encouraged to return null on memory exhaustion rather than aborting.
     match ptr::NonNull::new(raw_ptr) {
         Some(ptr) => Ok(ptr),
-        None => Err(ReserveError(())),
+        None => Err(ReserveError::Exhausted),
     }
 }
 

--- a/compact_str/src/repr/iter.rs
+++ b/compact_str/src/repr/iter.rs
@@ -19,7 +19,7 @@ impl FromIterator<char> for Repr {
         // If the size hint indicates we can't store this inline, then create a heap string
         let (size_hint, _) = iter.size_hint();
         if size_hint > MAX_SIZE {
-            return Repr::from_string(iter.collect(), true);
+            return Repr::from_string(iter.collect(), true).unwrap();
         }
 
         // Otherwise, continuously pull chars from the iterator
@@ -43,7 +43,7 @@ impl FromIterator<char> for Repr {
                 // extend heap with remaining characters
                 string.extend(iter);
 
-                return Repr::from_string(string, true);
+                return Repr::from_string(string, true).unwrap();
             }
 
             // write the current char into a slice of the unoccupied space
@@ -95,7 +95,7 @@ where
             // extend heap with remaining strings
             string.extend(iter);
 
-            return Repr::from_string(string, true);
+            return Repr::from_string(string, true).unwrap();
         }
 
         // write the current string into a slice of the unoccupied space

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -29,6 +29,8 @@ use last_utf8_char::LastUtf8Char;
 use static_str::StaticStr;
 pub use traits::IntoRepr;
 
+use crate::ReserveError;
+
 /// The max size of a string we can fit inline
 pub const MAX_SIZE: usize = core::mem::size_of::<String>();
 /// Used as a discriminant to identify different variants
@@ -61,18 +63,17 @@ unsafe impl Sync for Repr {}
 
 impl Repr {
     #[inline]
-    pub fn new(text: &str) -> Self {
+    pub fn new(text: &str) -> Result<Self, ReserveError> {
         let len = text.len();
 
         if len == 0 {
-            EMPTY
+            Ok(EMPTY)
         } else if len <= MAX_SIZE {
             // SAFETY: We checked that the length of text is less than or equal to MAX_SIZE
             let inline = unsafe { InlineBuffer::new(text) };
-            Repr::from_inline(inline)
+            Ok(Repr::from_inline(inline))
         } else {
-            let heap = HeapBuffer::new(text);
-            Repr::from_heap(heap)
+            HeapBuffer::new(text).map(Repr::from_heap)
         }
     }
 
@@ -97,12 +98,11 @@ impl Repr {
 
     /// Create a [`Repr`] with the provided `capacity`
     #[inline]
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Result<Self, ReserveError> {
         if capacity <= MAX_SIZE {
-            EMPTY
+            Ok(EMPTY)
         } else {
-            let heap = HeapBuffer::with_capacity(capacity);
-            Repr::from_heap(heap)
+            HeapBuffer::with_capacity(capacity).map(Repr::from_heap)
         }
     }
 
@@ -112,7 +112,7 @@ impl Repr {
         // Get a &str from the Vec, failing if it's not valid UTF-8
         let s = core::str::from_utf8(buf.as_ref())?;
         // Construct a Repr from the &str
-        Ok(Self::new(s))
+        Ok(Self::new(s).unwrap())
     }
 
     /// Create a [`Repr`] from a slice of bytes that is UTF-8, without validating that it is indeed
@@ -121,12 +121,12 @@ impl Repr {
     /// # Safety
     /// * The caller must guarantee that `buf` is valid UTF-8
     #[inline]
-    pub unsafe fn from_utf8_unchecked<B: AsRef<[u8]>>(buf: B) -> Self {
+    pub unsafe fn from_utf8_unchecked<B: AsRef<[u8]>>(buf: B) -> Result<Self, ReserveError> {
         let bytes = buf.as_ref();
         let bytes_len = bytes.len();
 
         // Create a Repr with enough capacity for the entire buffer
-        let mut repr = Repr::with_capacity(bytes_len);
+        let mut repr = Repr::with_capacity(bytes_len)?;
 
         // There's an edge case where the final byte of this buffer == `HEAP_MASK`, which is
         // invalid UTF-8, but would result in us creating an inline variant, that identifies as
@@ -137,7 +137,7 @@ impl Repr {
             // If we hit the edge case, reserve additional space to make the repr becomes heap
             // allocated, which prevents us from writing this last byte inline
             if last_byte >= 0b11000000 {
-                repr.reserve(MAX_SIZE + 1);
+                repr.reserve(MAX_SIZE + 1).unwrap();
             }
         }
 
@@ -151,7 +151,7 @@ impl Repr {
         // SAFETY: We just wrote the entire `buf` into the Repr
         repr.set_len(bytes_len);
 
-        repr
+        Ok(repr)
     }
 
     /// Create a [`Repr`] from a [`String`], in `O(1)` time. We'll attempt to inline the string
@@ -160,19 +160,18 @@ impl Repr {
     /// Note: If the provided [`String`] is >16 MB and we're on a 32-bit arch, we'll copy the
     /// `String`.
     #[inline]
-    pub fn from_string(s: String, should_inline: bool) -> Self {
+    pub fn from_string(s: String, should_inline: bool) -> Result<Self, ReserveError> {
         let og_cap = s.capacity();
         let cap = Capacity::new(og_cap);
 
         #[cold]
-        fn capacity_on_heap(s: String) -> Repr {
-            let heap = HeapBuffer::new(s.as_str());
-            Repr::from_heap(heap)
+        fn capacity_on_heap(s: String) -> Result<Repr, ReserveError> {
+            HeapBuffer::new(s.as_str()).map(Repr::from_heap)
         }
 
         #[cold]
-        fn empty() -> Repr {
-            EMPTY
+        fn empty() -> Result<Repr, ReserveError> {
+            Ok(EMPTY)
         }
 
         if cap.is_heap() {
@@ -185,7 +184,7 @@ impl Repr {
         } else if should_inline && s.len() <= MAX_SIZE {
             // SAFETY: Checked to make sure the string would fit inline
             let inline = unsafe { InlineBuffer::new(s.as_str()) };
-            Repr::from_inline(inline)
+            Ok(Repr::from_inline(inline))
         } else {
             let mut s = mem::ManuallyDrop::new(s.into_bytes());
             let len = s.len();
@@ -194,7 +193,7 @@ impl Repr {
             let ptr = ptr::NonNull::new(raw_ptr).expect("string with capacity has null ptr?");
             let heap = HeapBuffer { ptr, len, cap };
 
-            Repr::from_heap(heap)
+            Ok(Repr::from_heap(heap))
         }
     }
 
@@ -241,7 +240,7 @@ impl Repr {
     /// Reserves at least `additional` bytes. If there is already enough capacity to store
     /// `additional` bytes this is a no-op
     #[inline]
-    pub fn reserve(&mut self, additional: usize) {
+    pub fn reserve(&mut self, additional: usize) -> Result<(), ReserveError> {
         let len = self.len();
         let needed_capacity = len
             .checked_add(additional)
@@ -251,20 +250,20 @@ impl Repr {
             // we already have enough space, no-op
             // If self.is_static_str() is true, then we would have to convert
             // it to other variants since static_str variant cannot be modified.
-            return;
-        }
-
-        if needed_capacity <= MAX_SIZE {
+            Ok(())
+        } else if needed_capacity <= MAX_SIZE {
             // It's possible to have a `Repr` that is heap allocated with a capacity less than
             // MAX_SIZE, if that `Repr` was created From a String or Box<str>
             //
             // SAFTEY: Our needed_capacity is >= our length, which is <= than MAX_SIZE
             let inline = unsafe { InlineBuffer::new(self.as_str()) };
             *self = Repr::from_inline(inline);
+            Ok(())
         } else if !self.is_heap_allocated() {
             // We're not heap allocated, but need to be, create a HeapBuffer
-            let heap = HeapBuffer::with_additional(self.as_str(), additional);
+            let heap = HeapBuffer::with_additional(self.as_str(), additional)?;
             *self = Repr::from_heap(heap);
+            Ok(())
         } else {
             // We're already heap allocated, but we need more capacity
             //
@@ -276,9 +275,11 @@ impl Repr {
             // Attempt to grow our capacity, allocating a new HeapBuffer on failure
             if heap_buffer.realloc(amortized_capacity).is_err() {
                 // Create a new HeapBuffer
-                let heap = HeapBuffer::with_additional(self.as_str(), additional);
+                let heap = HeapBuffer::with_additional(self.as_str(), additional)?;
                 *self = Repr::from_heap(heap);
             }
+
+            Ok(())
         }
     }
 
@@ -327,7 +328,7 @@ impl Repr {
         let str_len = s.len();
 
         // Reserve at least enough space to fit `s`
-        self.reserve(str_len);
+        self.reserve(str_len).unwrap();
 
         // SAFTEY: `s` which we're appending to the buffer, is valid UTF-8
         let slice = unsafe { self.as_mut_buf() };
@@ -495,8 +496,15 @@ impl Repr {
     /// # Safety
     /// * Callers must guarantee that any modifications made to the buffer are valid UTF-8
     pub unsafe fn as_mut_buf(&mut self) -> &mut [u8] {
-        if let Some(s) = self.as_static_str() {
-            *self = Repr::new(s);
+        #[cold]
+        fn inline_static_str(this: &mut Repr) {
+            if let Some(s) = this.as_static_str() {
+                *this = Repr::new(s).unwrap();
+            }
+        }
+
+        if self.is_static_str() {
+            inline_static_str(self);
         }
 
         // the last byte stores our discriminant and stack length
@@ -661,7 +669,7 @@ impl Clone for Repr {
     fn clone(&self) -> Self {
         #[inline(never)]
         fn clone_heap(this: &Repr) -> Repr {
-            Repr::new(this.as_str())
+            Repr::new(this.as_str()).unwrap()
         }
 
         // There are only two cases we need to care about: If the string is allocated on the heap
@@ -706,7 +714,7 @@ impl Extend<char> for Repr {
         }
         let (lower_bound, _) = iterator.size_hint();
 
-        self.reserve(lower_bound);
+        self.reserve(lower_bound).unwrap();
         iterator.for_each(|c| self.push_str(c.encode_utf8(&mut [0; 4])));
     }
 }
@@ -763,7 +771,7 @@ mod tests {
     #[test_case("hello world!"; "inline")]
     #[test_case("this is a long string that should be stored on the heap"; "heap")]
     fn test_create(s: &'static str) {
-        let repr = Repr::new(s);
+        let repr = Repr::new(s).unwrap();
         assert_eq!(repr.as_str(), s);
         assert_eq!(repr.len(), s.len());
 
@@ -776,7 +784,7 @@ mod tests {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_create(s: String) {
-        let repr = Repr::new(&s);
+        let repr = Repr::new(&s).unwrap();
         assert_eq!(repr.as_str(), s);
         assert_eq!(repr.len(), s.len());
     }
@@ -786,7 +794,7 @@ mod tests {
     #[test_case(64; "long")]
     #[test_case(EIGHTEEN_MB; "huge")]
     fn test_with_capacity(cap: usize) {
-        let r = Repr::with_capacity(cap);
+        let r = Repr::with_capacity(cap).unwrap();
         assert!(r.capacity() >= MAX_SIZE);
         assert_eq!(r.len(), 0);
     }
@@ -834,7 +842,7 @@ mod tests {
         let s_cap = s.capacity();
         let s_str = s.clone();
 
-        let r = Repr::from_string(s, try_to_inline);
+        let r = Repr::from_string(s, try_to_inline).unwrap();
 
         assert_eq!(r.len(), s_len);
         assert_eq!(r.as_str(), s_str.as_str());
@@ -851,7 +859,7 @@ mod tests {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_from_string(s: String, try_to_inline: bool) {
-        let r = Repr::from_string(s.clone(), try_to_inline);
+        let r = Repr::from_string(s.clone(), try_to_inline).unwrap();
 
         assert_eq!(r.len(), s.len());
         assert_eq!(r.as_str(), s.as_str());
@@ -871,7 +879,7 @@ mod tests {
     #[test_case("nyc 🗽"; "short")]
     #[test_case("this is a really long string, which is intended"; "long")]
     fn test_into_string(control: &'static str) {
-        let r = Repr::new(control);
+        let r = Repr::new(control).unwrap();
         let s = r.into_string();
 
         assert_eq!(control.len(), s.len());
@@ -888,7 +896,7 @@ mod tests {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_into_string(control: String) {
-        let r = Repr::new(&control);
+        let r = Repr::new(&control).unwrap();
         let s = r.into_string();
 
         assert_eq!(control.len(), s.len());
@@ -900,7 +908,7 @@ mod tests {
     #[test_case("abc", "🗽🙂🦀🌈👏🐶", true; "inline_to_heap")]
     #[test_case("i am a long string that will be on the heap", "extra", true; "heap_to_heap")]
     fn test_push_str(control: &'static str, append: &'static str, is_heap: bool) {
-        let mut r = Repr::new(control);
+        let mut r = Repr::new(control).unwrap();
         let mut c = String::from(control);
 
         r.push_str(append);
@@ -927,7 +935,7 @@ mod tests {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_push_str(control: String, append: String) {
-        let mut r = Repr::new(&control);
+        let mut r = Repr::new(&control).unwrap();
         let mut c = control;
 
         r.push_str(&append);
@@ -947,7 +955,7 @@ mod tests {
         let control = unsafe { core::str::from_utf8_unchecked(buf) };
         let append = unsafe { core::str::from_utf8_unchecked(append) };
 
-        let mut r = Repr::new(control);
+        let mut r = Repr::new(control).unwrap();
         let mut c = String::from(control);
 
         r.push_str(append);
@@ -969,15 +977,15 @@ mod tests {
     #[test_case("I am a long string that will be on the heap", 10, true; "large_small")]
     #[test_case("I am a long string that will be on the heap", EIGHTEEN_MB, true; "large_huge")]
     fn test_reserve(initial: &'static str, additional: usize, is_heap: bool) {
-        let mut r = Repr::new(initial);
-        r.reserve(additional);
+        let mut r = Repr::new(initial).unwrap();
+        r.reserve(additional).unwrap();
 
         assert!(r.capacity() >= initial.len() + additional);
         assert_eq!(r.is_heap_allocated(), is_heap);
 
         // Test static_str variant
         let mut r = Repr::from_static_str(initial);
-        r.reserve(additional);
+        r.reserve(additional).unwrap();
 
         assert!(r.capacity() >= initial.len() + additional);
         assert_eq!(r.is_heap_allocated(), is_heap);
@@ -986,8 +994,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "Attempted to reserve more than 'usize' bytes")]
     fn test_reserve_overflow() {
-        let mut r = Repr::new("abc");
-        r.reserve(usize::MAX);
+        let mut r = Repr::new("abc").unwrap();
+        r.reserve(usize::MAX).unwrap();
     }
 
     #[test_case(""; "empty")]
@@ -995,7 +1003,7 @@ mod tests {
     #[test_case("i am a longer string that will be on the heap"; "long")]
     #[test_case(EIGHTEEN_MB_STR; "huge")]
     fn test_clone(initial: &'static str) {
-        let r_a = Repr::new(initial);
+        let r_a = Repr::new(initial).unwrap();
         let r_b = r_a.clone();
 
         assert_eq!(r_a.as_str(), initial);
@@ -1022,7 +1030,7 @@ mod tests {
     #[quickcheck]
     #[cfg_attr(miri, ignore)]
     fn quickcheck_clone(initial: String) {
-        let r_a = Repr::new(&initial);
+        let r_a = Repr::new(&initial).unwrap();
         let r_b = r_a.clone();
 
         assert_eq!(r_a.as_str(), initial);

--- a/compact_str/src/repr/num.rs
+++ b/compact_str/src/repr/num.rs
@@ -23,13 +23,12 @@ const DEC_DIGITS_LUT: &[u8] = b"\
 macro_rules! impl_IntoRepr {
     ($t:ident, $conv_ty:ident) => {
         impl IntoRepr for $t {
-            #[inline]
             fn into_repr(self) -> Repr {
                 // Determine the number of digits in this value
                 //
                 // Note: this considers the `-` symbol
                 let num_digits = NumChars::num_chars(self);
-                let mut repr = Repr::with_capacity(num_digits);
+                let mut repr = Repr::with_capacity(num_digits).unwrap();
 
                 #[allow(unused_comparisons)]
                 let is_nonnegative = self >= 0;
@@ -128,17 +127,19 @@ impl_IntoRepr!(isize, u64);
 /// characters and then writing.
 impl IntoRepr for u128 {
     #[inline]
+    #[track_caller]
     fn into_repr(self) -> Repr {
         let mut buffer = itoa::Buffer::new();
-        Repr::new(buffer.format(self))
+        Repr::new(buffer.format(self)).unwrap()
     }
 }
 
 impl IntoRepr for i128 {
     #[inline]
+    #[track_caller]
     fn into_repr(self) -> Repr {
         let mut buffer = itoa::Buffer::new();
-        Repr::new(buffer.format(self))
+        Repr::new(buffer.format(self)).unwrap()
     }
 }
 

--- a/compact_str/src/repr/traits.rs
+++ b/compact_str/src/repr/traits.rs
@@ -9,18 +9,22 @@ pub trait IntoRepr {
 }
 
 impl IntoRepr for f32 {
+    #[inline]
+    #[track_caller]
     fn into_repr(self) -> Repr {
         let mut buf = ryu::Buffer::new();
         let s = buf.format(self);
-        Repr::new(s)
+        Repr::new(s).unwrap()
     }
 }
 
 impl IntoRepr for f64 {
+    #[inline]
+    #[track_caller]
     fn into_repr(self) -> Repr {
         let mut buf = ryu::Buffer::new();
         let s = buf.format(self);
-        Repr::new(s)
+        Repr::new(s).unwrap()
     }
 }
 

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -71,6 +71,7 @@ unsafe impl LifetimeFree for Repr {}
 ///     * For floats we use [`ryu`] crate which sometimes provides different formatting than [`std`]
 impl<T: fmt::Display> ToCompactString for T {
     #[inline]
+    #[track_caller]
     fn to_compact_string(&self) -> CompactString {
         let repr = match_type!(self, {
             &u8 as s => s.into_repr(),
@@ -93,7 +94,7 @@ impl<T: fmt::Display> ToCompactString for T {
             //
             // <https://github.com/ParkMyCar/compact_str/issues/304>
             // &String as s => Repr::new(s),
-            &CompactString as s => Repr::new(s),
+            &CompactString as s => Repr::new(s).unwrap(),
             &num::NonZeroU8 as s => s.into_repr(),
             &num::NonZeroI8 as s => s.into_repr(),
             &num::NonZeroU16 as s => s.into_repr(),

--- a/examples/bytes/Cargo.toml
+++ b/examples/bytes/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bytes"
+name = "example-bytes"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/macros/Cargo.toml
+++ b/examples/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "macros"
+name = "example-macros"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/serde/Cargo.toml
+++ b/examples/serde/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "serde"
+name = "example-serde"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/traits/Cargo.toml
+++ b/examples/traits/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "traits"
+name = "example-traits"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
The CI error in #321 is actually an implementation error. Once a CompactString gets so big that its capacity cannot be stored inline anymore, it will always be at least this big. This PR lets `shrink_to()` allocate new `Repr` with a capacity that can be inlined.

To facilitate this change I made allocations and re-allocations fallible. As an added bonus better panic messages will be generated, mentioning the calling locations of the failing (re)allocations. And the user gets two new methods, `try_with_capacity()` and `try_reserve`, to manually handle out-of-memory cases.