### PR TITLE
fix: remove -Zmiri-check-number-validity from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
   PROPTEST_CASES: 10000
-  MIRIFLAGS: "-Zmiri-strict-provenance -Zmiri-check-number-validity"
+  MIRIFLAGS: "-Zmiri-strict-provenance"
 
 jobs:
   check:


### PR DESCRIPTION
PR #371 is failing in the CI due to the utilization of the removed MIRI flag `-Zmiri-check-number-validity`. This PR remove the flag from CI.

See for https://github.com/rust-lang/miri/pull/2151 the removal.
 