### PR TITLE
perf: assert Repr invariants to fold dead Err arms on construction

### DIFF
--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -70,6 +70,11 @@ impl Capacity {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit arches we can always fit the capacity inline
                 debug_assert!(capacity <= MAX_VALUE);
+                // SAFETY: a 64-bit capacity is `< 2^56`, so its `to_le()` form leaves the
+                // discriminant byte free for `HEAP_MARKER`, letting the compiler fold the dead
+                // `Err` arm at callers like `From<String>`. (`to_le()`, not the raw value:
+                // `VALID_MASK` is a byte-layout mask, so the raw check breaks on big-endian.)
+                unsafe { super::assume(capacity.to_le() & !VALID_MASK == 0) };
 
                 Capacity(capacity.to_le() | HEAP_MARKER)
             } else if #[cfg(target_pointer_width = "32")] {

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -70,7 +70,7 @@ impl Repr {
         } else if len <= MAX_SIZE {
             // SAFETY: We checked that the length of text is less than or equal to MAX_SIZE
             let inline = unsafe { InlineBuffer::new(text) };
-            Ok(Repr::from_inline(inline))
+            Repr::from_inline_ok(inline)
         } else {
             HeapBuffer::new(text).map(Repr::from_heap)
         }
@@ -183,7 +183,7 @@ impl Repr {
         } else if should_inline && s.len() <= MAX_SIZE {
             // SAFETY: Checked to make sure the string would fit inline
             let inline = unsafe { InlineBuffer::new(s.as_str()) };
-            Ok(Repr::from_inline(inline))
+            Repr::from_inline_ok(inline)
         } else {
             let mut s = mem::ManuallyDrop::new(s.into_bytes());
             let len = s.len();
@@ -650,6 +650,18 @@ impl Repr {
         unsafe { core::mem::transmute(inline) }
     }
 
+    /// `Ok(from_inline(inline))`, plus a hint to the compiler that the result is in fact `Ok`.
+    #[inline(always)]
+    fn from_inline_ok(inline: InlineBuffer) -> Result<Self, ReserveError> {
+        let repr = Self::from_inline(inline);
+        // SAFETY: `InlineBuffer` always produces a valid inline last byte (`< HEAP_MASK`). The
+        // compiler cannot see this through the transmute; without the hint it cannot fold the
+        // niche-encoded `Err` arm at the call site. Kept here (not in `from_inline`) so callers
+        // that don't wrap in `Result` avoid materializing the load of the last byte.
+        unsafe { assume(repr.last_byte() < HEAP_MASK) };
+        Ok(repr)
+    }
+
     /// Reinterprets a [`HeapBuffer`] into a [`Repr`]
     ///
     /// Note: This is safe because [`HeapBuffer`] and [`Repr`] are the same size. We used to define
@@ -882,6 +894,25 @@ fn ensure_read(value: usize) -> usize {
     };
 
     value
+}
+
+/// Polyfill for [`core::hint::assert_unchecked`] (stabilized in Rust 1.81; our MSRV is 1.71). The
+/// two are equivalent — `assert_unchecked` is defined as this — so the release codegen is identical.
+///
+/// In debug builds we also `debug_assert!` the condition, so a violated invariant panics loudly
+/// instead of being silent UB. This compiles out of release builds, leaving only the hint.
+///
+/// TODO(MSRV 1.81): drop this and call `core::hint::assert_unchecked` directly.
+///
+/// # Safety
+/// `cond` must always hold; the compiler is free to assume it.
+#[inline(always)]
+const unsafe fn assume(cond: bool) {
+    debug_assert!(cond);
+    if !cond {
+        // SAFETY: guaranteed by the caller.
+        core::hint::unreachable_unchecked();
+    }
 }
 
 #[cfg(test)]

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -2050,3 +2050,43 @@ fn test_repeat_capacity_overflow() {
     let s = CompactString::new("abc");
     let _ = s.repeat(usize::MAX);
 }
+
+#[test]
+fn test_inline_max_len_maximal_last_byte() {
+    // Tightest case for `from_inline_ok`: a `MAX_SIZE`-length inline string. At `len == MAX_SIZE`
+    // the length byte is overwritten by real UTF-8 data, so the discriminant *is* the final data
+    // byte. `U+07FF` encodes as `DF BF`, giving a trailing byte of `0xBF` (191) — the largest a
+    // valid UTF-8 trailing byte can be, i.e. the closest the invariant ever gets to `HEAP_MASK`.
+    let s = "a".repeat(MAX_SIZE - 2) + "\u{07FF}";
+    assert_eq!(s.len(), MAX_SIZE);
+
+    // via `&str` -> `Repr::new` inline arm -> `from_inline_ok`
+    let a = CompactString::new(s.as_str());
+    assert!(!a.is_heap_allocated());
+    assert_eq!(a, s);
+
+    // via `String` -> `Repr::from_string(_, true)` inline arm -> `from_inline_ok`
+    let b = CompactString::from(s.clone());
+    assert!(!b.is_heap_allocated());
+    assert_eq!(b, s);
+}
+
+#[test]
+fn test_inline_all_lengths_reach_from_inline_ok() {
+    // Walk every inline length through both call sites of `from_inline_ok`.
+    for len in 0..=MAX_SIZE {
+        let s = "a".repeat(len);
+
+        let a = CompactString::new(s.as_str()); // Repr::new
+        assert!(!a.is_heap_allocated(), "len {} via &str went to heap", len);
+        assert_eq!(a, s);
+
+        let b = CompactString::from(s.clone()); // Repr::from_string(_, true)
+        assert!(
+            !b.is_heap_allocated(),
+            "len {} via String went to heap",
+            len
+        );
+        assert_eq!(b, s);
+    }
+}


### PR DESCRIPTION
Two `assume` hints tell the compiler about invariants it can't derive through the `Repr` transmute/niche encoding, so it can fold away the dead `Err` arm at construction call sites:

- `Capacity::new` (64-bit): a valid capacity always fits inline (its high byte is zero), so the last byte is exactly `HEAP_MARKER`. This lets the `Err` arm of `Result<Repr, ReserveError>` fold at heap-construction sites like `From<String>`.
- `from_inline_ok`: a freshly built `InlineBuffer` always has an inline last byte (`< HEAP_MASK`), which the compiler can't see through the `transmute`. It's kept out of `from_inline` itself so the infallible callers don't materialize the load; `Repr::new` and `from_string`'s inline arms route through it.

`core::hint::assert_unchecked` would be the natural tool, but it's `1.81`-only and our MSRV is `1.71`, so there's a one-line `assume` polyfill (`if !cond { unreachable_unchecked() }` — stable since `1.27`, and `assert_unchecked` is literally defined as this, so the release codegen is identical). In debug builds it also `debug_assert!`s the condition, so a violated invariant panics loudly instead of being silent UB. A `TODO(MSRV 1.81)` marks it for removal.

Since these are `unsafe` "trust me" hints, I added two deterministic tests that walk `from_inline_ok`'s invariant under Miri (the proptests are `miri`-ignored, so they don't cover it): a full `0..=MAX_SIZE` length sweep and the tightest `MAX_SIZE` case (a trailing `0xBF` byte), through both the `&str` and `String` paths. A wrong invariant would surface as UB under Miri.

Measured with cachegrind (deterministic executed-instruction counts; wall-clock is too noisy on the machine I'm testing on):

| construction | main | branch | change |
|---|---|---|---|
| `try_new` inline | 92 | 77 | −16.3% |
| `from(String)` short | 241 | 235 | −2.5% |
| `from(String)` long | 228 | 220 | −3.5% |
| `from_utf8` inline | 222 | 214 | −3.6% |

Verified with `cargo test` (247), `cargo +nightly miri test` (187), and `cargo check` on `1.71` (default and `--no-default-features`, with `-D warnings`).
