### PR TITLE
perf: add Repr::new_panic to skip the Result machinery on CompactString::new

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -185,7 +185,14 @@ impl CompactString {
     #[inline]
     #[track_caller]
     pub fn new<T: AsRef<str>>(text: T) -> Self {
-        Self::try_new(text).unwrap_with_msg()
+        // Route `&str` through the infallible `new_panic` so the hot inline path avoids the
+        // `Result` machinery, while still reusing an owned `String`'s allocation via `from_string`.
+        let repr = match_type!(text, {
+            String as text => Repr::from_string(text, true).unwrap_with_msg(),
+            text => Repr::new_panic(text.as_ref()),
+        });
+
+        CompactString(repr)
     }
 
     /// Fallible version of [`CompactString::new()`]

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -76,6 +76,26 @@ impl Repr {
         }
     }
 
+    /// Infallible variant of [`Repr::new`] that panics on allocation failure.
+    ///
+    /// Keeping the inline arm out of the `Result` machinery lets the compiler drop the dead unwrap
+    /// check from the hot inline path.
+    #[inline]
+    #[track_caller]
+    pub(crate) fn new_panic(text: &str) -> Self {
+        let len = text.len();
+
+        if len == 0 {
+            EMPTY
+        } else if len <= MAX_SIZE {
+            // SAFETY: We checked that the length of text is less than or equal to MAX_SIZE
+            let inline = unsafe { InlineBuffer::new(text) };
+            Repr::from_inline(inline)
+        } else {
+            Repr::from_heap(HeapBuffer::new(text).unwrap_with_msg())
+        }
+    }
+
     #[inline]
     pub(crate) const fn const_new(text: &'static str) -> Self {
         if text.len() <= MAX_SIZE {


### PR DESCRIPTION
`CompactString::new` delegated to the fallible `try_new` and then unwrapped the `Result`. That left the hot construction path carrying the `Result`/unwrap machinery, including a dead re-check of the discriminant on a `Repr` we'd *just* built inline, even though inline construction can't fail.

This adds an infallible `Repr::new_panic` whose inline arm builds a `Repr` directly with no `Result`, and points `new()`'s `&str` inputs at it. Owned `String` inputs still reuse their allocation via `from_string`, so the behavior from #460 is preserved.

I couldn't get a trustworthy wall-clock number (the machine I'm benchmarking on is too noisy for a sub-nanosecond change), so these are deterministic executed-instruction counts from cachegrind, measuring one `new()` + read per iteration:

| construction | before | after | change |
|---|---|---|---|
| inline (24 bytes) | 72 instr | 58 instr | −19% |
| heap (43 bytes) | 234 instr | 218 instr | −7% |

Verified with `cargo test` and `cargo +nightly miri test`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_