### PR TITLE
fix: avoid exposing uninitialized spare capacity

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -584,14 +584,17 @@ impl CompactString {
     #[inline]
     pub fn as_mut_str(&mut self) -> &mut str {
         let len = self.len();
-        unsafe { core::str::from_utf8_unchecked_mut(&mut self.0.as_mut_buf()[..len]) }
+        let ptr = self.0.as_mut_ptr();
+        // SAFETY: The first `len` bytes of a `CompactString` are initialized and valid UTF-8.
+        let bytes = unsafe { slice::from_raw_parts_mut(ptr, len) };
+        // SAFETY: The bytes came from a valid `CompactString`.
+        unsafe { core::str::from_utf8_unchecked_mut(bytes) }
     }
 
     unsafe fn spare_capacity_mut(&mut self) -> &mut [mem::MaybeUninit<u8>] {
-        let buf = self.0.as_mut_buf();
-        let ptr = buf.as_mut_ptr();
-        let cap = buf.len();
         let len = self.len();
+        let ptr = self.0.as_mut_ptr();
+        let cap = self.capacity();
 
         slice::from_raw_parts_mut(ptr.add(len) as *mut mem::MaybeUninit<u8>, cap - len)
     }
@@ -614,6 +617,9 @@ impl CompactString {
     //
     /// Provides a mutable reference to the underlying buffer of bytes.
     ///
+    /// The returned slice has length [`CompactString::capacity()`]. For heap-allocated strings,
+    /// this method initializes the spare capacity before returning.
+    ///
     /// # Safety
     /// * All Rust strings, including `CompactString`, must be valid UTF-8. The caller must
     ///   guarantee that any modifications made to the underlying buffer are valid UTF-8.
@@ -633,7 +639,21 @@ impl CompactString {
     /// ```
     #[inline]
     pub unsafe fn as_mut_bytes(&mut self) -> &mut [u8] {
-        self.0.as_mut_buf()
+        let len = self.len();
+        let ptr = self.0.as_mut_ptr();
+        let cap = self.capacity();
+
+        // Inline buffers are fully initialized when they are created. Heap buffers only
+        // initialize their string contents, so initialize their spare capacity before exposing it
+        // through a `[u8]` reference.
+        if self.is_heap_allocated() {
+            // SAFETY: The heap allocation is valid for `cap` bytes and `len <= cap`.
+            unsafe { ptr.add(len).write_bytes(0, cap - len) };
+        }
+
+        // SAFETY: All `cap` bytes are initialized. Inline buffers are initialized on creation, and
+        // heap spare capacity was initialized above.
+        unsafe { slice::from_raw_parts_mut(ptr, cap) }
     }
 
     /// Appends the given [`char`] to the end of this [`CompactString`].
@@ -995,7 +1015,7 @@ impl CompactString {
     /// Converts a mutable [`CompactString`] to a raw pointer.
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
-        unsafe { self.0.as_mut_buf().as_mut_ptr() }
+        self.0.as_mut_ptr()
     }
 
     /// Insert string character at an index.

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -591,12 +591,45 @@ impl CompactString {
         unsafe { core::str::from_utf8_unchecked_mut(bytes) }
     }
 
-    unsafe fn spare_capacity_mut(&mut self) -> &mut [mem::MaybeUninit<u8>] {
+    /// Returns the remaining spare capacity of this [`CompactString`] as a slice of
+    /// [`MaybeUninit`](mem::MaybeUninit) bytes.
+    ///
+    /// The returned slice covers the range `len()..capacity()`. After initializing a prefix of the
+    /// slice, use [`CompactString::set_len`] to include those bytes in the string.
+    ///
+    /// # Safety
+    ///
+    /// * Before increasing the length, the caller must initialize every newly included byte and
+    ///   ensure the resulting string is valid UTF-8.
+    /// * For an inline string, the final byte of the spare capacity also stores the representation
+    ///   tag. It may only be overwritten as the final byte of a completely initialized, valid
+    ///   UTF-8 string that fills the inline capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use compact_str::CompactString;
+    /// let mut s = CompactString::new("hello");
+    /// let suffix = b" world";
+    ///
+    /// let spare = unsafe { s.spare_capacity_mut() };
+    /// for (slot, byte) in spare.iter_mut().zip(suffix) {
+    ///     slot.write(*byte);
+    /// }
+    /// // SAFETY: We initialized the appended bytes, and the result is valid UTF-8.
+    /// unsafe { s.set_len(s.len() + suffix.len()) };
+    ///
+    /// assert_eq!(s, "hello world");
+    /// ```
+    #[inline]
+    pub unsafe fn spare_capacity_mut(&mut self) -> &mut [mem::MaybeUninit<u8>] {
         let len = self.len();
         let ptr = self.0.as_mut_ptr();
         let cap = self.capacity();
 
-        slice::from_raw_parts_mut(ptr.add(len) as *mut mem::MaybeUninit<u8>, cap - len)
+        // SAFETY: The buffer is valid for `cap` bytes, and `len <= cap`. `MaybeUninit<u8>` does
+        // not require the spare bytes to be initialized.
+        unsafe { slice::from_raw_parts_mut(ptr.add(len) as *mut mem::MaybeUninit<u8>, cap - len) }
     }
 
     /// Returns a byte slice of the [`CompactString`]'s contents.
@@ -615,10 +648,10 @@ impl CompactString {
 
     // TODO: Implement a `try_as_mut_slice(...)` that will fail if it results in cloning?
     //
-    /// Provides a mutable reference to the underlying buffer of bytes.
+    /// Provides a mutable reference to the initialized bytes in this [`CompactString`].
     ///
-    /// The returned slice has length [`CompactString::capacity()`]. For heap-allocated strings,
-    /// this method initializes the spare capacity before returning.
+    /// The returned slice has length [`CompactString::len()`]. To write into the remaining
+    /// capacity, use [`CompactString::spare_capacity_mut`].
     ///
     /// # Safety
     /// * All Rust strings, including `CompactString`, must be valid UTF-8. The caller must
@@ -629,31 +662,18 @@ impl CompactString {
     /// # use compact_str::CompactString;
     /// let mut s = CompactString::new("hello");
     ///
-    /// let slice = unsafe { s.as_mut_bytes() };
-    /// // copy bytes into our string
-    /// slice[5..11].copy_from_slice(" world".as_bytes());
-    /// // set the len of the string
-    /// unsafe { s.set_len(11) };
+    /// let bytes = unsafe { s.as_mut_bytes() };
+    /// bytes[0] = b'H';
     ///
-    /// assert_eq!(s, "hello world");
+    /// assert_eq!(s, "Hello");
     /// ```
     #[inline]
     pub unsafe fn as_mut_bytes(&mut self) -> &mut [u8] {
         let len = self.len();
         let ptr = self.0.as_mut_ptr();
-        let cap = self.capacity();
 
-        // Inline buffers are fully initialized when they are created. Heap buffers only
-        // initialize their string contents, so initialize their spare capacity before exposing it
-        // through a `[u8]` reference.
-        if self.is_heap_allocated() {
-            // SAFETY: The heap allocation is valid for `cap` bytes and `len <= cap`.
-            unsafe { ptr.add(len).write_bytes(0, cap - len) };
-        }
-
-        // SAFETY: All `cap` bytes are initialized. Inline buffers are initialized on creation, and
-        // heap spare capacity was initialized above.
-        unsafe { slice::from_raw_parts_mut(ptr, cap) }
+        // SAFETY: The first `len` bytes of a `CompactString` are initialized.
+        unsafe { slice::from_raw_parts_mut(ptr, len) }
     }
 
     /// Appends the given [`char`] to the end of this [`CompactString`].

--- a/compact_str/src/repr/bytes.rs
+++ b/compact_str/src/repr/bytes.rs
@@ -58,11 +58,16 @@ impl Repr {
             // reserve at least enough space to fit this chunk
             repr.reserve(chunk_len).unwrap_with_msg();
 
-            // SAFETY: The caller is responsible for making sure the provided buffer is UTF-8. This
-            // invariant is documented in the public API
-            let slice = repr.as_mut_buf();
-            // write the chunk into the Repr
-            slice[bytes_written..bytes_written + chunk_len].copy_from_slice(chunk);
+            // Write the chunk into the spare capacity without first creating a reference to the
+            // uninitialized memory.
+            //
+            // SAFETY:
+            // * `reserve` guarantees at least `bytes_written + chunk_len` bytes of capacity.
+            // * `chunk` is valid for reads of `chunk_len` bytes.
+            // * `chunk` belongs to `buf`, so it cannot overlap `repr`.
+            repr.as_mut_ptr()
+                .add(bytes_written)
+                .copy_from_nonoverlapping(chunk.as_ptr(), chunk_len);
 
             // Set the length of the Repr
             // SAFETY: We just wrote an additional `chunk_len` bytes into the Repr

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -140,11 +140,17 @@ impl Repr {
         // Create a Repr with enough capacity for the entire buffer
         let mut repr = Repr::with_capacity(bytes_len)?;
 
-        // SAFETY: The caller is responsible for making sure the provided buffer is UTF-8. This
-        // invariant is documented in the public API
-        let slice = repr.as_mut_buf();
-        // write the chunk into the Repr
-        slice[..bytes_len].copy_from_slice(bytes);
+        // Write the bytes into the uninitialized buffer without first creating a reference to
+        // that memory.
+        //
+        // SAFETY:
+        // * `repr` was created with capacity for at least `bytes_len` bytes.
+        // * `bytes` is valid for reads of `bytes_len` bytes.
+        // * The newly allocated buffer does not overlap `bytes`.
+        unsafe {
+            repr.as_mut_ptr()
+                .copy_from_nonoverlapping(bytes.as_ptr(), bytes_len)
+        };
 
         // Set the length of the Repr
         // SAFETY: We just wrote the entire `buf` into the Repr
@@ -344,14 +350,18 @@ impl Repr {
         // Reserve at least enough space to fit `s`
         self.reserve(str_len).unwrap_with_msg();
 
-        // SAFETY: `s` which we're appending to the buffer, is valid UTF-8
-        let slice = unsafe { self.as_mut_buf() };
-        let push_buffer = &mut slice[len..len + str_len];
-
-        debug_assert_eq!(push_buffer.len(), s.len());
-
-        // Copy the string into our buffer
-        push_buffer.copy_from_slice(s.as_bytes());
+        // Copy the string into the spare capacity without first creating a reference to the
+        // uninitialized memory.
+        //
+        // SAFETY:
+        // * `reserve` guarantees at least `len + str_len` bytes of capacity.
+        // * `s` is valid for reads of `str_len` bytes.
+        // * The mutable borrow of `self` guarantees the source and destination do not overlap.
+        unsafe {
+            self.as_mut_ptr()
+                .add(len)
+                .copy_from_nonoverlapping(s.as_ptr(), str_len)
+        };
 
         // Increment the length of our string
         //
@@ -497,6 +507,9 @@ impl Repr {
     }
 
     /// Returns a mutable raw pointer to the start of the underlying buffer.
+    ///
+    /// The pointer is valid for writes up to [`Repr::capacity`], but only the first [`Repr::len`]
+    /// bytes are guaranteed to be initialized.
     #[inline]
     pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
         #[cold]
@@ -516,41 +529,6 @@ impl Repr {
         } else {
             self as *mut Self as *mut u8
         }
-    }
-
-    /// Return a mutable reference to the entirely underlying buffer
-    ///
-    /// # Safety
-    /// * Callers must guarantee that any modifications made to the buffer are valid UTF-8
-    pub(crate) unsafe fn as_mut_buf(&mut self) -> &mut [u8] {
-        #[cold]
-        fn inline_static_str(this: &mut Repr) {
-            if let Some(s) = this.as_static_str() {
-                *this = Repr::new(s).unwrap_with_msg();
-            }
-        }
-
-        if self.is_static_str() {
-            inline_static_str(self);
-        }
-
-        // the last byte stores our discriminant and stack length
-        let last_byte = self.last_byte();
-
-        let (ptr, cap) = if last_byte == HEAP_MASK {
-            // SAFETY: We just checked the discriminant to make sure we're heap allocated
-            let heap_buffer = self.as_heap();
-            let ptr = heap_buffer.ptr.as_ptr();
-            let cap = heap_buffer.capacity();
-
-            (ptr, cap)
-        } else {
-            let ptr = self as *mut Self as *mut u8;
-            (ptr, MAX_SIZE)
-        };
-
-        // SAFETY: Our data is valid for `cap` bytes, and is initialized
-        core::slice::from_raw_parts_mut(ptr, cap)
     }
 
     /// Sets the length of the string that our underlying buffer contains

--- a/compact_str/src/repr/num.rs
+++ b/compact_str/src/repr/num.rs
@@ -37,10 +37,8 @@ macro_rules! impl_IntoRepr {
                 };
                 let mut curr = num_digits as isize;
 
-                // our string will end up being num_digits long
-                unsafe { repr.set_len(num_digits) };
                 // get mutable pointer to our buffer
-                let buf_ptr = unsafe { repr.as_mut_buf().as_mut_ptr() };
+                let buf_ptr = repr.as_mut_ptr();
 
                 let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
@@ -93,6 +91,10 @@ macro_rules! impl_IntoRepr {
 
                 // we should have moved all the way down our buffer
                 debug_assert_eq!(curr, 0);
+
+                // SAFETY: We initialized all `num_digits` bytes above with ASCII digits and an
+                // optional leading `-`.
+                unsafe { repr.set_len(num_digits) };
 
                 Ok(repr)
             }

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -128,23 +128,47 @@ fn proptest_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) 
 }
 
 #[test]
-fn test_as_mut_bytes_exposes_initialized_capacity() {
+fn test_as_mut_bytes_only_exposes_initialized_data() {
     for mut compact in [
         CompactString::new("inline"),
         CompactString::with_capacity(100),
     ] {
-        let capacity = compact.capacity();
+        let len = compact.len();
 
         // SAFETY: We do not modify the buffer, so the string remains valid UTF-8.
         let bytes = unsafe { compact.as_mut_bytes() };
 
-        assert_eq!(bytes.len(), capacity);
+        assert_eq!(bytes.len(), len);
         for byte in bytes {
-            // Reading each byte under Miri verifies that `as_mut_bytes` did not expose
-            // uninitialized spare capacity through a `[u8]` reference.
+            // Reading each byte under Miri verifies that `as_mut_bytes` only exposes initialized
+            // string data through a `[u8]` reference.
             core::hint::black_box(*byte);
         }
     }
+}
+
+#[test]
+fn test_spare_capacity_mut() {
+    let mut inline = CompactString::new("");
+    let spare = unsafe { inline.spare_capacity_mut() };
+    assert_eq!(spare.len(), MAX_SIZE);
+    for slot in spare {
+        slot.write(b'a');
+    }
+    // SAFETY: Every byte is initialized to ASCII, including the inline tag byte, so the full
+    // buffer is valid UTF-8.
+    unsafe { inline.set_len(MAX_SIZE) };
+    assert_eq!(inline, "a".repeat(MAX_SIZE));
+
+    let mut heap = CompactString::with_capacity(100);
+    let suffix = b"hello";
+    let spare = unsafe { heap.spare_capacity_mut() };
+    for (slot, byte) in spare.iter_mut().zip(suffix) {
+        slot.write(*byte);
+    }
+    // SAFETY: The first `suffix.len()` bytes were initialized to valid UTF-8 above.
+    unsafe { heap.set_len(suffix.len()) };
+    assert_eq!(heap, "hello");
 }
 
 #[proptest]
@@ -156,9 +180,12 @@ fn proptest_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {
     // reserve enough space to write our bytes
     compact.reserve(word.len());
 
-    // SAFETY: We're writing a String which we know is UTF-8
-    let slice = unsafe { compact.as_mut_bytes() };
-    slice[..word.len()].copy_from_slice(word.as_bytes());
+    // SAFETY: We only initialize a prefix of the spare capacity, and don't overwrite the inline
+    // tag unless `word` fills the entire inline buffer with valid UTF-8.
+    let spare = unsafe { compact.spare_capacity_mut() };
+    for (slot, byte) in spare.iter_mut().zip(word.bytes()) {
+        slot.write(byte);
+    }
 
     // SAFETY: We know this is the length of our string, since `compact` started with 0 bytes
     // and we just wrote `word.len()` bytes
@@ -176,9 +203,12 @@ fn proptest_reserve_and_write_bytes_allocated_properly(#[strategy(rand_unicode()
     // reserve enough space to write our bytes
     compact.reserve(word.len());
 
-    // SAFETY: We're writing a String which we know is UTF-8
-    let slice = unsafe { compact.as_mut_bytes() };
-    slice[..word.len()].copy_from_slice(word.as_bytes());
+    // SAFETY: We only initialize a prefix of the spare capacity, and don't overwrite the inline
+    // tag unless `word` fills the entire inline buffer with valid UTF-8.
+    let spare = unsafe { compact.spare_capacity_mut() };
+    for (slot, byte) in spare.iter_mut().zip(word.bytes()) {
+        slot.write(byte);
+    }
 
     // SAFETY: We know this is the length of our string, since `compact` started with 0 bytes
     // and we just wrote `word.len()` bytes

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -127,6 +127,26 @@ fn proptest_from_lossy_cow_roundtrips(#[strategy(rand_bytes())] bytes: Vec<u8>) 
     prop_assert_eq!(cow, compact);
 }
 
+#[test]
+fn test_as_mut_bytes_exposes_initialized_capacity() {
+    for mut compact in [
+        CompactString::new("inline"),
+        CompactString::with_capacity(100),
+    ] {
+        let capacity = compact.capacity();
+
+        // SAFETY: We do not modify the buffer, so the string remains valid UTF-8.
+        let bytes = unsafe { compact.as_mut_bytes() };
+
+        assert_eq!(bytes.len(), capacity);
+        for byte in bytes {
+            // Reading each byte under Miri verifies that `as_mut_bytes` did not expose
+            // uninitialized spare capacity through a `[u8]` reference.
+            core::hint::black_box(*byte);
+        }
+    }
+}
+
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn proptest_reserve_and_write_bytes(#[strategy(rand_unicode())] word: String) {


### PR DESCRIPTION
`Repr::as_mut_buf` created a `&mut [u8]` over the full heap allocation even though only the string’s current length was initialized. This exposed uninitialized spare capacity through a reference, including from the public `CompactString::as_mut_bytes` API.

This replaces the internal full-buffer slice with a raw pointer and updates construction, append, and number-formatting paths to write through that pointer before setting the initialized length. APIs that need references now restrict them to initialized bytes or use `MaybeUninit`. To preserve the existing behavior of `as_mut_bytes`, heap spare capacity is zero-initialized before returning the capacity-length byte slice, and that behavior is now documented.

The regression test covers inline and heap representations and reads every returned byte under Miri. The change passes all-feature tests, Clippy, no-std checking, and focused strict-provenance Miri tests.

Closes https://github.com/ParkMyCar/compact_str/issues/326.

Closes https://github.com/ParkMyCar/compact_str/issues/453.
