### PR TITLE
Update Cargo.toml

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -34,7 +34,7 @@ sqlx-sqlite = ["sqlx", "sqlx/sqlite"]
 arbitrary = { version = "1", optional = true, default-features = false }
 borsh = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
-diesel = { version = "2", optional = true, default-features = false }
+diesel = { version = "2.2.3", optional = true, default-features = false }
 markup = { version = "0.13", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = ["std"] }
 quickcheck = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)