### PR TITLE
fix: possible undefined behavior with realloc in a `HeapString`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   PROPTEST_CASES: 10000
   MIRIFLAGS: "-Zmiri-strict-provenance"
   RUST_VERSION: 1.92.0
-  RUST_NIGHTLY_VERSION: "nightly-2025-12-18"
+  RUST_NIGHTLY_VERSION: "nightly-2026-02-27"
 
 jobs:
   check:
@@ -35,7 +35,7 @@ jobs:
       matrix:
         include:
           - toolchain: "1.92.0"
-          - toolchain: "nightly-2025-12-18"
+          - toolchain: "nightly-2026-02-27"
 
     name: cargo test
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
   RUST_VERSION: 1.92.0
-  RUST_NIGHTLY_VERSION: "nightly-2025-12-18"
+  RUST_NIGHTLY_VERSION: "nightly-2026-02-27"
 
 jobs:
   fmt:

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -17,7 +17,7 @@ env:
   # local default for proptest is 100
   PROPTEST_CASES: 1000
   RUSTFLAGS: "-D warnings"
-  MIRIFAGS: "-Zmiri-tag-raw-pointers -Zmiri-check-number-validity"
+  MIRIFLAGS: "-Zmiri-strict-provenance"
   RUST_NIGHTLY_VERSION: "nightly-2025-12-18"
 
 jobs:

--- a/.github/workflows/cross_platform.yml
+++ b/.github/workflows/cross_platform.yml
@@ -18,7 +18,7 @@ env:
   PROPTEST_CASES: 1000
   RUSTFLAGS: "-D warnings"
   MIRIFLAGS: "-Zmiri-strict-provenance"
-  RUST_NIGHTLY_VERSION: "nightly-2025-12-18"
+  RUST_NIGHTLY_VERSION: "nightly-2026-02-27"
 
 jobs:
   cross-test:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,7 +18,7 @@ name: Fuzz
 env:
   CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings -Zrandomize-layout"
-  RUST_NIGHTLY_VERSION: "nightly-2025-12-18"
+  RUST_NIGHTLY_VERSION: "nightly-2026-02-27"
 
 jobs:
   libFuzzer_x86_64:

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -70,7 +70,7 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 quickcheck = { version = "1", default-features = false }
 quickcheck_macros = "1"
 rayon = "1"
-rkyv = { version = "0.8.8" }
+rkyv = { version = "0.8", default-features = false, features = ["alloc", "bytecheck"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 test-case = "3"

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -932,7 +932,8 @@ impl CompactString {
         } else if n == 1 {
             self.clone()
         } else {
-            let mut out = Self::with_capacity(self.len() * n);
+            let cap = self.len().checked_mul(n).expect("capacity overflow");
+            let mut out = Self::with_capacity(cap);
             (0..n).for_each(|_| out.push_str(self));
             out
         }
@@ -942,7 +943,8 @@ impl CompactString {
     ///
     /// If the length of the [`CompactString`] is less or equal to `new_len`, the call is a no-op.
     ///
-    /// Calling this function does not change the capacity of the [`CompactString`].
+    /// Calling this function does not change the capacity of the [`CompactString`], unless the
+    /// [`CompactString`] is backed by a `&'static str`.
     ///
     /// # Panics
     ///
@@ -1039,7 +1041,8 @@ impl CompactString {
 
     /// Reduces the length of the [`CompactString`] to zero.
     ///
-    /// Calling this function does not change the capacity of the [`CompactString`].
+    /// Calling this function does not change the capacity of the [`CompactString`], unless the
+    /// [`CompactString`] is backed by a `&'static str`.
     ///
     /// ```
     /// # use compact_str::CompactString;

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -102,8 +102,6 @@ impl HeapBuffer {
 
     /// Try to grow the [`HeapBuffer`] by reallocating, returning an error if we fail
     pub(crate) fn realloc(&mut self, new_capacity: usize) -> Result<usize, ()> {
-        let new_cap = Capacity::new(new_capacity);
-
         // We can't reallocate to a size less than our length, or else we'd clip the string
         if new_capacity < self.len {
             return Err(());
@@ -116,6 +114,9 @@ impl HeapBuffer {
 
         // Always allocate at least MIN_HEAP_SIZE
         let new_capacity = cmp::max(new_capacity, MIN_HEAP_SIZE);
+        // N.B. must be computed _after_ the MIN_HEAP_SIZE clamp so the stored capacity matches the
+        // layout we actually (re)allocate with, otherwise dealloc/realloc get a mismatched layout.
+        let new_cap = Capacity::new(new_capacity);
 
         let (new_cap, new_ptr) = match (self.cap.is_heap(), new_cap.is_heap()) {
             // both current and new capacity can be stored inline
@@ -516,6 +517,20 @@ mod test {
     fn test_realloc_shrink_heap_to_inline() {
         // TODO: test this case
         assert_eq!(1, 1);
+    }
+
+    #[test]
+    fn test_realloc_shrink_to_min_heap_gap() {
+        // Shrinking to a size in (MAX_SIZE, MIN_HEAP_SIZE) must store the clamped
+        // capacity, otherwise the recorded capacity won't match the actual allocation
+        // layout.
+        let mut h = HeapBuffer::with_capacity(100).unwrap();
+        let target = super::MAX_SIZE + 1;
+        assert!(target < MIN_HEAP_SIZE);
+
+        assert_eq!(h.realloc(target), Ok(MIN_HEAP_SIZE));
+        assert_eq!(h.capacity(), MIN_HEAP_SIZE);
+        // Drop runs dealloc with the stored capacity; under miri this fails if the layout is wrong.
     }
 
     #[test_case(&[42; 0]; "empty")]

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -2018,3 +2018,26 @@ fn test_is_empty() {
         }
     }
 }
+
+#[test]
+fn test_shrink_to_within_min_heap_gap() {
+    // N.B. shrinking a heap allocated string to a capacity just above the inline limit
+    // must report a capacity matching the actual allocation layout.
+    let mut s = CompactString::with_capacity(100);
+    assert!(s.is_heap_allocated());
+
+    let target = crate::repr::MAX_SIZE + 1;
+    s.shrink_to(target);
+    assert!(s.is_heap_allocated());
+
+    // Capacity is clamped up to MIN_HEAP_SIZE by the allocator, the stored value must reflect that.
+    assert!(s.capacity() >= target);
+    drop(s);
+}
+
+#[test]
+#[should_panic(expected = "capacity overflow")]
+fn test_repeat_capacity_overflow() {
+    let s = CompactString::new("abc");
+    let _ = s.repeat(usize::MAX);
+}


### PR DESCRIPTION
`HeapString::realloc` allocates the `max(new_capacity, MIN_HEAP_SIZE)`, but the value of `capacity` that we would store in `HeapString` was always `new_capacity`. Thus when `Drop`-ing a `HeapString` we would calculate the wrong `Layout` and cause undefined behavior.

I believe the chances of hitting this are relatively small because when transitioning from inline to heap we always allocate at least `MIN_HEAP_SIZE`. The most common ways I can think of hitting this are using `CompactString::shrink_to` with a value in the range of `[25, 32)` or converting a `String` with a capacity in that same range, then resizing the resulting `CompactString`.

I've never had a report of UB (doesn't mean it hasn't happened though!) and I suspect this may not have led to segfaults or other bad behaviors because for most memory allocators, size 25 and 32 are the same thing. For example, [jemalloc's size classes](https://jemalloc.net/jemalloc.3.html#size_classes) are [8, 16, 32, ...] so whether you request 25 bytes or 32 bytes, jemalloc is giving you the same thing.

_Why didn't the fuzzer catch this?_

We exercise `shrink_to` in the fuzzing harness which checks with ASan, exactly the tools I would lean on to catch a bug like this. It turns out the [unix system allocator drops `Layout` when deallocating](https://github.com/rust-lang/rust/blob/main/library/std/src/sys/alloc/unix.rs#L46-L49) so ASan is blind to exactly this bug.

Miri catches this issue though! And I added a regression test to exercise it.