### PR TITLE
Update sqlx requirement from 0.8 to 0.9

### DIFF
--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1", optional = true, default-features = false, features = [
     "alloc",
 ] }
 smallvec = { version = "1", optional = true, features = ["union"] }
-sqlx = { version = "0.8", optional = true, default-features = false }
+sqlx = { version = "0.9", optional = true, default-features = false }
 utoipa = { version = "5", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -43,7 +43,7 @@ where
 impl<'q> Encode<'q, sqlx::MySql> for CompactString {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::MySql as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::MySql as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::MySql>::encode_by_ref(&self.as_str(), buf)
     }
@@ -81,7 +81,7 @@ where
 impl<'q> Encode<'q, sqlx::Postgres> for CompactString {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Postgres as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Postgres as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Postgres>::encode_by_ref(&self.as_str(), buf)
     }
@@ -133,14 +133,14 @@ where
 impl<'q> Encode<'q, sqlx::Sqlite> for CompactString {
     fn encode(
         self,
-        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Sqlite>::encode(self.into_string(), buf)
     }
 
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Sqlite>::encode(alloc::string::String::from(self.as_str()), buf)
     }


### PR DESCRIPTION
`sqlx 0.9.0` has been released a few days ago.

`sqlx 0.8` depends on `rsa 0.9` crate which has a vulnerability reported at [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071.html). So I hope this PR will be accepted and we can update `sqlx`.
