### PR TITLE
Document CompactString has niches

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -2686,3 +2686,4 @@ fn unwrap_with_msg_fail<E: fmt::Display>(error: E) -> ! {
 }
 
 static_assertions::assert_eq_size!(CompactString, String);
+static_assertions::assert_eq_size!(Option<CompactString>, CompactString);


### PR DESCRIPTION
Add `assert_eq_size!` assertion.