### PR TITLE
chore: re-level MSRV to 1.71 and revert unreleased no-std Error

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -37,4 +37,4 @@ jobs:
         #
         # See <https://github.com/rust-lang/api-guidelines/discussions/231>
         run: |
-          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.60..
+          cargo hack check --manifest-path=compact_str/Cargo.toml --version-range 1.71..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
-... all released!
+
+## Changes
+* Minimum supported Rust version (MSRV) was bumped to `v1.71`.
+    * Required by the `itoa` (`v1.68`) and `ryu` (`v1.71`) dependencies.
+* The `Error` trait impls once again require the `std` feature. This reverts the (unreleased)
+  no-std `core::error::Error` support from [#443](https://github.com/ParkMyCar/compact_str/pull/443),
+  which required Rust `v1.81`; it can return once the MSRV reaches `v1.81`.
 
 # 0.9.0
 ### February 24, 2025

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.9.0"
 authors = ["Parker Timmerman <parker@parkertimmerman.com>"]
 edition = "2021"
 license = "MIT"
-rust-version = "1.81"                                                                                        # For core::error::Error
+rust-version = "1.71"                                                                                        # itoa 1.68 / ryu 1.71; core::error::Error is version-gated
 homepage = "https://github.com/ParkMyCar/compact_str"
 repository = "https://github.com/ParkMyCar/compact_str"
 readme = "../README.md"
@@ -60,7 +60,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 castaway = { version = "0.2.3", default-features = false, features = ["alloc"] }
 cfg-if = "1"
 itoa = "1"
-rustversion = "1"
 ryu = "1"
 static_assertions = "1"
 

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -242,8 +242,7 @@ impl CompactString {
     /// );
     /// ```
     #[inline]
-    #[rustversion::attr(since(1.64), const)]
-    pub fn as_static_str(&self) -> Option<&'static str> {
+    pub const fn as_static_str(&self) -> Option<&'static str> {
         self.0.as_static_str()
     }
 
@@ -2217,11 +2216,12 @@ impl From<CompactString> for alloc::rc::Rc<str> {
     }
 }
 
-impl From<CompactString> for Box<dyn core::error::Error + Send + Sync> {
+#[cfg(feature = "std")]
+impl From<CompactString> for Box<dyn std::error::Error + Send + Sync> {
     fn from(value: CompactString) -> Self {
         struct StringError(CompactString);
 
-        impl core::error::Error for StringError {
+        impl std::error::Error for StringError {
             #[allow(deprecated)]
             fn description(&self) -> &str {
                 &self.0
@@ -2245,10 +2245,11 @@ impl From<CompactString> for Box<dyn core::error::Error + Send + Sync> {
     }
 }
 
-impl From<CompactString> for Box<dyn core::error::Error> {
+#[cfg(feature = "std")]
+impl From<CompactString> for Box<dyn std::error::Error> {
     fn from(value: CompactString) -> Self {
-        let err1: Box<dyn core::error::Error + Send + Sync> = From::from(value);
-        let err2: Box<dyn core::error::Error> = err1;
+        let err1: Box<dyn std::error::Error + Send + Sync> = From::from(value);
+        let err2: Box<dyn std::error::Error> = err1;
         err2
     }
 }
@@ -2601,7 +2602,9 @@ impl fmt::Display for ReserveError {
     }
 }
 
-impl core::error::Error for ReserveError {}
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for ReserveError {}
 
 /// A possible error value if [`ToCompactString::try_to_compact_string()`] failed.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2636,8 +2639,10 @@ impl From<fmt::Error> for ToCompactStringError {
     }
 }
 
-impl core::error::Error for ToCompactStringError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for ToCompactStringError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ToCompactStringError::Reserve(err) => Some(err),
             ToCompactStringError::Fmt(err) => Some(err),

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -120,7 +120,6 @@ impl InlineBuffer {
 
 #[cfg(test)]
 mod tests {
-    #[rustversion::since(1.63)]
     #[test]
     #[ignore] // we run this in CI, but unless you're compiling in release, this takes a while
     fn test_unused_utf8_bytes() {

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -475,8 +475,7 @@ impl Repr {
     }
 
     #[inline]
-    #[rustversion::attr(since(1.64), const)]
-    pub(crate) fn as_static_str(&self) -> Option<&'static str> {
+    pub(crate) const fn as_static_str(&self) -> Option<&'static str> {
         if self.is_static_str() {
             // SAFETY: A `Repr` is transmuted from `StaticStr`
             let s: &StaticStr = unsafe { &*(self as *const Self as *const StaticStr) };

--- a/compact_str/src/repr/static_str.rs
+++ b/compact_str/src/repr/static_str.rs
@@ -33,8 +33,7 @@ impl StaticStr {
         }
     }
 
-    #[rustversion::attr(since(1.64), const)]
-    pub(super) fn get_text(&self) -> &'static str {
+    pub(super) const fn get_text(&self) -> &'static str {
         // SAFETY: `StaticStr` invariants requires it to be a valid str
         unsafe { str::from_utf8_unchecked(slice::from_raw_parts(self.ptr.as_ptr(), self.len)) }
     }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1987,7 +1987,6 @@ fn test_alloc_excessively_long_string() {
 
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first
 // released in Rust 1.65.
-#[rustversion::since(1.65)]
 #[test]
 fn multiple_niches_test() {
     #[allow(unused)]


### PR DESCRIPTION
The declared MSRV was `1.81` only because of the (unreleased) no-std `core::error::Error` support from #443. Carrying `1.81` for a single unreleased feature felt heavy, so this re-levels the MSRV to `1.71` — the floor our `itoa` (`1.68`) and `ryu` (`1.71`) dependencies actually require — and reverts #443 so the `Error` impls once again live behind the `std` feature. The no-std `Error` support can return for free once the MSRV naturally reaches `1.81`.

Because the `rustversion` gates we had were all for `1.63`/`1.64`/`1.65`, they're now below the floor and become unconditional (`as_static_str`/`get_text` are just `const fn`, and the two version-gated tests lose their gate), so the `rustversion` dependency drops out entirely.

Targeting the next semver-breaking release (`v0.10`).

Verified with `cargo check` on `1.71` (default and `--no-default-features`, with `-D warnings`) and `cargo test` on stable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_