### PR TITLE
Align InlineBuffer same as Repr

### DIFF
--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -39,6 +39,7 @@ pub struct HeapBuffer {
     pub cap: Capacity,
 }
 static_assertions::assert_eq_size!(HeapBuffer, Repr);
+static_assertions::assert_eq_align!(HeapBuffer, Repr);
 
 impl HeapBuffer {
     /// Create a [`HeapBuffer`] with the provided text

--- a/compact_str/src/repr/static_str.rs
+++ b/compact_str/src/repr/static_str.rs
@@ -24,6 +24,7 @@ pub struct StaticStr {
     discriminant: [u8; DISCRIMINANT_SIZE],
 }
 static_assertions::assert_eq_size!(StaticStr, Repr);
+static_assertions::assert_eq_align!(StaticStr, Repr);
 static_assertions::assert_eq_size!(&'static str, (*const u8, usize));
 
 impl StaticStr {


### PR DESCRIPTION
Fixes #353.

I also added assertions that `HeapBuffer` and `StaticStr` have same alignment as `Repr`.