### PR TITLE
perf: Drop passes heap fields by-value instead of &mut Repr

### DIFF
--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -777,14 +777,17 @@ impl Drop for Repr {
         // By "outlining" the actual Drop code and only calling it if we're a heap variant, it
         // allows dropping an inline variant to be as cheap as possible.
         if self.is_heap_allocated() {
-            outlined_drop(self)
+            // SAFETY: We just checked the discriminant to make sure we're heap allocated
+            let heap = unsafe { self.as_heap() };
+            // Pass the heap fields by value so the address of `*self` never escapes, otherwise
+            // dropping a by-value `CompactString` must materialize the full 24 bytes on the
+            // caller's stack just to hand `&mut Repr` to the outlined function.
+            outlined_drop(heap.ptr, heap.cap)
         }
 
         #[cold]
-        fn outlined_drop(this: &mut Repr) {
-            // SAFETY: We just checked the discriminant to make sure we're heap allocated
-            let heap_buffer = unsafe { this.as_mut_heap() };
-            heap_buffer.dealloc();
+        fn outlined_drop(ptr: ptr::NonNull<u8>, cap: Capacity) {
+            heap::deallocate_ptr(ptr, cap);
         }
     }
 }


### PR DESCRIPTION
`Repr`'s `Drop` impl "outlines" the actual deallocation into a `#[cold]` function so that dropping an inline variant is as cheap as possible, ideally just a discriminant check. But we were passing `&mut Repr` into that outlined function, which lets the address of `*self` escape into a non-inlined call. That forces the compiler to materialize the full 24 bytes of the `Repr` onto the caller's stack on _every_ drop, even the common inline case that never actually calls the outlined function.

This PR pulls out the only two fields we need to deallocate, `ptr` and `cap`, and passes them by value instead. Now the address of `*self` never escapes, so the `Repr` can stay in registers and only the rare heap branch has to touch memory. The behavior is identical: `heap::deallocate_ptr` is the same function that `HeapBuffer::dealloc` was already calling under the hood.

Since every `CompactString` gets dropped, this shows up across the construction and clone benchmarks:

| benchmark | before | after | change |
|---|---|---|---|
| `new/0` | 1.65 ns | 0.97 ns | −41% |
| `with_capacity/small` | 1.55 ns | 0.81 ns | −48% |
| `clone/inline` | 1.96 ns | 1.63 ns | −17% |

Verified with `cargo test` and `cargo +nightly miri test`.
