### PR TITLE
fix sqlx type impl, add utoipa feature

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std"]
+default = ["std", "sqlx", "sqlx-postgres", "sqlx-mysql", "sqlx-sqlite"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std"]
+default = ["std", "sqlx"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -31,6 +31,7 @@ sqlx-mysql = ["sqlx", "sqlx/mysql"]
 sqlx-postgres = ["sqlx", "sqlx/postgres"]
 sqlx-sqlite = ["sqlx", "sqlx/sqlite"]
 zeroize = ["dep:zeroize"]
+utoipa = ["dep:utoipa", "std"]
 
 [dependencies]
 arbitrary = { version = "1", optional = true, default-features = false }
@@ -46,6 +47,7 @@ serde = { version = "1", optional = true, default-features = false, features = [
 smallvec = { version = "1", optional = true, features = ["union"] }
 sqlx = { version = "0.8", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
+utoipa = { version = "5", optional = true, default-features = false }
 
 castaway = { version = "0.2.3", default-features = false, features = ["alloc"] }
 cfg-if = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1", optional = true, default-features = false, features = [
 smallvec = { version = "1", optional = true, features = ["union"] }
 sqlx = { version = "0.8", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
-utoipa = { version = "5", optional = true, default-features = false }
+utoipa = { version = "5", optional = true }
 
 castaway = { version = "0.2.3", default-features = false, features = ["alloc"] }
 cfg-if = "1"

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std", "sqlx"]
+default = ["std"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["string", "compact", "small", "memory", "mutable"]
 categories = ["encoding", "parsing", "memory-management", "text-processing"]
 
 [features]
-default = ["std", "sqlx", "sqlx-postgres", "sqlx-mysql", "sqlx-sqlite"]
+default = ["std"]
 std = []
 
 arbitrary = ["dep:arbitrary"]

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -24,7 +24,7 @@ mod serde;
 mod smallvec;
 #[cfg(feature = "sqlx")]
 mod sqlx;
-#[cfg(feature = "zeroize")]
-mod zeroize;
 #[cfg(feature = "utoipa")]
 mod utoipa;
+#[cfg(feature = "zeroize")]
+mod zeroize;

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -26,3 +26,5 @@ mod smallvec;
 mod sqlx;
 #[cfg(feature = "zeroize")]
 mod zeroize;
+#[cfg(feature = "utoipa")]
+mod utoipa;

--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -10,23 +10,6 @@ use sqlx::{Database, Decode, Type};
 use crate::{CompactString, ToCompactString};
 
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
-impl<DB> Type<DB> for CompactString
-where
-    DB: Database,
-    for<'x> &'x str: Type<DB>,
-{
-    #[inline]
-    fn type_info() -> <DB as Database>::TypeInfo {
-        <&str as Type<DB>>::type_info()
-    }
-
-    #[inline]
-    fn compatible(ty: &<DB as Database>::TypeInfo) -> bool {
-        <&str as Type<DB>>::compatible(ty)
-    }
-}
-
-#[cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
 impl<'r, DB> Decode<'r, DB> for CompactString
 where
     DB: Database,
@@ -35,6 +18,23 @@ where
     fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         let value = <&str as Decode<DB>>::decode(value)?;
         Ok(value.try_to_compact_string()?)
+    }
+}
+
+#[cfg(feature = "sqlx-mysql")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx-mysql")))]
+impl Type<sqlx::MySql> for CompactString
+where
+    for<'x> &'x str: Type<sqlx::MySql>,
+{
+    #[inline]
+    fn type_info() -> <sqlx::MySql as Database>::TypeInfo {
+        <std::string::String as Type<sqlx::MySql>>::type_info()
+    }
+
+    #[inline]
+    fn compatible(ty: &<sqlx::MySql as Database>::TypeInfo) -> bool {
+        <std::string::String as Type<sqlx::MySql>>::compatible(ty)
     }
 }
 
@@ -56,6 +56,23 @@ impl<'q> Encode<'q, sqlx::MySql> for CompactString {
     #[inline]
     fn size_hint(&self) -> usize {
         <&str as Encode<'_, sqlx::MySql>>::size_hint(&self.as_str())
+    }
+}
+
+#[cfg(feature = "sqlx-postgres")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx-postgres")))]
+impl Type<sqlx::Postgres> for CompactString
+where
+    for<'x> &'x str: Type<sqlx::Postgres>,
+{
+    #[inline]
+    fn type_info() -> <sqlx::Postgres as Database>::TypeInfo {
+        <std::string::String as Type<sqlx::Postgres>>::type_info()
+    }
+
+    #[inline]
+    fn compatible(ty: &<sqlx::Postgres as Database>::TypeInfo) -> bool {
+        <std::string::String as Type<sqlx::Postgres>>::compatible(ty)
     }
 }
 
@@ -85,6 +102,23 @@ impl<'q> Encode<'q, sqlx::Postgres> for CompactString {
 impl sqlx::postgres::PgHasArrayType for CompactString {
     fn array_type_info() -> sqlx::postgres::PgTypeInfo {
         <std::string::String as sqlx::postgres::PgHasArrayType>::array_type_info()
+    }
+}
+
+#[cfg(feature = "sqlx-sqlite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx-sqlite")))]
+impl Type<sqlx::Sqlite> for CompactString
+where
+    for<'x> &'x str: Type<sqlx::Sqlite>,
+{
+    #[inline]
+    fn type_info() -> <sqlx::Sqlite as Database>::TypeInfo {
+        <std::string::String as Type<sqlx::Sqlite>>::type_info()
+    }
+
+    #[inline]
+    fn compatible(ty: &<sqlx::Sqlite as Database>::TypeInfo) -> bool {
+        <std::string::String as Type<sqlx::Sqlite>>::compatible(ty)
     }
 }
 

--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -19,6 +19,11 @@ where
     fn type_info() -> <DB as Database>::TypeInfo {
         <&str as Type<DB>>::type_info()
     }
+
+    #[inline]
+    fn compatible(ty: &<DB as Database>::TypeInfo) -> bool {
+        <&str as Type<DB>>::compatible(ty)
+    }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]

--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -100,8 +100,14 @@ impl<'q> Encode<'q, sqlx::Postgres> for CompactString {
 #[cfg(feature = "sqlx-postgres")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx-postgres")))]
 impl sqlx::postgres::PgHasArrayType for CompactString {
+    #[inline]
     fn array_type_info() -> sqlx::postgres::PgTypeInfo {
         <std::string::String as sqlx::postgres::PgHasArrayType>::array_type_info()
+    }
+
+    #[inline]
+    fn array_compatible(ty: &sqlx::postgres::PgTypeInfo) -> bool {
+        <std::string::String as sqlx::postgres::PgHasArrayType>::array_compatible(ty)
     }
 }
 

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -5,7 +5,7 @@ impl utoipa::__dev::ComposeSchema for CompactString {
     fn compose(
         new_generics: std::vec::Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
     ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        std::string::String::compose(new_generics)
+        str::compose(new_generics)
     }
 }
 
@@ -13,7 +13,7 @@ impl utoipa::__dev::ComposeSchema for CompactString {
 impl utoipa::ToSchema for CompactString {
     #[inline]
     fn name() -> std::borrow::Cow<'static, str> {
-        std::string::String::name()
+        str::name()
     }
 
     #[inline]
@@ -23,7 +23,7 @@ impl utoipa::ToSchema for CompactString {
             utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
         )>,
     ) {
-        std::string::String::schemas(schemas)
+        str::schemas(schemas)
     }
 }
 
@@ -35,5 +35,7 @@ mod tests {
             utoipa::schema!(std::string::String),
             utoipa::schema!(crate::CompactString)
         );
+        assert_eq!(utoipa::schema!(str), utoipa::schema!(crate::CompactString));
+        assert_eq!(utoipa::schema!(&str), utoipa::schema!(crate::CompactString));
     }
 }

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -1,11 +1,16 @@
 use crate::CompactString;
+use std::vec::Vec;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
 impl utoipa::__dev::ComposeSchema for CompactString {
     fn compose(
-        new_generics: std::vec::Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+        _new_generics: std::vec::Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
     ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        str::compose(new_generics)
+        utoipa::schema!(
+            #[inline]
+            std::string::String
+        )
+        .into()
     }
 }
 
@@ -13,7 +18,7 @@ impl utoipa::__dev::ComposeSchema for CompactString {
 impl utoipa::ToSchema for CompactString {
     #[inline]
     fn name() -> std::borrow::Cow<'static, str> {
-        str::name()
+        std::string::String::name()
     }
 
     #[inline]
@@ -23,7 +28,7 @@ impl utoipa::ToSchema for CompactString {
             utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
         )>,
     ) {
-        str::schemas(schemas)
+        std::string::String::schemas(schemas)
     }
 }
 

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -1,27 +1,21 @@
 use crate::CompactString;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
-impl utoipa::PartialSchema for CompactString {
-    #[inline]
-    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        std::string::String::schema()
+impl utoipa::__dev::ComposeSchema for CompactString {
+    fn compose(
+        new_generics: std::vec::Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+    ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        std::string::String::compose(new_generics)
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
-impl utoipa::ToSchema for CompactString {
-    #[inline]
-    fn name() -> std::borrow::Cow<'static, str> {
-        std::string::String::name()
-    }
-
-    #[inline]
-    fn schemas(
-        schemas: &mut std::vec::Vec<(
-            std::string::String,
-            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
-        )>,
-    ) {
-        std::string::String::schemas(schemas)
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_schema_type() {
+        assert_eq!(
+            utoipa::schema!(std::string::String),
+            utoipa::schema!(crate::CompactString)
+        );
     }
 }

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -9,6 +9,24 @@ impl utoipa::__dev::ComposeSchema for CompactString {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
+impl utoipa::ToSchema for CompactString {
+    #[inline]
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::string::String::name()
+    }
+
+    #[inline]
+    fn schemas(
+        schemas: &mut std::vec::Vec<(
+            std::string::String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        std::string::String::schemas(schemas)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -1,0 +1,27 @@
+use crate::CompactString;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
+impl utoipa::PartialSchema for CompactString {
+    #[inline]
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        std::string::String::schema()
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
+impl utoipa::ToSchema for CompactString {
+    #[inline]
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::string::String::name()
+    }
+
+    #[inline]
+    fn schemas(
+        schemas: &mut std::vec::Vec<(
+            std::string::String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        std::string::String::schemas(schemas)
+    }
+}

--- a/compact_str/src/features/utoipa.rs
+++ b/compact_str/src/features/utoipa.rs
@@ -4,13 +4,13 @@ use std::vec::Vec;
 #[cfg_attr(docsrs, doc(cfg(feature = "utoipa")))]
 impl utoipa::__dev::ComposeSchema for CompactString {
     fn compose(
-        _new_generics: std::vec::Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+        _generics: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
     ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-        utoipa::schema!(
-            #[inline]
-            std::string::String
-        )
-        .into()
+        utoipa::openapi::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::new(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .into()
     }
 }
 
@@ -18,17 +18,17 @@ impl utoipa::__dev::ComposeSchema for CompactString {
 impl utoipa::ToSchema for CompactString {
     #[inline]
     fn name() -> std::borrow::Cow<'static, str> {
-        std::string::String::name()
+        std::borrow::Cow::Borrowed("CompactString")
     }
 
     #[inline]
     fn schemas(
-        schemas: &mut std::vec::Vec<(
+        schemas: &mut Vec<(
             std::string::String,
             utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
         )>,
     ) {
-        std::string::String::schemas(schemas)
+        schemas.extend([]);
     }
 }
 


### PR DESCRIPTION
This PR adds the missing `compatible` impl on the sqlx::Type trait, without it, the following can happen:
<img width="702" height="197" alt="image" src="https://github.com/user-attachments/assets/643ccde5-8544-4fbe-af5c-4a3dd3ebf762" />
It also adds support for [utoipa](https://github.com/juhaku/utoipa), so that CompactStrings are recognized as Strings in OpenAPI Schemas.