### PR TITLE
Some slightly performance & style updates

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -614,7 +614,7 @@ impl CompactString {
     /// ```
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
-        &self.0.as_slice()[..self.len()]
+        self.0.as_slice()
     }
 
     // TODO: Implement a `try_as_mut_slice(...)` that will fail if it results in cloning?

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -23,6 +23,7 @@ const HEAP_MARKER: usize = {
 ///
 /// All bytes `255`, with the last being [`LastByte::Heap`], using the same amount of bytes
 /// as `usize`. Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 216]`
+#[cfg(not(target_pointer_width = "64"))]
 const CAPACITY_IS_ON_THE_HEAP: Capacity = Capacity(VALID_MASK | HEAP_MARKER);
 
 /// The maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2.

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -101,7 +101,13 @@ impl Capacity {
     /// stored on the heap
     #[inline(always)]
     pub(crate) fn is_heap(self) -> bool {
-        self == CAPACITY_IS_ON_THE_HEAP
+        cfg_if::cfg_if! {
+            if #[cfg(target_pointer_width = "64")] {
+                false
+            } else {
+                self == CAPACITY_IS_ON_THE_HEAP
+            }
+        }
     }
 }
 

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1937,7 +1937,7 @@ fn test_from_string_buffer_inlines_on_clone() {
 #[should_panic = "Cannot allocate memory to hold CompactString"]
 fn test_alloc_excessively_long_string() {
     // 2**56 - 2 bytes, the maximum number `Capacity` can hold
-    CompactString::with_capacity((1 << 56) - 2);
+    std::hint::black_box(CompactString::with_capacity((1 << 56) - 2));
 }
 
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first


### PR DESCRIPTION
* In the function `fn as_bytes` in `impl CompactString`, there is an redundant slicing (with a `self.len()` call) which is unnecessary after the update c95edd5.
* This crate has documented that for 64-bit architectures the capacity will be always inlined. So the logic of `is_heap` can be replaced with directly returning `false` to reduce some code generation.