### PR TITLE
Update README.md - fix one grammatical bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This crate exposes one macro `format_compact!` that can be used to create `Compa
 ### How it works
 Note: this explanation assumes a 64-bit architecture, for 32-bit architectures generally divide any number by 2.
 
-Normally strings are stored on the heap since they're dynamically sized. In Rust a `String` consists of three fields, each of which are the size of a `usize`.
+Normally strings are stored on the heap since they're dynamically sized. In Rust, a `String` consists of three fields, each of which are the size of a `usize`.
 e.g. its layout is something like the following:
 
 `String: [ ptr<8> | len<8> | cap<8> ]`


### PR DESCRIPTION
Grammar mistake in **README.md** inside section "**How it Works**".

" **In Rust a String consists..**"  should be " **In Rust, a String consists..**"

Screenshot- 

![Screenshot (103)](https://github.com/ParkMyCar/compact_str/assets/114826902/006d914e-8fec-4f39-bc11-b61365cd81de)
