### PR TITLE
Make as_slice() an implementation detail 

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -30,5 +30,9 @@ name = "comparison"
 harness = false
 
 [[bench]]
+name = "micro"
+harness = false
+
+[[bench]]
 name = "random"
 harness = false

--- a/bench/benches/micro.rs
+++ b/bench/benches/micro.rs
@@ -1,0 +1,85 @@
+use std::time::{
+    Duration,
+    Instant,
+};
+
+use compact_str::CompactString;
+use criterion::{
+    black_box,
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
+
+const EMPTY: &str = "";
+const SMALL: &str = "small";
+const BIG: &str = "This string has thirty-four chars.";
+const HUGE: &str = include_str!("../data/moby10b.txt");
+
+macro_rules! benchmarks_simple {
+    ($($method:ident),+) => {
+        $(
+            fn $method(c: &mut Criterion) {
+                benchmarks_simple!(@ c $method EMPTY SMALL BIG HUGE);
+            }
+        )+
+    };
+
+    (@ $c:ident $method:ident $($length:ident)+) => {$(
+        $c.bench_function(stringify!($method $length), |b| {
+            let string = CompactString::new(black_box($length));
+            b.iter(|| {
+                let _ = black_box(black_box(&string).$method());
+            })
+        });
+    )+}
+}
+
+macro_rules! benchmarks_complex {
+    ($($method:ident [$expr:expr])+) => {
+        $(
+            fn $method(c: &mut Criterion) {
+                benchmarks_complex!(@ c $method [$expr] EMPTY SMALL BIG HUGE);
+            }
+        )+
+    };
+
+    (@ $c:ident $method:ident [$expr:expr] $($length:ident)+) => {$(
+        $c.bench_function(stringify!($method $length), |b| {
+            b.iter_custom(|iters| {
+                let mut duration = Duration::default();
+                for _ in 0..iters {
+                    let mut string = CompactString::new(black_box($length));
+                    let start = Instant::now();
+                    $expr(black_box(&mut string));
+                    duration += start.elapsed();
+                    drop(string);
+                }
+                duration
+            });
+        });
+
+        $c.bench_function(stringify!($method $length repeated), |b| {
+            let mut string = CompactString::new(black_box($length));
+            b.iter(|| {
+                $expr(black_box(&mut string));
+            });
+        });
+    )+}
+}
+
+benchmarks_simple!(as_bytes, as_str, capacity, is_empty, is_heap_allocated, len);
+
+benchmarks_complex! {
+    as_mut_bytes [|s: &mut CompactString| { let _ = black_box(unsafe { s.as_mut_bytes() }); }]
+    as_mut_ptr [|s: &mut CompactString| { let _ = black_box(s.as_mut_ptr()); }]
+    as_mut_str [|s: &mut CompactString| { let _ = black_box(s.as_mut_str()); }]
+}
+
+criterion_group! {
+    micro,
+    as_bytes, as_str, capacity, is_empty, is_heap_allocated, len,
+    as_mut_bytes, as_mut_ptr, as_mut_str,
+}
+
+criterion_main!(micro);

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -618,7 +618,7 @@ impl CompactString {
     /// ```
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
-        &self.0.as_slice()[..self.len()]
+        self.as_str().as_bytes()
     }
 
     // TODO: Implement a `try_as_mut_slice(...)` that will fail if it results in cloning?
@@ -996,16 +996,16 @@ impl CompactString {
         unsafe { self.set_len(new_len) };
     }
 
-    /// Converts a [`CompactString`] to a raw pointer.
+    /// Return a reference to the underlying buffer
     #[inline]
     pub fn as_ptr(&self) -> *const u8 {
-        self.0.as_slice().as_ptr()
+        self.0.as_ptr()
     }
 
-    /// Converts a mutable [`CompactString`] to a raw pointer.
+    /// Return a mutable reference to the underlying buffer
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
-        unsafe { self.0.as_mut_buf().as_mut_ptr() }
+        self.0.as_mut_ptr()
     }
 
     /// Insert string character at an index.

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1961,3 +1961,10 @@ fn test_is_empty() {
         }
     }
 }
+
+#[test]
+fn test_drain_from_static_string() {
+    let mut compact =
+        CompactString::const_new("I am a very long string. Well, longer than 24 bytes at least.");
+    let _ = compact.drain(4..=10);
+}


### PR DESCRIPTION
```text
as_bytes EMPTY          time:   [1.4595 ns 1.4694 ns 1.4797 ns]
                        change: [-27.836% -27.281% -26.629%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

as_bytes SMALL          time:   [1.4472 ns 1.4626 ns 1.4815 ns]
                        change: [-28.946% -28.503% -28.007%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

as_bytes BIG            time:   [1.4627 ns 1.4786 ns 1.4972 ns]
                        change: [-26.822% -26.105% -25.396%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

as_bytes HUGE           time:   [1.4732 ns 1.4876 ns 1.5033 ns]
                        change: [-27.390% -26.700% -25.940%] (p = 0.00 < 0.05)
                        Performance has improved.
```