### PR TITLE
Simplify `is_empty()`

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -499,7 +499,7 @@ impl CompactString {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.0.is_empty()
     }
 
     /// Returns the capacity of the [`CompactString`], in bytes.

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1853,95 +1853,25 @@ fn multiple_niches_test() {
 
 #[test]
 fn test_is_empty() {
-    // 0
+    const ZEROS: &[&str] = &[
+        "\0",                                                 // 1
+        "\0\0\0\0\0\0\0\0\0\0\0\0",                           // 12
+        "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",   // 24
+        "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", // 25
+    ];
+
     assert!(CompactString::new("").is_empty());
     assert!(CompactString::from_static_str("").is_empty());
-    // 1
-    assert!(!CompactString::new("\0").is_empty());
-    assert!(!CompactString::from_static_str("\0").is_empty());
-    // 2
-    assert!(!CompactString::new("\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0").is_empty());
-    // 3
-    assert!(!CompactString::new("\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0").is_empty());
-    // 4
-    assert!(!CompactString::new("\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0").is_empty());
-    // 5
-    assert!(!CompactString::new("\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0").is_empty());
-    // 6
-    assert!(!CompactString::new("\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0").is_empty());
-    // 7
-    assert!(!CompactString::new("\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0").is_empty());
-    // 8
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0").is_empty());
-    // 9
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0").is_empty());
-    // 10
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 11
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 12
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 13
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 14
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 15
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 16
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 17
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 18
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 19
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 20
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    // 21
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(
-        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty()
-    );
-    // 22
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(
-        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty()
-    );
-    // 23
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(
-        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
-            .is_empty()
-    );
-    // 24
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(
-        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
-            .is_empty()
-    );
-    // 25
-    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
-    assert!(
-        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
-            .is_empty()
-    );
+
+    for (len, s) in ZEROS.iter().copied().enumerate() {
+        let mut a = CompactString::new(s);
+        let mut b = CompactString::new(s);
+
+        for _ in (1..=len).rev() {
+            a.truncate(len);
+            b.truncate(len);
+            assert!(!a.is_empty());
+            assert!(!b.is_empty());
+        }
+    }
 }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1836,7 +1836,7 @@ fn test_alloc_excessively_long_string() {
 // released in Rust 1.65.
 #[rustversion::since(1.65)]
 #[test]
-fn multiple_nieches_test() {
+fn multiple_niches_test() {
     #[allow(unused)]
     enum Value {
         String(CompactString),
@@ -1848,5 +1848,100 @@ fn multiple_nieches_test() {
     assert_eq!(
         core::mem::size_of::<Value>(),
         core::mem::size_of::<String>()
+    );
+}
+
+#[test]
+fn test_is_empty() {
+    // 0
+    assert!(CompactString::new("").is_empty());
+    assert!(CompactString::from_static_str("").is_empty());
+    // 1
+    assert!(!CompactString::new("\0").is_empty());
+    assert!(!CompactString::from_static_str("\0").is_empty());
+    // 2
+    assert!(!CompactString::new("\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0").is_empty());
+    // 3
+    assert!(!CompactString::new("\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0").is_empty());
+    // 4
+    assert!(!CompactString::new("\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0").is_empty());
+    // 5
+    assert!(!CompactString::new("\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0").is_empty());
+    // 6
+    assert!(!CompactString::new("\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0").is_empty());
+    // 7
+    assert!(!CompactString::new("\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0").is_empty());
+    // 8
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0").is_empty());
+    // 9
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0").is_empty());
+    // 10
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 11
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 12
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 13
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 14
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 15
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 16
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 17
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 18
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 19
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 20
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(!CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    // 21
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(
+        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty()
+    );
+    // 22
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(
+        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty()
+    );
+    // 23
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(
+        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
+            .is_empty()
+    );
+    // 24
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(
+        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
+            .is_empty()
+    );
+    // 25
+    assert!(!CompactString::new("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").is_empty());
+    assert!(
+        !CompactString::from_static_str("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0")
+            .is_empty()
     );
 }


### PR DESCRIPTION
Before:

```asm
0000000000000000 <<compact_str::CompactString>::is_empty>:
   0:   48 8b 77 08             mov    0x8(%rdi),%rsi
   4:   0f b6 57 17             movzbl 0x17(%rdi),%edx
   8:   48 8d 8a 40 ff ff ff    lea    -0xc0(%rdx),%rcx
   f:   48 83 f9 18             cmp    $0x18,%rcx
  13:   b8 18 00 00 00          mov    $0x18,%eax
  18:   48 0f 42 c1             cmovb  %rcx,%rax
  1c:   48 81 fa d8 00 00 00    cmp    $0xd8,%rdx
  23:   48 0f 43 c6             cmovae %rsi,%rax
  27:   48 85 c0                test   %rax,%rax
  2a:   0f 94 c0                sete   %al
  2d:   c3                      ret
```

After

```asm
0000000000000000 <<compact_str::CompactString>::is_empty>:
   0:   48 8b 57 08             mov    0x8(%rdi),%rdx
   4:   0f b6 4f 17             movzbl 0x17(%rdi),%ecx
   8:   48 8d 81 40 ff ff ff    lea    -0xc0(%rcx),%rax
   f:   48 81 f9 d8 00 00 00    cmp    $0xd8,%rcx
  16:   48 0f 43 c2             cmovae %rdx,%rax
  1a:   48 85 c0                test   %rax,%rax
  1d:   0f 94 c0                sete   %al
  20:   c3                      ret
```