### PR TITLE
impl sqlx::postgres::PgHasArrayType

### DIFF
--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -87,6 +87,14 @@ impl<'q> Encode<'q, sqlx::Postgres> for CompactString {
     }
 }
 
+#[cfg(feature = "sqlx-postgres")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx-postgres")))]
+impl sqlx::postgres::PgHasArrayType for CompactString {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        <std::string::String as sqlx::postgres::PgHasArrayType>::array_type_info()
+    }
+}
+
 #[cfg(feature = "sqlx-sqlite")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx-sqlite")))]
 impl<'q> Encode<'q, sqlx::Sqlite> for CompactString {


### PR DESCRIPTION
This impl is necessary to use `CompactString` in newtypes