### PR TITLE
Increase CI fuzz time from 2 to 5 minutes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Fuzz Time
         run: |
           if [[ "${{github.event_name}}" == "push" || "${{github.event_name}}" == "pull_request" ]]; then
-            echo "fuzz_time=120" >> $GITHUB_ENV
+            echo "fuzz_time=300" >> $GITHUB_ENV
           else
             echo "fuzz_time=1800" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
Fuzzing on `push`/`pull_request` was capped at `-max_total_time=120` (2 minutes) so the fuzz job wouldn't be the long pole in CI. That's no longer true: on recent `main` runs the `cargo miri test` job takes ~5m56s and `cargo test -Zrandomize-layout` ~4m, while the fuzz job finishes in ~2m45s. We're leaving CI wall-clock (and fuzz coverage) on the table.

This bumps `fuzz_time` to `300`. With ~45s of fixed overhead (checkout, toolchain, `cargo-fuzz` install, target build) the fuzz job lands around 5m45s, i.e. just under Miri, so we get ~2.5x more fuzzing per run without extending total CI time. The `workflow_dispatch`/scheduled path stays at 1800s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_