### PR TITLE
 On 64bit platforms, the capacity is always stored inline 

### DIFF
--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -23,6 +23,7 @@ const HEAP_MARKER: usize = {
 ///
 /// All bytes `255`, with the last being [`LastUtf8Char::Heap`], using the same amount of bytes
 /// as `usize`. Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 216]`
+#[cfg(not(target_pointer_width = "64"))]
 const CAPACITY_IS_ON_THE_HEAP: Capacity = Capacity(VALID_MASK | HEAP_MARKER);
 
 /// The maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2.
@@ -100,6 +101,7 @@ impl Capacity {
     /// Returns whether or not this [`Capacity`] has a value that indicates the capacity is being
     /// stored on the heap
     #[inline(always)]
+    #[cfg(not(target_pointer_width = "64"))]
     pub fn is_heap(self) -> bool {
         self == CAPACITY_IS_ON_THE_HEAP
     }

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -271,6 +271,11 @@ impl Drop for HeapBuffer {
 /// in the `Capacity` itself.
 #[inline]
 pub fn allocate_ptr(capacity: usize) -> Result<(Capacity, ptr::NonNull<u8>), ReserveError> {
+    #[cfg(target_pointer_width = "64")]
+    if capacity > super::capacity::MAX_VALUE {
+        return Err(ReserveError(()));
+    }
+
     // We allocate at least MIN_HEAP_SIZE bytes because we need to allocate at least one byte
     let capacity = capacity.max(MIN_HEAP_SIZE);
     let cap = Capacity::new(capacity);

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1922,7 +1922,11 @@ fn test_from_string_buffer_inlines_on_clone() {
 #[should_panic = "Cannot allocate memory to hold CompactString"]
 fn test_alloc_excessively_long_string() {
     // 2**56 - 2 bytes, the maximum number `Capacity` can hold
-    CompactString::with_capacity((1 << 56) - 2);
+    let capacity = core::hint::black_box((1 << 56) - 2);
+    let compact = CompactString::with_capacity(capacity);
+    // rationale: make sure that the result is used.
+    let compact = core::hint::black_box(compact);
+    drop(compact);
 }
 
 #[cfg(target_pointer_width = "64")]
@@ -1930,7 +1934,11 @@ fn test_alloc_excessively_long_string() {
 #[should_panic = "Cannot allocate memory to hold CompactString"]
 fn test_alloc_even_more_excessively_long_string() {
     // 2**56 - 1 bytes, the lowest value that exceeds `Capacity`'s maximum
-    CompactString::with_capacity((1 << 56) - 1);
+    let capacity = core::hint::black_box((1 << 56) - 1);
+    let compact = CompactString::with_capacity(capacity);
+    // rationale: make sure that the result is used.
+    let compact = core::hint::black_box(compact);
+    drop(compact);
 }
 
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1925,6 +1925,14 @@ fn test_alloc_excessively_long_string() {
     CompactString::with_capacity((1 << 56) - 2);
 }
 
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic = "Cannot allocate memory to hold CompactString"]
+fn test_alloc_even_more_excessively_long_string() {
+    // 2**56 - 1 bytes, the lowest value that exceeds `Capacity`'s maximum
+    CompactString::with_capacity((1 << 56) - 1);
+}
+
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first
 // released in Rust 1.65.
 #[rustversion::since(1.65)]


### PR DESCRIPTION
On 64 bit platforms we do not have to check if the capacity is stored on the heap, because it will never be stored on the heap.