### PR TITLE
feat: tweak the `CompactStringExt` trait so `join_compact` and `concat_compact` work better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolchain: "1.83.0"
+          - toolchain: "1.85.0"
           - toolchain: "nightly-2024-12-20"
 
     name: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   RUSTFLAGS: "-D warnings"
   PROPTEST_CASES: 10000
   MIRIFLAGS: "-Zmiri-strict-provenance"
-  RUST_VERSION: 1.83.0
+  RUST_VERSION: 1.85.0
   RUST_NIGHTLY_VERSION: "nightly-2024-12-20"
 
 jobs:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,7 +10,7 @@ name: Clippy
 env:
   CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
-  RUST_VERSION: 1.83.0
+  RUST_VERSION: 1.85.0
   RUST_NIGHTLY_VERSION: "nightly-2024-12-20"
 
 jobs:

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -328,7 +328,7 @@ impl Repr {
         let slice = unsafe { self.as_mut_buf() };
         let push_buffer = &mut slice[len..len + str_len];
 
-        debug_assert_eq!(push_buffer.len(), s.as_bytes().len());
+        debug_assert_eq!(push_buffer.len(), s.len());
 
         // Copy the string into our buffer
         push_buffer.copy_from_slice(s.as_bytes());

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -132,11 +132,11 @@ impl<T: fmt::Display> ToCompactString for T {
 /// let words = vec!["☀️", "🌕", "🌑", "☀️"];
 ///
 /// // directly concatenate all the words together
-/// let concat = words.concat_compact();
+/// let concat = words.iter().concat_compact();
 /// assert_eq!(concat, "☀️🌕🌑☀️");
 ///
 /// // join the words, with a separator
-/// let join = words.join_compact(" ➡️ ");
+/// let join = words.iter().join_compact(" ➡️ ");
 /// assert_eq!(join, "☀️ ➡️ 🌕 ➡️ 🌑 ➡️ ☀️");
 /// ```
 pub trait CompactStringExt {

--- a/compact_str/src/traits.rs
+++ b/compact_str/src/traits.rs
@@ -233,11 +233,7 @@ mod tests {
         let compact = values.iter().map(|x| x.to_string()).join_compact("/");
         assert_eq!(compact, "foo/bar/baz");
 
-        let compact = values
-            .clone()
-            .into_iter()
-            .map(|x| x.trim())
-            .join_compact("-");
+        let compact = values.into_iter().map(|x| x.trim()).join_compact("-");
         assert_eq!(compact, "foo-bar-baz");
 
         let compact = values

--- a/fuzz/src/creation.rs
+++ b/fuzz/src/creation.rs
@@ -688,7 +688,7 @@ impl Creation<'_> {
                 Some((compact, word))
             }
             Join(collection, seperator) => {
-                let compact: CompactString = collection.join_compact(seperator);
+                let compact: CompactString = (&collection).join_compact(seperator);
                 let std_str: String = collection.join(seperator);
 
                 assert_eq!(compact, std_str);
@@ -697,7 +697,7 @@ impl Creation<'_> {
                 Some((compact, std_str))
             }
             Concat(collection) => {
-                let compact: CompactString = collection.concat_compact();
+                let compact: CompactString = (&collection).concat_compact();
                 let std_str: String = collection.concat();
 
                 assert_eq!(compact, std_str);


### PR DESCRIPTION
Fixes https://github.com/ParkMyCar/compact_str/issues/412

This is a possibly breaking change.

Previously `CompactStringExt` was (more or less) implemented for any type `C` where a `&C` implemented `IntoIterator<Item = &str>`. This worked well for when you wanted to join `Vec`s or slices, but would result in a confusing compile time error when you tried to join an iterator of some type, e.g. when you tried to do `values.iter().map(|val| val.trim()).join_compact(",")`.

There is a [blanket impl for `IntoIterator`](https://doc.rust-lang.org/src/core/iter/traits/collect.rs.html#351) for all types that implement `Iterator`, but our trait bound required some _reference_ of a type to implement `IntoIterator` which wasn't covered by this blanket impl.