### PR TITLE
Remove invalid UTF8 check from `Repr::from_utf8_unchecked`

### DIFF
--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -123,19 +123,6 @@ impl Repr {
         // Create a Repr with enough capacity for the entire buffer
         let mut repr = Repr::with_capacity(bytes_len)?;
 
-        // There's an edge case where the final byte of this buffer == `HEAP_MASK`, which is
-        // invalid UTF-8, but would result in us creating an inline variant, that identifies as
-        // a heap variant. If a user ever tried to reference the data at all, we'd incorrectly
-        // try and read data from an invalid memory address, causing undefined behavior.
-        if bytes_len == MAX_SIZE {
-            let last_byte = bytes[bytes_len - 1];
-            // If we hit the edge case, reserve additional space to make the repr becomes heap
-            // allocated, which prevents us from writing this last byte inline
-            if last_byte >= 0b11000000 {
-                repr.reserve(MAX_SIZE + 1)?;
-            }
-        }
-
         // SAFETY: The caller is responsible for making sure the provided buffer is UTF-8. This
         // invariant is documented in the public API
         let slice = repr.as_mut_buf();

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -301,11 +301,11 @@ fn proptest_remove(#[strategy(rand_unicode_with_range(1..80))] mut control: Stri
 
 #[proptest]
 #[cfg_attr(miri, ignore)]
-fn proptest_from_utf8_unchecked(#[strategy(rand_bytes())] bytes: Vec<u8>) {
-    let compact = unsafe { CompactString::from_utf8_unchecked(&bytes) };
-    let std_str = unsafe { String::from_utf8_unchecked(bytes.clone()) };
+fn proptest_from_utf8_unchecked(#[strategy(rand_unicode())] std_str: String) {
+    let bytes = std_str.as_bytes();
+    let compact = unsafe { CompactString::from_utf8_unchecked(bytes) };
 
-    // we might not make valid strings, but we should be able to read the underlying bytes
+    // we should be able to read the underlying bytes
     assert_eq!(compact.as_bytes(), std_str.as_bytes());
     assert_eq!(compact.as_bytes(), bytes);
 
@@ -314,7 +314,7 @@ fn proptest_from_utf8_unchecked(#[strategy(rand_bytes())] bytes: Vec<u8>) {
 
     // check if we were valid UTF-8, if so, assert the data written into the CompactString is
     // correct
-    let data_is_valid = core::str::from_utf8(&bytes);
+    let data_is_valid = core::str::from_utf8(bytes);
     let compact_is_valid = core::str::from_utf8(compact.as_bytes());
     let std_str_is_valid = core::str::from_utf8(std_str.as_bytes());
 


### PR DESCRIPTION
This PR removes the following code from `Repr::from_utf8_unchecked`:

https://github.com/ParkMyCar/compact_str/blob/d4798639c24cacf528770d83e8842336b79fbc39/compact_str/src/repr/mod.rs#L126-L137

In my opinion, this code should be removed for 2 reasons:

1. It is part of the safety contract for `from_utf8_unchecked` that `buf` is the bytes of a valid UTF8 string. This check penalizes users who follow the safety contract (which everyone should), in order to support users who don't (and therefore have opted in to UB).
2. This check alone is not enough to avoid UB anyway. If `buf` ends with the first byte of a multi-byte Unicode character, for example calling `.as_str().chars().collect::<Vec<char>>()` on the resulting `CompactString` will cause an out of bounds read.