### PR TITLE
chore: align MSRV tooling with the declared 1.81 minimum

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -37,4 +37,4 @@ jobs:
         #
         # See <https://github.com/rust-lang/api-guidelines/discussions/231>
         run: |
-          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.60..
+          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.81..

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -60,7 +60,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 castaway = { version = "0.2.3", default-features = false, features = ["alloc"] }
 cfg-if = "1"
 itoa = "1"
-rustversion = "1"
 ryu = "1"
 static_assertions = "1"
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -235,8 +235,7 @@ impl CompactString {
     /// );
     /// ```
     #[inline]
-    #[rustversion::attr(since(1.64), const)]
-    pub fn as_static_str(&self) -> Option<&'static str> {
+    pub const fn as_static_str(&self) -> Option<&'static str> {
         self.0.as_static_str()
     }
 

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -120,7 +120,6 @@ impl InlineBuffer {
 
 #[cfg(test)]
 mod tests {
-    #[rustversion::since(1.63)]
     #[test]
     #[ignore] // we run this in CI, but unless you're compiling in release, this takes a while
     fn test_unused_utf8_bytes() {

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -455,8 +455,7 @@ impl Repr {
     }
 
     #[inline]
-    #[rustversion::attr(since(1.64), const)]
-    pub(crate) fn as_static_str(&self) -> Option<&'static str> {
+    pub(crate) const fn as_static_str(&self) -> Option<&'static str> {
         if self.is_static_str() {
             // SAFETY: A `Repr` is transmuted from `StaticStr`
             let s: &StaticStr = unsafe { &*(self as *const Self as *const StaticStr) };

--- a/compact_str/src/repr/static_str.rs
+++ b/compact_str/src/repr/static_str.rs
@@ -33,8 +33,7 @@ impl StaticStr {
         }
     }
 
-    #[rustversion::attr(since(1.64), const)]
-    pub(super) fn get_text(&self) -> &'static str {
+    pub(super) const fn get_text(&self) -> &'static str {
         // SAFETY: `StaticStr` invariants requires it to be a valid str
         unsafe { str::from_utf8_unchecked(slice::from_raw_parts(self.ptr.as_ptr(), self.len)) }
     }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1987,7 +1987,6 @@ fn test_alloc_excessively_long_string() {
 
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first
 // released in Rust 1.65.
-#[rustversion::since(1.65)]
 #[test]
 fn multiple_niches_test() {
     #[allow(unused)]


### PR DESCRIPTION
The `rust-version` in `Cargo.toml` is `1.81` (for `core::error::Error`), but a couple of things still assumed an older minimum:

- The MSRV workflow ran `cargo hack check --version-range 1.60..`. `cargo hack` clamps the range to the `rust-version` floor, so it was effectively checking `1.81..` already, but the `1.60` literal is stale and misleading. This bumps it to `1.81..` to match.
- The source carried `rustversion` gates targeting 1.63/1.64/1.65, all of which are now unconditionally satisfied at our 1.81 minimum. This drops them: the three `attr(since(1.64), const)` sites become plain `const fn`, and the two `since(...)` test gates are removed.
- With no `rustversion` uses left, the dependency is removed.

No behavior change — the `const fn` conversions were already `const` on every compiler at or above our MSRV.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_