### PR TITLE
fix: The `borsch` feature with no-std

### DIFF
--- a/compact_str/src/features/borsh.rs
+++ b/compact_str/src/features/borsh.rs
@@ -43,7 +43,7 @@ fn vec_from_reader<R: Read>(len: usize, reader: &mut R) -> Result<Vec<u8>> {
     // less efficient (since we need to loop and reallocate) but it protects
     // us from someone sending us [0xff, 0xff, 0xff, 0xff] and forcing us to
     // allocate 4GiB of memory.
-    let mut vec = vec![0u8; len.min(1024 * 1024)];
+    let mut vec = alloc::vec![0u8; len.min(1024 * 1024)];
     let mut pos = 0;
     while pos < len {
         if pos == vec.len() {


### PR DESCRIPTION
Fixes using the `borsch` feature in `no_std` contexts but qualifying the `vec!` macro