### PR TITLE
fix: avoid invalid UTF-8 references in retain

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1239,14 +1239,26 @@ impl CompactString {
             src_idx: 0,
             dst_idx: 0,
         };
-        let s = g.self_.as_mut_str();
-        while let Some(ch) = s[g.src_idx..].chars().next() {
+        let original_len = g.self_.len();
+        let ptr = g.self_.0.as_mut_ptr();
+        while g.src_idx < original_len {
+            // SAFETY: Everything at and after `src_idx` is an untouched suffix of the
+            // original string. In particular, it is initialized, valid UTF-8, and non-empty.
+            let ch = unsafe {
+                let suffix =
+                    core::slice::from_raw_parts(ptr.add(g.src_idx), original_len - g.src_idx);
+                core::str::from_utf8_unchecked(suffix)
+                    .chars()
+                    .next()
+                    .expect("source suffix is non-empty")
+            };
             let ch_len = ch.len_utf8();
             if predicate(ch) {
-                // SAFETY: We know that both indices are valid, and that we don't split a char.
+                // SAFETY: Both ranges are in the allocation and `copy` permits overlap. The
+                // destination ends no later than the end of the current source character, so
+                // the unprocessed suffix remains unchanged.
                 unsafe {
-                    let p = s.as_mut_ptr();
-                    core::ptr::copy(p.add(g.src_idx), p.add(g.dst_idx), ch_len);
+                    core::ptr::copy(ptr.add(g.src_idx), ptr.add(g.dst_idx), ch_len);
                 }
                 g.dst_idx += ch_len;
             }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -496,6 +496,28 @@ impl Repr {
         }
     }
 
+    /// Returns a mutable raw pointer to the start of the underlying buffer.
+    #[inline]
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut u8 {
+        #[cold]
+        fn inline_static_str(this: &mut Repr) {
+            if let Some(s) = this.as_static_str() {
+                *this = Repr::new(s).unwrap_with_msg();
+            }
+        }
+
+        if self.is_static_str() {
+            inline_static_str(self);
+        }
+
+        if self.is_heap_allocated() {
+            // SAFETY: We just checked the discriminant to make sure we're heap allocated.
+            unsafe { self.as_mut_heap().ptr.as_ptr() }
+        } else {
+            self as *mut Self as *mut u8
+        }
+    }
+
     /// Return a mutable reference to the entirely underlying buffer
     ///
     /// # Safety

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -1397,6 +1397,25 @@ fn test_retain() {
     s.retain(|_| false);
     assert_eq!(s, "");
 
+    // Moving a multi-byte character by one byte temporarily leaves the full old-length
+    // buffer invalid UTF-8. `retain` must only interpret the untouched source suffix.
+    let mut s = CompactString::from("0è0");
+    s.retain(|c| c != '0');
+    assert_eq!(s, "è");
+
+    let input = "0èabcdefghijklmnopqrstuvwxyz";
+    let expected = "èabcdefghijklmnopqrstuvwxyz";
+
+    let mut heap = CompactString::from(input);
+    assert!(heap.is_heap_allocated());
+    heap.retain(|c| c != '0');
+    assert_eq!(heap, expected);
+
+    let mut static_str = CompactString::const_new(input);
+    assert_eq!(static_str.as_static_str(), Some(input));
+    static_str.retain(|c| c != '0');
+    assert_eq!(static_str, expected);
+
     let mut s = CompactString::from("0è0");
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut count = 0;


### PR DESCRIPTION
`CompactString::retain` held a mutable `str` reference over the entire buffer while shifting retained characters in place. Moving a multi-byte character to an earlier byte could temporarily make the full old-length buffer invalid UTF-8 while that reference was still live, which I believe is UB (a `str` reference to invalid UTF-8).

This changes `retain` to work through a raw buffer pointer and constructs short-lived `str` references only for the untouched source suffix, which remains initialized and valid UTF-8 throughout the operation. A new internal `Repr::as_mut_ptr` helper handles inline, heap, and static-string representations while preserving the existing panic guard behavior.
