### PR TITLE
feat: support schemars

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -23,6 +23,7 @@ bytes = ["dep:bytes"]
 defmt = ["dep:defmt"]
 diesel = ["dep:diesel"]
 markup = ["dep:markup"]
+schemars = ["dep:schemars"]
 proptest = ["dep:proptest"]
 quickcheck = ["dep:quickcheck"]
 rkyv = ["dep:rkyv"]
@@ -43,6 +44,7 @@ bytes = { version = "1", optional = true }
 defmt = { version = "1", optional = true }
 diesel = { version = "2", optional = true, default-features = false }
 markup = { version = "0.15", optional = true, default-features = false }
+schemars = { version = "1", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = [
     "std",
 ] }

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -20,10 +20,10 @@ mod proptest;
 mod quickcheck;
 #[cfg(feature = "rkyv")]
 mod rkyv;
-#[cfg(feature = "serde")]
-mod serde;
 #[cfg(feature = "schemars")]
 mod schemars;
+#[cfg(feature = "serde")]
+mod serde;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 #[cfg(feature = "sqlx")]

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -22,6 +22,8 @@ mod quickcheck;
 mod rkyv;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "schemars")]
+mod schemars;
 #[cfg(feature = "smallvec")]
 mod smallvec;
 #[cfg(feature = "sqlx")]

--- a/compact_str/src/features/schemars.rs
+++ b/compact_str/src/features/schemars.rs
@@ -1,0 +1,51 @@
+use alloc::borrow::Cow;
+use alloc::string::String;
+
+use schemars::Schema;
+use schemars::SchemaGenerator;
+
+use crate::CompactString;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "schemars")))]
+impl schemars::JsonSchema for CompactString {
+    fn inline_schema() -> bool {
+        <String as schemars::JsonSchema>::inline_schema()
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_name()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        <String as schemars::JsonSchema>::schema_id()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        <String as schemars::JsonSchema>::json_schema(generator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use schemars::JsonSchema;
+
+    use crate::CompactString;
+
+    #[test]
+    fn test_schema_matches_string() {
+        let compact_name = CompactString::schema_name();
+        let string_name = String::schema_name();
+        assert_eq!(compact_name, string_name);
+
+        let compact_id = CompactString::schema_id();
+        let string_id = String::schema_id();
+        assert_eq!(compact_id, string_id);
+
+        let mut gen = schemars::SchemaGenerator::default();
+        let compact_schema = CompactString::json_schema(&mut gen);
+        let string_schema = String::json_schema(&mut gen);
+        assert_eq!(compact_schema, string_schema);
+    }
+}

--- a/compact_str/src/features/schemars.rs
+++ b/compact_str/src/features/schemars.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "schemars")))]
+
 use alloc::borrow::Cow;
 use alloc::string::String;
 
@@ -6,7 +8,6 @@ use schemars::SchemaGenerator;
 
 use crate::CompactString;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "schemars")))]
 impl schemars::JsonSchema for CompactString {
     fn inline_schema() -> bool {
         <String as schemars::JsonSchema>::inline_schema()


### PR DESCRIPTION
Adds support for `schemars` crate if the corresponding feature is enabled.

There are attempts to add opposite code to schemars, but the process stalled
* https://github.com/GREsau/schemars/pull/308
* https://github.com/GREsau/schemars/issues/500

Anyway, the `schemars` crate is v1, so probably it's even better to support the feature here than in the opposite way (e.g. the PR above depends on `compact_str` v0.8)