### PR TITLE
fix: Merge skew and MSRV workflow

### DIFF
--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -35,13 +35,13 @@ jobs:
             OS: ubuntu-latest
             target: i686-unknown-linux-gnu
             cross: true
-          - name: Linux MIPS Big Endian 32-bit
+          - name: Linux ARMv6 32-bit
             OS: ubuntu-latest
-            target: mips-unknown-linux-gnu
+            target: arm-unknown-linux-gnueabihf
             cross: true
-          - name: Linux MIPS Little Endian 32-bit
+          - name: Linux ARMv7-A 32-bit
             OS: ubuntu-latest
-            target: mipsel-unknown-linux-gnu
+            target: armv7-unknown-linux-gnueabihf
             cross: true
           - name: Linux PowerPC Big Endian 32-bit
             OS: ubuntu-latest
@@ -50,6 +50,14 @@ jobs:
           - name: Linux PowerPC Little Endian 64-bit
             OS: ubuntu-latest
             target: powerpc64le-unknown-linux-gnu
+            cross: true
+          - name: Linux ARM64 Little Endian 64-bit
+            OS: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
+          - name: Linux PowerPC Big Endian 64-bit
+            OS: ubuntu-latest
+            target: powerpc64-unknown-linux-gnu
             cross: true
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.OS }}

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -42,7 +42,7 @@ jobs:
         # Note2: Even though our MSRV is 1.59, we only test from 1.60 because we hit the issue
         # described in <https://github.com/rust-lang/cargo/issues/10189> when using 1.59.
         run: |
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --version-range 1.60..
+          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.60..
           cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec,proptest,arbitrary --manifest-path=compact_str/Cargo.toml --version-range 1.64..
 
   feature_powerset:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -30,16 +30,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: cargo test msrv..
-        # note: we exclude both `arbitrary` and `proptest` from here because their MSRVs were both
+        # Note: we exclude both `arbitrary` and `proptest` from here because their MSRVs were both
         # bumped on a minor version release:
         #
         # - abitrary >= 1.1.14 has an MSRV >= 1.63
         # - proptest >= 1.1.0 has an MSRV >= 1.60
         #
         # Instead of pinning to a specific version of `arbitrary` or `proptest`, we'll let user's 
-        # deps decide the version since the API should still be semver compatible
+        # deps decide the version since the API should still be semver compatible.
+        #
+        # Note2: Even though our MSRV is 1.59, we only test from 1.60 because we hit the issue
+        # described in <https://github.com/rust-lang/cargo/issues/10189> when using 1.59.
         run: |
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.59..
+          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --version-range 1.60..
           cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec,proptest,arbitrary --manifest-path=compact_str/Cargo.toml --version-range 1.64..
 
   feature_powerset:

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -1069,13 +1069,13 @@ mod tests {
 
     #[test_case(Repr::from_static_str(""), Repr::from_static_str(""); "empty clone from static")]
     #[test_case(Repr::new_inline("abc"), Repr::from_static_str("efg"); "short clone from static")]
-    #[test_case(Repr::new("i am a longer string that will be on the heap"), Repr::from_static_str(EIGHTEEN_MB_STR); "long clone from static")]
+    #[test_case(Repr::new("i am a longer string that will be on the heap").unwrap(), Repr::from_static_str(EIGHTEEN_MB_STR); "long clone from static")]
     #[test_case(Repr::from_static_str(""), Repr::new_inline(""); "empty clone from inline")]
     #[test_case(Repr::new_inline("abc"), Repr::new_inline("efg"); "short clone from inline")]
-    #[test_case(Repr::new("i am a longer string that will be on the heap"), Repr::new_inline("small"); "long clone from inline")]
-    #[test_case(Repr::from_static_str(""), Repr::new(EIGHTEEN_MB_STR); "empty clone from heap")]
-    #[test_case(Repr::new_inline("abc"), Repr::new(EIGHTEEN_MB_STR); "short clone from heap")]
-    #[test_case(Repr::new("i am a longer string that will be on the heap"), Repr::new(EIGHTEEN_MB_STR); "long clone from heap")]
+    #[test_case(Repr::new("i am a longer string that will be on the heap").unwrap(), Repr::new_inline("small"); "long clone from inline")]
+    #[test_case(Repr::from_static_str(""), Repr::new(EIGHTEEN_MB_STR).unwrap(); "empty clone from heap")]
+    #[test_case(Repr::new_inline("abc"), Repr::new(EIGHTEEN_MB_STR).unwrap(); "short clone from heap")]
+    #[test_case(Repr::new("i am a longer string that will be on the heap").unwrap(), Repr::new(EIGHTEEN_MB_STR).unwrap(); "long clone from heap")]
     fn test_clone_from(mut initial: Repr, source: Repr) {
         initial.clone_from(&source);
         assert_eq!(initial.as_str(), source.as_str());


### PR DESCRIPTION
With some recent PRs we hit some merge skews that prevented a test from compiling, this PR fixes those issues. It also bumps the MSRV CI workflow to 1.60, suddenly when running in 1.59 we get the following error:

```
$ cargo +1.59 check --no-default-features                                                                                                                         [±fix/merge-skew ●]
    Updating crates.io index
error: failed to select a version for `rkyv`.
    ... required by package `compact_str v0.8.0-beta (/Users/parker/Development/compact_str/compact_str)`
versions that meet the requirements `^0.7` are: 0.7.41, 0.7.40, 0.7.39, 0.7.38, 0.7.37, 0.7.36, 0.7.35, 0.7.34, 0.7.33, 0.7.32, 0.7.31, 0.7.30, 0.7.29, 0.7.28, 0.7.27, 0.7.26, 0.7.25, 0.7.24, 0.7.23, 0.7.22, 0.7.21, 0.7.20, 0.7.19, 0.7.18, 0.7.17, 0.7.16, 0.7.15, 0.7.14, 0.7.13, 0.7.12, 0.7.11, 0.7.10, 0.7.9, 0.7.8, 0.7.7, 0.7.6, 0.7.5, 0.7.4, 0.7.3, 0.7.2, 0.7.1, 0.7.0

all possible versions conflict with previously selected packages.

  previously selected package `rkyv v0.7.31`
    ... which satisfies dependency `rkyv = "^0.7"` of package `compact_str v0.8.0-beta (/Users/parker/Development/compact_str/compact_str)`

failed to select a version for `rkyv` which could resolve this conflict
```
... which is confusing, since the version of `rkyv` selected satisfies the dependency, and there haven't been any new versions of `rkyv` released in 5 months? It seems related to this issue, https://github.com/rust-lang/cargo/issues/10189, which indicates something further down in the dependency chain is to blame. Haven't had a chance to dig further, so I bumped the MSRV workflow to 1.60