### PR TITLE
pub(crate) private code

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::string::String;
-#[doc(hidden)]
+#[doc(hidden)] // Referenced in macros.
 pub use core;
 use core::borrow::{
     Borrow,

--- a/compact_str/src/repr/bytes.rs
+++ b/compact_str/src/repr/bytes.rs
@@ -10,7 +10,7 @@ use crate::UnwrapWithMsg;
 
 impl Repr {
     /// Converts a [`Buf`] of bytes to a [`Repr`], checking that the provided bytes are valid UTF-8
-    pub fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
+    pub(crate) fn from_utf8_buf<B: Buf>(buf: &mut B) -> Result<Self, Utf8Error> {
         // SAFETY: We check below to make sure the provided buffer is valid UTF-8
         let (repr, bytes_written) = unsafe { Self::collect_buf(buf) };
 
@@ -25,7 +25,7 @@ impl Repr {
     ///
     /// # Safety
     /// * The provided buffer must be valid UTF-8
-    pub unsafe fn from_utf8_buf_unchecked<B: Buf>(buf: &mut B) -> Self {
+    pub(crate) unsafe fn from_utf8_buf_unchecked<B: Buf>(buf: &mut B) -> Self {
         let (repr, _bytes_written) = Self::collect_buf(buf);
         repr
     }

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -26,7 +26,7 @@ const HEAP_MARKER: usize = {
 const CAPACITY_IS_ON_THE_HEAP: Capacity = Capacity(VALID_MASK | HEAP_MARKER);
 
 /// The maximum value we're able to store, e.g. on 64-bit arch this is 2^56 - 2.
-pub const MAX_VALUE: usize = {
+pub(crate) const MAX_VALUE: usize = {
     let mut bytes = [255; USIZE_SIZE];
     bytes[USIZE_SIZE - 1] = 0;
     usize::from_le_bytes(bytes) - 1
@@ -51,7 +51,7 @@ pub const MAX_VALUE: usize = {
 /// string larger than 16 megabytes probably isn't that uncommon.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct Capacity(usize);
+pub(crate) struct Capacity(usize);
 
 static_assertions::assert_eq_size!(Capacity, usize);
 static_assertions::assert_eq_align!(Capacity, usize);
@@ -64,7 +64,7 @@ impl fmt::Debug for Capacity {
 
 impl Capacity {
     #[inline]
-    pub const fn new(capacity: usize) -> Self {
+    pub(crate) const fn new(capacity: usize) -> Self {
         cfg_if::cfg_if! {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit arches we can always fit the capacity inline
@@ -93,14 +93,14 @@ impl Capacity {
     /// # SAFETY:
     /// * `self` must be less than or equal to [`MAX_VALUE`]
     #[inline(always)]
-    pub unsafe fn as_usize(self) -> usize {
+    pub(crate) unsafe fn as_usize(self) -> usize {
         usize::from_le(self.0 & VALID_MASK)
     }
 
     /// Returns whether or not this [`Capacity`] has a value that indicates the capacity is being
     /// stored on the heap
     #[inline(always)]
-    pub fn is_heap(self) -> bool {
+    pub(crate) fn is_heap(self) -> bool {
         self == CAPACITY_IS_ON_THE_HEAP
     }
 }

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -9,11 +9,11 @@ use super::{
 /// A buffer stored on the stack whose size is equal to the stack size of `String`
 #[cfg(target_pointer_width = "64")]
 #[repr(C, align(8))]
-pub struct InlineBuffer(pub [u8; MAX_SIZE]);
+pub(crate) struct InlineBuffer(pub(crate) [u8; MAX_SIZE]);
 
 #[cfg(target_pointer_width = "32")]
 #[repr(C, align(4))]
-pub struct InlineBuffer(pub [u8; MAX_SIZE]);
+pub(crate) struct InlineBuffer(pub(crate) [u8; MAX_SIZE]);
 
 static_assertions::assert_eq_size!(InlineBuffer, Repr);
 static_assertions::assert_eq_align!(InlineBuffer, Repr);
@@ -24,7 +24,7 @@ impl InlineBuffer {
     /// SAFETY:
     /// * The caller must guarantee that the length of `text` is less than [`MAX_SIZE`]
     #[inline]
-    pub unsafe fn new(text: &str) -> Self {
+    pub(crate) unsafe fn new(text: &str) -> Self {
         debug_assert!(text.len() <= MAX_SIZE);
 
         let len = text.len();
@@ -50,7 +50,7 @@ impl InlineBuffer {
     }
 
     #[inline]
-    pub const fn new_const(text: &str) -> Self {
+    pub(crate) const fn new_const(text: &str) -> Self {
         if text.len() > MAX_SIZE {
             panic!("Provided string has a length greater than our MAX_SIZE");
         }
@@ -76,7 +76,7 @@ impl InlineBuffer {
 
     /// Returns an empty [`InlineBuffer`]
     #[inline(always)]
-    pub const fn empty() -> Self {
+    pub(crate) const fn empty() -> Self {
         Self::new_const("")
     }
 
@@ -84,7 +84,7 @@ impl InlineBuffer {
     /// string that it contains
     #[inline]
     #[cfg(feature = "smallvec")]
-    pub fn into_array(self) -> ([u8; MAX_SIZE], usize) {
+    pub(crate) fn into_array(self) -> ([u8; MAX_SIZE], usize) {
         let mut buffer = self.0;
 
         let length = core::cmp::min(
@@ -110,7 +110,7 @@ impl InlineBuffer {
     /// # SAFETY:
     /// * The caller must guarantee that `len` bytes in the buffer are valid UTF-8
     #[inline]
-    pub unsafe fn set_len(&mut self, len: usize) {
+    pub(crate) unsafe fn set_len(&mut self, len: usize) {
         debug_assert!(len <= MAX_SIZE);
 
         // If `length` == MAX_SIZE, then we infer the length to be the capacity of the buffer. We

--- a/compact_str/src/repr/last_utf8_char.rs
+++ b/compact_str/src/repr/last_utf8_char.rs
@@ -9,7 +9,7 @@ use alloc::string::String;
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-pub enum LastUtf8Char {
+pub(crate) enum LastUtf8Char {
     // single character, ASCII:
     V0 = 0,
     V1 = 1,

--- a/compact_str/src/repr/smallvec.rs
+++ b/compact_str/src/repr/smallvec.rs
@@ -10,7 +10,7 @@ impl Repr {
     ///
     /// Note: both for the inlined case and the heap case, the buffers are re-used
     #[inline]
-    pub fn into_bytes(self) -> SmallVec<[u8; MAX_SIZE]> {
+    pub(crate) fn into_bytes(self) -> SmallVec<[u8; MAX_SIZE]> {
         if let Some(s) = self.as_static_str() {
             SmallVec::from(s.as_bytes())
         } else if self.is_heap_allocated() {

--- a/compact_str/src/repr/static_str.rs
+++ b/compact_str/src/repr/static_str.rs
@@ -17,7 +17,7 @@ pub(super) const DISCRIMINANT_SIZE: usize = MAX_SIZE - mem::size_of::<&'static s
 /// The last byte is set to 0.
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct StaticStr {
+pub(crate) struct StaticStr {
     ptr: ptr::NonNull<u8>,
     len: usize,
     #[allow(unused)]
@@ -29,7 +29,7 @@ static_assertions::assert_eq_size!(&'static str, (*const u8, usize));
 
 impl StaticStr {
     #[inline]
-    pub const fn new(text: &'static str) -> Self {
+    pub(crate) const fn new(text: &'static str) -> Self {
         let mut discriminant = [0; DISCRIMINANT_SIZE];
         discriminant[DISCRIMINANT_SIZE - 1] = STATIC_STR_MASK;
 

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -30,22 +30,24 @@ const MAX_SIZE: usize = 12;
 const SIXTEEN_MB: usize = 16 * 1024 * 1024;
 
 /// generates random unicode strings, upto 80 chars long
-pub fn rand_unicode() -> impl Strategy<Value = String> {
+pub(crate) fn rand_unicode() -> impl Strategy<Value = String> {
     proptest::collection::vec(proptest::char::any(), 0..80).prop_map(|v| v.into_iter().collect())
 }
 
 /// generates a random collection of bytes, upto 80 bytes long
-pub fn rand_bytes() -> impl Strategy<Value = Vec<u8>> {
+pub(crate) fn rand_bytes() -> impl Strategy<Value = Vec<u8>> {
     proptest::collection::vec(any::<u8>(), 0..80)
 }
 
 /// generates a random collection of `u16`s, upto 80 elements long
-pub fn rand_u16s() -> impl Strategy<Value = Vec<u16>> {
+pub(crate) fn rand_u16s() -> impl Strategy<Value = Vec<u16>> {
     proptest::collection::vec(any::<u16>(), 0..80)
 }
 
 /// [`proptest::strategy::Strategy`] that generates [`String`]s with up to `len` bytes
-pub fn rand_unicode_with_range(range: impl Into<SizeRange>) -> impl Strategy<Value = String> {
+pub(crate) fn rand_unicode_with_range(
+    range: impl Into<SizeRange>,
+) -> impl Strategy<Value = String> {
     proptest::collection::vec(proptest::char::any(), range).prop_map(|v| v.into_iter().collect())
 }
 

--- a/compact_str/src/unicode_data.rs
+++ b/compact_str/src/unicode_data.rs
@@ -55,7 +55,7 @@ const fn decode_length(short_offset_run_header: u32) -> usize {
 }
 
 #[rustfmt::skip]
-pub mod case_ignorable {
+pub(crate) mod case_ignorable {
     static SHORT_OFFSET_RUNS: [u32; 35] = [
         688, 44045149, 572528402, 576724925, 807414908, 878718981, 903913493, 929080568, 933275148,
         937491230, 1138818560, 1147208189, 1210124160, 1222707713, 1235291428, 1260457643,
@@ -98,7 +98,7 @@ pub mod case_ignorable {
         14, 0, 1, 61, 4, 0, 5, 0, 7, 109, 8, 0, 5, 0, 1, 30, 96, 128, 240, 0,
     ];
     #[inline(always)]
-    pub fn lookup(c: char) -> bool {
+    pub(crate) fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
             &SHORT_OFFSET_RUNS,
@@ -108,7 +108,7 @@ pub mod case_ignorable {
 }
 
 #[rustfmt::skip]
-pub mod cased {
+pub(crate) mod cased {
     static SHORT_OFFSET_RUNS: [u32; 22] = [
         4256, 115348384, 136322176, 144711446, 163587254, 320875520, 325101120, 350268208,
         392231680, 404815649, 413205504, 421595008, 467733632, 484513952, 492924480, 497144832,
@@ -129,7 +129,7 @@ pub mod cased {
         0, 62, 0, 68, 0, 26, 6, 26, 6, 26, 0,
     ];
     #[inline(always)]
-    pub fn lookup(c: char) -> bool {
+    pub(crate) fn lookup(c: char) -> bool {
         super::skip_search(
             c as u32,
             &SHORT_OFFSET_RUNS,


### PR DESCRIPTION
When reading sources, make it more obvious what is public API, and
what is internals.

Also `pub(crate)` prevents exposing internals accidentally.
