### PR TITLE
perf: reuse owned String in `CompactString::new`

### DIFF
--- a/bench/benches/compact_str.rs
+++ b/bench/benches/compact_str.rs
@@ -1,6 +1,7 @@
 use compact_str::{CompactString, ToCompactString};
 use compact_str_6::CompactString as CompactString6;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use std::mem::size_of;
 
 fn bench_new(c: &mut Criterion) {
     c.bench_with_input(
@@ -32,6 +33,28 @@ fn bench_new(c: &mut Criterion) {
         &"I am a very long string that will get allocated on the heap",
         |b, &word| b.iter(|| String::from(word)),
     );
+}
+
+fn bench_new_owned_string(c: &mut Criterion) {
+    let mut group = c.benchmark_group("CompactString::new(String)");
+    let max_inline = size_of::<String>();
+
+    for (kind, len) in [
+        ("inline-short", max_inline / 2),
+        ("inline-limit", max_inline),
+        ("heap-boundary", max_inline + 1),
+        ("heap-medium", 64),
+        ("heap-large", 1024),
+    ] {
+        let value = "a".repeat(len);
+        group.bench_with_input(BenchmarkId::new(kind, len), &value, |b, value| {
+            b.iter_batched(
+                || black_box(value.clone()),
+                |value| black_box(CompactString::new(value)),
+                BatchSize::SmallInput,
+            )
+        });
+    }
 }
 
 fn bench_to_compact_string(c: &mut Criterion) {
@@ -146,5 +169,10 @@ fn bench_repr_access(c: &mut Criterion) {
 }
 criterion_group!(repr_benches, bench_repr_creation, bench_repr_access);
 
-criterion_group!(compact_str, bench_new, bench_to_compact_string);
+criterion_group!(
+    compact_str,
+    bench_new,
+    bench_new_owned_string,
+    bench_to_compact_string
+);
 criterion_main!(compact_str, repr_benches);

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -12,6 +12,7 @@ extern crate alloc;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::string::String;
+use castaway::match_type;
 #[doc(hidden)] // Referenced in macros.
 pub use core;
 use core::borrow::{Borrow, BorrowMut};
@@ -129,7 +130,8 @@ pub struct CompactString(Repr);
 
 impl CompactString {
     /// Creates a new [`CompactString`] from any type that implements `AsRef<str>`.
-    /// If the string is short enough, then it will be inlined on the stack!
+    /// If the string is short enough, then it will be inlined on the stack! When `text` is an owned
+    /// [`String`] that does not fit inline, its existing allocation is reused.
     ///
     /// In a `static` or `const` context you can use the method [`CompactString::const_new()`].
     ///
@@ -192,7 +194,12 @@ impl CompactString {
     /// Otherwise it behaves the same as [`CompactString::new()`].
     #[inline]
     pub fn try_new<T: AsRef<str>>(text: T) -> Result<Self, ReserveError> {
-        Repr::new(text.as_ref()).map(CompactString)
+        let repr = match_type!(text, {
+            String as text => Repr::from_string(text, true)?,
+            text => Repr::new(text.as_ref())?,
+        });
+
+        Ok(CompactString(repr))
     }
 
     /// Creates a new inline [`CompactString`] from `&'static str` at compile time.

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -69,6 +69,16 @@ fn proptest_strings_allocated_properly(#[strategy(rand_unicode())] word: String)
     assert_allocated_properly(&compact);
 }
 
+#[test]
+fn test_new_owned_string_reuses_heap_allocation() {
+    let value = "a".repeat(MAX_SIZE + 1);
+    let ptr = value.as_ptr();
+    let capacity = value.capacity();
+    let compact = CompactString::new(value);
+    assert_eq!(compact.as_ptr(), ptr);
+    assert_eq!(compact.capacity(), capacity);
+}
+
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn proptest_char_iterator_roundtrips(#[strategy(rand_unicode())] word: String) {


### PR DESCRIPTION
This PR specializes `CompactString::new` and `try_new` for owned Strings, such that Strings that do not fit inline can now transfer their allocation directly into the `CompactString`.

In the criterion benchmark, this is 90% faster for a 25-byte (heap-allocated) string, and just 2.6% slower for a 24-byte inline string.
