### PR TITLE
api: Re-add `new_inline()` and `from_static_str()` as deprecated

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -235,14 +235,20 @@ impl CompactString {
     }
 
     /// Creates a new inline [`CompactString`] at compile time.
-    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new, will be removed in 0.9.0")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "replaced by CompactString::const_new, will be removed in 0.9.0"
+    )]
     #[inline]
     pub const fn new_inline(text: &'static str) -> Self {
         CompactString::const_new(text)
     }
 
     /// Creates a new inline [`CompactString`] from `&'static str` at compile time.
-    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new, will be removed in 0.9.0")]
+    #[deprecated(
+        since = "0.8.0",
+        note = "replaced by CompactString::const_new, will be removed in 0.9.0"
+    )]
     #[inline]
     pub const fn from_static_str(text: &'static str) -> Self {
         CompactString::const_new(text)

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -234,6 +234,20 @@ impl CompactString {
         CompactString(Repr::const_new(text))
     }
 
+    /// Creates a new inline [`CompactString`] at compile time.
+    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new")]
+    #[inline]
+    pub const fn new_inline(text: &'static str) -> Self {
+        CompactString::const_new(text)
+    }
+
+    /// Creates a new inline [`CompactString`] from `&'static str` at compile time.
+    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new")]
+    #[inline]
+    pub const fn from_static_str(text: &'static str) -> Self {
+        CompactString::const_new(text)
+    }
+
     /// Get back the `&'static str` constructed by [`CompactString::const_new`].
     ///
     /// If the string was short enough that it could be inlined, then it was inline, and

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -235,14 +235,14 @@ impl CompactString {
     }
 
     /// Creates a new inline [`CompactString`] at compile time.
-    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new")]
+    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new, will be removed in 0.9.0")]
     #[inline]
     pub const fn new_inline(text: &'static str) -> Self {
         CompactString::const_new(text)
     }
 
     /// Creates a new inline [`CompactString`] from `&'static str` at compile time.
-    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new")]
+    #[deprecated(since = "0.8.0", note = "replaced by CompactString::const_new, will be removed in 0.9.0")]
     #[inline]
     pub const fn from_static_str(text: &'static str) -> Self {
         CompactString::const_new(text)


### PR DESCRIPTION
https://github.com/ParkMyCar/compact_str/pull/336 removed these APIs in favor of `CompactString::const_new()`, I still think that's a great idea but want to retain these APIs for one release, marked as deprecated.