### PR TITLE
fix: More `PartialEq` impls

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -2033,9 +2033,39 @@ impl<T: AsRef<str>> PartialEq<T> for CompactString {
     }
 }
 
+impl PartialEq<CompactString> for &CompactString {
+    fn eq(&self, other: &CompactString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
 impl PartialEq<CompactString> for String {
     fn eq(&self, other: &CompactString) -> bool {
         self.as_str() == other.as_str()
+    }
+}
+
+impl<'a> PartialEq<&'a CompactString> for String {
+    fn eq(&self, other: &&CompactString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<CompactString> for &String {
+    fn eq(&self, other: &CompactString) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialEq<CompactString> for str {
+    fn eq(&self, other: &CompactString) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl<'a> PartialEq<&'a CompactString> for str {
+    fn eq(&self, other: &&CompactString) -> bool {
+        self == other.as_str()
     }
 }
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -624,8 +624,7 @@ impl CompactString {
     ///
     /// # Safety
     /// * All Rust strings, including `CompactString`, must be valid UTF-8. The caller must
-    ///   guarantee
-    /// that any modifications made to the underlying buffer are valid UTF-8.
+    ///   guarantee that any modifications made to the underlying buffer are valid UTF-8.
     ///
     /// # Examples
     /// ```
@@ -2027,7 +2026,7 @@ impl BorrowMut<str> for CompactString {
 
 impl Eq for CompactString {}
 
-impl<T: AsRef<str>> PartialEq<T> for CompactString {
+impl<T: AsRef<str> + ?Sized> PartialEq<T> for CompactString {
     fn eq(&self, other: &T) -> bool {
         self.as_str() == other.as_ref()
     }
@@ -2075,9 +2074,33 @@ impl PartialEq<CompactString> for &str {
     }
 }
 
+impl PartialEq<CompactString> for &&str {
+    fn eq(&self, other: &CompactString) -> bool {
+        **self == other.as_str()
+    }
+}
+
 impl<'a> PartialEq<CompactString> for Cow<'a, str> {
     fn eq(&self, other: &CompactString) -> bool {
         *self == other.as_str()
+    }
+}
+
+impl<'a> PartialEq<CompactString> for &Cow<'a, str> {
+    fn eq(&self, other: &CompactString) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<String> for &CompactString {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl<'a> PartialEq<Cow<'a, str>> for &CompactString {
+    fn eq(&self, other: &Cow<'a, str>) -> bool {
+        self.as_str() == other
     }
 }
 

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -607,7 +607,7 @@ impl Repr {
     ///
     /// # SAFETY
     /// * The caller must guarantee that the provided [`Repr`] is actually a [`HeapBuffer`] by
-    /// checking the discriminant
+    ///   checking the discriminant.
     ///
     /// Note: We used to define [`Repr`] as a `union` which implicitly transmuted between the two
     /// types, but that prevented us from defining a "niche" value to make `Option<CompactString>`
@@ -621,7 +621,7 @@ impl Repr {
     ///
     /// # SAFETY
     /// * The caller must guarantee that the provided [`Repr`] is actually a [`HeapBuffer`] by
-    /// checking the discriminant
+    ///   checking the discriminant.
     ///
     /// Note: We used to define [`Repr`] as a `union` which implicitly transmuted between the two
     /// types, but that prevented us from defining a "niche" value to make `Option<CompactString>`
@@ -636,7 +636,7 @@ impl Repr {
     ///
     /// # SAFETY
     /// * The caller must guarantee that the provided [`Repr`] is actually a [`HeapBuffer`] by
-    /// checking the discriminant
+    ///   checking the discriminant.
     ///
     /// Note: We used to define [`Repr`] as a `union` which implicitly transmuted between the two
     /// types, but that prevented us from defining a "niche" value to make `Option<CompactString>`
@@ -651,7 +651,7 @@ impl Repr {
     ///
     /// # SAFETY
     /// * The caller must guarantee that the provided [`Repr`] is actually an [`InlineBuffer`] by
-    /// checking the discriminant
+    ///   checking the discriminant.
     ///
     /// Note: We used to define [`Repr`] as a `union` which implicitly transmuted between the two
     /// types, but that prevented us from defining a "niche" value to make `Option<CompactString>`
@@ -666,7 +666,7 @@ impl Repr {
     ///
     /// # SAFETY
     /// * The caller must guarantee that the provided [`Repr`] is actually an [`InlineBuffer`] by
-    /// checking the discriminant
+    ///   checking the discriminant.
     ///
     /// Note: We used to define [`Repr`] as a `union` which implicitly transmuted between the two
     /// types, but that prevented us from defining a "niche" value to make `Option<CompactString>`

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -639,6 +639,10 @@ fn test_plus_equals_operator_static_str() {
     assert_eq!(m, "ab");
 }
 
+// Allow these lints because we're explicitly testing impls for owned types and
+// reference types.
+#[allow(clippy::cmp_owned)]
+#[allow(clippy::op_ref)]
 #[test]
 fn test_eq_operator() {
     let x = CompactString::const_new("foo");

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -648,15 +648,22 @@ fn test_eq_operator() {
     let x = CompactString::const_new("foo");
     let y = x.clone();
 
-    let _ = "a" == x;
-    let _ = "a" == &x;
-    let _ = String::from("a") == x;
-    let _ = String::from("a") == &x;
-    let _ = &String::from("a") == x;
-    let _ = &String::from("a") == &x;
-    let _ = x == y;
-    let _ = &x == y;
-    let _ = &x == &y;
+    macro_rules! test_impl {
+        ($a:expr, $b:expr) => {
+            let _ = $a == $b;
+            let _ = &$a == $b;
+            let _ = &$a == &$b;
+
+            let _ = $b == $a;
+            let _ = &$b == $a;
+            let _ = &$b == &$a;
+        };
+    }
+
+    test_impl!("a", x);
+    test_impl!(String::from("a"), x);
+    test_impl!(Cow::Borrowed("a"), x);
+    test_impl!(y, x);
 }
 
 #[test]

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -640,6 +640,22 @@ fn test_plus_equals_operator_static_str() {
 }
 
 #[test]
+fn test_eq_operator() {
+    let x = CompactString::const_new("foo");
+    let y = x.clone();
+
+    let _ = "a" == x;
+    let _ = "a" == &x;
+    let _ = String::from("a") == x;
+    let _ = String::from("a") == &x;
+    let _ = &String::from("a") == x;
+    let _ = &String::from("a") == &x;
+    let _ = x == y;
+    let _ = &x == y;
+    let _ = &x == &y;
+}
+
+#[test]
 fn test_u8_to_compact_string() {
     let vals = [u8::MIN, 1, 42, u8::MAX - 2, u8::MAX - 1, u8::MAX];
 


### PR DESCRIPTION
This PR adds some more impls of PartialEq between `String`, `str`, and `CompactString`. 

Fixes https://github.com/ParkMyCar/compact_str/issues/372