### PR TITLE
fix: MSRV check and change MSRV to 1.60

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -37,4 +37,4 @@ jobs:
         #
         # See <https://github.com/rust-lang/api-guidelines/discussions/231>
         run: |
-          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.59..
+          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.60..

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   msrv:
-    name: cargo check msrv 1.59..
+    name: cargo check msrv...
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,18 +29,12 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
 
-      - name: cargo test msrv..
-        # Note: we exclude both `arbitrary` and `proptest` from here because their MSRVs were both
-        # bumped on a minor version release:
+      - name: cargo check msrv..
+        # Note: For a while we tried including all of our features in the MSRV
+        # check but it ended up being very flaky since a change in MSRV is not
+        # considered a breaking change, so often the feature crates would bump
+        # their MSRV causing this test to break.
         #
-        # - abitrary >= 1.1.14 has an MSRV >= 1.63
-        # - proptest >= 1.1.0 has an MSRV >= 1.65
-        #
-        # Instead of pinning to a specific version of `arbitrary` or `proptest`, we'll let user's 
-        # deps decide the version since the API should still be semver compatible.
-        #
-        # Note2: Even though our MSRV is 1.59, we only test from 1.60 because we hit the issue
-        # described in <https://github.com/rust-lang/cargo/issues/10189> when using 1.59.
+        # See <https://github.com/rust-lang/api-guidelines/discussions/231>
         run: |
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec --manifest-path=compact_str/Cargo.toml --version-range 1.60..
-          cargo hack check --features bytes,markup,quickcheck,rkyv,serde,smallvec,proptest,arbitrary --manifest-path=compact_str/Cargo.toml --version-range 1.65..
+          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.59..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
 
-      - name: cargo test msrv..
+      - name: cargo check feature-powerset
         run: |
-          cd compact_str
-          cargo hack check --feature-powerset --optional-deps
+          cargo hack check --manifest-path=compact_str/Cargo.toml --feature-powerset --optional-deps

--- a/compact_str/README.md
+++ b/compact_str/README.md
@@ -5,7 +5,7 @@
   <a href="https://crates.io/crates/compact_str">
     <img alt="version on crates.io" src="https://img.shields.io/crates/v/compact_str"/>
   </a>
-  <img alt="Minimum supported Rust Version: 1.59" src="https://img.shields.io/badge/MSRV-1.59-blueviolet">
+  <img alt="Minimum supported Rust Version: 1.60" src="https://img.shields.io/badge/MSRV-1.60-blueviolet">
   <a href="LICENSE">
     <img alt="mit license" src="https://img.shields.io/crates/l/compact_str"/>
   </a>
@@ -142,7 +142,7 @@ Specifically, the last byte on the stack for a `CompactString` has the following
 ### Testing
 Strings and unicode can be quite messy, even further, we're working with things at the bit level. `compact_str` has an _extensive_ test suite comprised of unit testing, property testing, and fuzz testing, to ensure our invariants are upheld. We test across all major OSes (Windows, macOS, and Linux), architectures (64-bit and 32-bit), and endian-ness (big endian and little endian).
 
-Fuzz testing is run with `libFuzzer`, `AFL++`, *and* `honggfuzz`, with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every Rust compiler since `v1.59` to ensure support for our minimum supported Rust version (MSRV).
+Fuzz testing is run with `libFuzzer`, `AFL++`, *and* `honggfuzz`, with `AFL++` running on both `x86_64` and `ARMv7` architectures. We test with [`miri`](https://github.com/rust-lang/miri) to catch cases of undefined behavior, and run all tests on every Rust compiler since `v1.60` to ensure support for our minimum supported Rust version (MSRV).
 
 ### `unsafe` code
 `CompactString` uses a bit of unsafe code because we manually define what variant we are, so unlike an enum, the compiler can't guarantee what value is actually stored.


### PR DESCRIPTION
Changes the MSRV check to not enable features which is too flaky, it also updates the MSRV to 1.60. Technically the MSRV was already `1.60` because of optional features using `dep:...` which isn't supported in Rust 1.59