### PR TITLE
Add `borsh` support

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std", "borsh"]
+default = ["std"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -16,6 +16,7 @@ default = ["std"]
 std = []
 
 arbitrary = ["dep:arbitrary"]
+borsh = ["dep:borsh"]
 bytes = ["dep:bytes"]
 diesel = ["dep:diesel"]
 markup = ["dep:markup"]
@@ -31,6 +32,7 @@ sqlx-sqlite = ["sqlx", "sqlx/sqlite"]
 
 [dependencies]
 arbitrary = { version = "1", optional = true, default-features = false }
+borsh = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
 diesel = { version = "2", optional = true, default-features = false }
 markup = { version = "0.13", optional = true, default-features = false }

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std"]
+default = ["std", "borsh"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/src/features/borsh.rs
+++ b/compact_str/src/features/borsh.rs
@@ -1,0 +1,78 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+
+use borsh::io::{
+    Error,
+    ErrorKind,
+    Read,
+    Result,
+    Write,
+};
+use borsh::{
+    BorshDeserialize,
+    BorshSerialize,
+};
+
+use crate::CompactString;
+
+impl BorshSerialize for CompactString {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+        self.as_str().serialize(writer)
+    }
+}
+
+impl BorshDeserialize for CompactString {
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self> {
+        let len = u32::deserialize_reader(&mut *reader)? as usize;
+
+        // Do not call `Error::new` on OOM as it allocates.
+        let mut s = CompactString::try_with_capacity(len).map_err(|_| ErrorKind::OutOfMemory)?;
+
+        // SAFETY: The current length is zero so the bytes are uninterpreted
+        // and don't have to form valid UTF-8
+        let buf = unsafe { s.as_mut_bytes() };
+
+        reader.read_exact(&mut buf[..len])?;
+        std::str::from_utf8(&buf[..len]).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+
+        // SAFETY: The first `len` bytes are initialized and are valid UTF-8
+        unsafe { s.set_len(len) };
+
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use test_strategy::proptest;
+
+    use crate::CompactString;
+
+    #[test]
+    fn test_roundtrip() {
+        const VALUE: &str = "Hello, 🌍!";
+
+        let bytes_compact = borsh::to_vec(&CompactString::from(VALUE)).unwrap();
+        let bytes_control = borsh::to_vec(&String::from(VALUE)).unwrap();
+        assert_eq!(&*bytes_compact, &*bytes_control);
+
+        let compact: CompactString = borsh::from_slice(&bytes_compact).unwrap();
+        let control: String = borsh::from_slice(&bytes_control).unwrap();
+        assert_eq!(compact, VALUE);
+        assert_eq!(control, VALUE);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[proptest]
+    fn proptest_roundtrip(s: String) {
+        let bytes_compact = borsh::to_vec(&CompactString::from(&s)).unwrap();
+        let bytes_control = borsh::to_vec(&String::from(&s)).unwrap();
+        assert_eq!(&*bytes_compact, &*bytes_control);
+
+        let compact: CompactString = borsh::from_slice(&bytes_compact).unwrap();
+        let control: String = borsh::from_slice(&bytes_control).unwrap();
+        assert_eq!(compact, s);
+        assert_eq!(control, s);
+    }
+}

--- a/compact_str/src/features/borsh.rs
+++ b/compact_str/src/features/borsh.rs
@@ -38,8 +38,7 @@ impl BorshDeserialize for CompactString {
         } else {
             let mut buf = Vec::new();
             buf.try_reserve_exact(len)?;
-            buf.resize(len, 0u8);
-            reader.read_exact(&mut buf[..])?;
+            reader.take(len as u64).read_to_end(&mut buf)?;
             let s =
                 String::from_utf8(buf).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
             Ok(CompactString::from(s))

--- a/compact_str/src/features/borsh.rs
+++ b/compact_str/src/features/borsh.rs
@@ -32,7 +32,7 @@ impl BorshDeserialize for CompactString {
         let buf = unsafe { s.as_mut_bytes() };
 
         reader.read_exact(&mut buf[..len])?;
-        std::str::from_utf8(&buf[..len]).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
+        core::str::from_utf8(&buf[..len]).map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
 
         // SAFETY: The first `len` bytes are initialized and are valid UTF-8
         unsafe { s.set_len(len) };

--- a/compact_str/src/features/borsh.rs
+++ b/compact_str/src/features/borsh.rs
@@ -47,6 +47,10 @@ mod tests {
 
     use test_strategy::proptest;
 
+    use crate::repr::{
+        HEAP_MASK,
+        MAX_SIZE,
+    };
     use crate::CompactString;
 
     #[test]
@@ -61,6 +65,12 @@ mod tests {
         let control: String = borsh::from_slice(&bytes_control).unwrap();
         assert_eq!(compact, VALUE);
         assert_eq!(control, VALUE);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_utf8() {
+        let bytes = borsh::to_vec(&[HEAP_MASK; MAX_SIZE] as &[u8]).unwrap();
+        borsh::from_slice::<CompactString>(&bytes).unwrap_err();
     }
 
     #[cfg_attr(miri, ignore)]

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
+#[cfg(feature = "borsh")]
+mod borsh;
 #[cfg(feature = "bytes")]
 mod bytes;
 #[cfg(feature = "diesel")]


### PR DESCRIPTION
This PR adds support for the `borsh` serialization library, similar to that of `serde` and `rkyv`.