### PR TITLE
docs: Update some naming and README

### DIFF
--- a/compact_str/README.md
+++ b/compact_str/README.md
@@ -154,10 +154,17 @@ That being said, uses of unsafe code in this library are constrained to only whe
 
 ### Similar Crates
 Storing strings on the stack is not a new idea, in fact there are a few other crates in the Rust ecosystem that do similar things, an incomplete list:
-1. [`smol_str`](https://crates.io/crates/smol_str) - Can inline 22 bytes, `Clone` is `O(1)`, doesn't adjust for 32-bit archs
-2. [`smartstring`](https://crates.io/crates/smartstring) - Can inline 23 bytes, `Clone` is `O(n)`, is mutable
-3. [`kstring`](https://crates.io/crates/kstring) - Can inline 15 or 22 bytes dependent on crate features, `Clone` is `O(1)`, can also store `&'static str`s
-4. [`flexstr`](https://crates.io/crates/flexstr) - Can inline 22 bytes, `Clone` is `O(1)`, can also store `&'static str`s
+
+*  [`arcstr`](https://crates.io/crates/arcstr)
+*  [`byteyarn`](https://crates.io/crates/byteyarn)
+*  [`ecow`](https://crates.io/crates/ecow)
+*  [`flexstr`](https://crates.io/crates/flexstr)
+*  [`hipstr`](https://crates.io/crates/hipstr)
+*  [`imstr`](https://crates.io/crates/imstr)
+*  [`kstring`](https://crates.io/crates/kstring)
+*  [`smartstring`](https://crates.io/crates/smartstring)
+
+For a comparison of all these crates (and possibly more!) please see the [Rust String Benchmarks](https://github.com/rosetta-rs/string-rosetta-rs).
 
 <br />
 Thanks for readingme!

--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::repr::LastUtf8Char;
+use crate::repr::LastByte;
 
 // how many bytes a `usize` occupies
 const USIZE_SIZE: usize = core::mem::size_of::<usize>();
@@ -15,13 +15,13 @@ const VALID_MASK: usize = {
 /// Mask of bits that are set in [`Capacity`] if the string data is stored on the heap.
 const HEAP_MARKER: usize = {
     let mut bytes = [0; USIZE_SIZE];
-    bytes[USIZE_SIZE - 1] = LastUtf8Char::Heap as u8;
+    bytes[USIZE_SIZE - 1] = LastByte::Heap as u8;
     usize::from_ne_bytes(bytes)
 };
 
 /// State that describes the capacity as being stored on the heap.
 ///
-/// All bytes `255`, with the last being [`LastUtf8Char::Heap`], using the same amount of bytes
+/// All bytes `255`, with the last being [`LastByte::Heap`], using the same amount of bytes
 /// as `usize`. Example (64-bit): `[255, 255, 255, 255, 255, 255, 255, 216]`
 const CAPACITY_IS_ON_THE_HEAP: Capacity = Capacity(VALID_MASK | HEAP_MARKER);
 
@@ -78,7 +78,7 @@ impl Capacity {
                     // the heap. return an Error so `BoxString` can do the right thing
                     CAPACITY_IS_ON_THE_HEAP
                 } else {
-                    // otherwise, we can store this capacity inline! Set the last byte to be our `LastUtf8Char::Heap as u8`
+                    // otherwise, we can store this capacity inline! Set the last byte to be our `LastByte::Heap as u8`
                     // for our discriminant, using the leading bytes to store the actual value
                     Capacity(capacity.to_le() | HEAP_MARKER)
                 }

--- a/compact_str/src/repr/last_utf8_char.rs
+++ b/compact_str/src/repr/last_utf8_char.rs
@@ -1,15 +1,15 @@
 use alloc::string::String;
 
-/// [`LastUtf8Char`] is an unsigned 8-bit integer data type that has a valid range of `[0, 216]`.
-/// Excluding `[217, 255]` allows the Rust compiler to use these values as niches.
+/// [`LastByte`] is an unsigned 8-bit integer data type that has a valid range of `[0, 217]`.
+/// Excluding `[218, 255]` allows the Rust compiler to use these values as niches.
 ///
 /// Specifically the compiler can use a value in this range to encode the `None` variant of
-/// `Option<NonMaxU8>` allowing
-/// `std::mem::size_of::<NonMaxU8> == std::mem::size_of::<Option<NonMaxU8>>()`
+/// `Option<LastByte>` allowing:
+/// `std::mem::size_of::<LastByte> == std::mem::size_of::<Option<LastByte>>()`
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-pub(crate) enum LastUtf8Char {
+pub(crate) enum LastByte {
     // single character, ASCII:
     V0 = 0,
     V1 = 1,
@@ -241,5 +241,5 @@ pub(crate) enum LastUtf8Char {
     Static = 217,
 }
 
-static_assertions::assert_eq_size!(LastUtf8Char, Option<LastUtf8Char>, u8);
+static_assertions::assert_eq_size!(LastByte, Option<LastByte>, u8);
 static_assertions::const_assert!(core::mem::size_of::<String>() <= 24);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -53,10 +53,12 @@ pub(crate) struct Repr(
     /// Then we need two `usize`s (aka WORDs) of data, for the first we just define a `usize`...
     usize,
     /// ...but the second we breakup into multiple pieces...
-    #[cfg(target_pointer_width = "64")] u32,
+    #[cfg(target_pointer_width = "64")]
+    u32,
     u16,
     u8,
-    /// ...so that the last byte can be a [`LastByte`], which allows the compiler to see a niche value.
+    /// ...so that the last byte can be a [`LastByte`], which allows the compiler to see a niche
+    /// value.
     LastByte,
 );
 static_assertions::assert_eq_size!([u8; MAX_SIZE], Repr);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -25,7 +25,7 @@ use alloc::string::String;
 use capacity::Capacity;
 use heap::HeapBuffer;
 use inline::InlineBuffer;
-use last_utf8_char::LastUtf8Char;
+use last_utf8_char::LastByte;
 use static_str::StaticStr;
 pub(crate) use traits::IntoRepr;
 
@@ -37,9 +37,9 @@ use crate::{
 /// The max size of a string we can fit inline
 pub(crate) const MAX_SIZE: usize = core::mem::size_of::<String>();
 /// Used as a discriminant to identify different variants
-pub(crate) const HEAP_MASK: u8 = LastUtf8Char::Heap as u8;
+pub(crate) const HEAP_MASK: u8 = LastByte::Heap as u8;
 /// Used for `StaticStr` variant
-pub(crate) const STATIC_STR_MASK: u8 = LastUtf8Char::Static as u8;
+pub(crate) const STATIC_STR_MASK: u8 = LastByte::Static as u8;
 /// When our string is stored inline, we represent the length of the string in the last byte, offset
 /// by `LENGTH_MASK`
 pub(crate) const LENGTH_MASK: u8 = 0b11000000;
@@ -48,16 +48,16 @@ const EMPTY: Repr = Repr::const_new("");
 
 #[repr(C)]
 pub(crate) struct Repr(
-    // We have a pointer in the representation to properly carry provenance
+    /// We have a pointer in the representation to properly carry provenance.
     *const (),
-    // Then we need two `usize`s (aka WORDs) of data, for the first we just define a `usize`...
+    /// Then we need two `usize`s (aka WORDs) of data, for the first we just define a `usize`...
     usize,
-    // ...but the second we breakup into multiple pieces...
+    /// ...but the second we breakup into multiple pieces...
     #[cfg(target_pointer_width = "64")] u32,
     u16,
     u8,
-    // ...so that the last byte can be a NonMax, which allows the compiler to see a niche value
-    LastUtf8Char,
+    /// ...so that the last byte can be a [`LastByte`], which allows the compiler to see a niche value.
+    LastByte,
 );
 static_assertions::assert_eq_size!([u8; MAX_SIZE], Repr);
 
@@ -420,8 +420,8 @@ impl Repr {
     pub(crate) fn is_empty(&self) -> bool {
         let len_heap = ensure_read(self.1);
         let last_byte = self.last_byte() as usize;
-        let mut len = last_byte.wrapping_sub(LastUtf8Char::L0 as u8 as usize);
-        if last_byte >= LastUtf8Char::Heap as u8 as usize {
+        let mut len = last_byte.wrapping_sub(LastByte::L0 as u8 as usize);
+        if last_byte >= LastByte::Heap as u8 as usize {
             len = len_heap;
         }
         len == 0


### PR DESCRIPTION
As suggested during the discussion on [HackerNews](https://news.ycombinator.com/item?id=41338776)

* Update the name of `LastByteUtf8` to `LastByte` since it represents more than just the possible values of the last byte of a UTF-8 char.
* Update the README to include more similar crates