### PR TITLE
feat: Expose `core::error::Error` without the `std` feature

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.9.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"
+rust-version = "1.81" # For core::error::Error
 homepage = "https://github.com/ParkMyCar/compact_str"
 repository = "https://github.com/ParkMyCar/compact_str"
 readme = "../README.md"

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -2200,12 +2200,11 @@ impl From<CompactString> for alloc::rc::Rc<str> {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<CompactString> for Box<dyn std::error::Error + Send + Sync> {
+impl From<CompactString> for Box<dyn core::error::Error + Send + Sync> {
     fn from(value: CompactString) -> Self {
         struct StringError(CompactString);
 
-        impl std::error::Error for StringError {
+        impl core::error::Error for StringError {
             #[allow(deprecated)]
             fn description(&self) -> &str {
                 &self.0
@@ -2229,11 +2228,10 @@ impl From<CompactString> for Box<dyn std::error::Error + Send + Sync> {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<CompactString> for Box<dyn std::error::Error> {
+impl From<CompactString> for Box<dyn core::error::Error> {
     fn from(value: CompactString) -> Self {
-        let err1: Box<dyn std::error::Error + Send + Sync> = From::from(value);
-        let err2: Box<dyn std::error::Error> = err1;
+        let err1: Box<dyn core::error::Error + Send + Sync> = From::from(value);
+        let err2: Box<dyn core::error::Error> = err1;
         err2
     }
 }
@@ -2586,9 +2584,7 @@ impl fmt::Display for ReserveError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ReserveError {}
+impl core::error::Error for ReserveError {}
 
 /// A possible error value if [`ToCompactString::try_to_compact_string()`] failed.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2623,10 +2619,8 @@ impl From<fmt::Error> for ToCompactStringError {
     }
 }
 
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::error::Error for ToCompactStringError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ToCompactStringError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             ToCompactStringError::Reserve(err) => Some(err),
             ToCompactStringError::Fmt(err) => Some(err),


### PR DESCRIPTION
Since Rust 1.81.0, the `std::error::Error` type is just a reexport from `core`, so we can finally expose it even in `no_std` environments!

I’ve tested that everything builds against rustc 1.81.0.