### PR TITLE
feat: add garde validation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "examples/bevy-reflect",
     "examples/bytes",
     "examples/diesel",
+    "examples/garde",
     "examples/macros",
     "examples/serde",
     "examples/sqlx",

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -22,6 +22,7 @@ borsh = ["dep:borsh"]
 bytes = ["dep:bytes"]
 defmt = ["dep:defmt"]
 diesel = ["dep:diesel"]
+garde = ["dep:garde"]
 markup = ["dep:markup"]
 proptest = ["dep:proptest"]
 quickcheck = ["dep:quickcheck"]
@@ -42,6 +43,7 @@ borsh = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
 defmt = { version = "1", optional = true }
 diesel = { version = "2", optional = true, default-features = false }
+garde = { version = "0.23", optional = true, default-features = false, features = ["derive"] }
 markup = { version = "0.15", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = [
     "std",

--- a/compact_str/src/features/garde.rs
+++ b/compact_str/src/features/garde.rs
@@ -1,0 +1,241 @@
+use crate::CompactString;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "garde")))]
+impl garde::rules::AsStr for CompactString {
+    fn as_str(&self) -> &str {
+        self.as_str()
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "garde")))]
+impl garde::rules::length::HasBytes for CompactString {
+    fn num_bytes(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "garde")))]
+impl garde::rules::length::HasChars for CompactString {
+    fn num_chars(&self) -> usize {
+        self.chars().count()
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "garde")))]
+impl garde::rules::length::HasSimpleLength for CompactString {
+    fn length(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "garde")))]
+impl garde::rules::length::HasUtf16CodeUnits for CompactString {
+    fn num_code_units(&self) -> usize {
+        self.encode_utf16().count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use garde::Validate;
+
+    use crate::CompactString;
+
+    // Validates that CompactString works as a field in a garde-validated struct
+    // using the `ascii` rule (which relies on AsStr).
+    #[derive(garde::Validate)]
+    struct AsciiTest {
+        #[garde(ascii)]
+        value: CompactString,
+    }
+
+    #[test]
+    fn as_str_ascii_valid() {
+        let t = AsciiTest {
+            value: CompactString::from("hello world!"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn as_str_ascii_invalid() {
+        let t = AsciiTest {
+            value: CompactString::from("héllo"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    // Tests length(bytes, ...) which relies on HasBytes.
+    // Multi-byte UTF-8 chars make byte count diverge from char count.
+    #[derive(garde::Validate)]
+    struct ByteLengthTest {
+        #[garde(length(bytes, min = 1, max = 4))]
+        value: CompactString,
+    }
+
+    #[test]
+    fn has_bytes_within_limit() {
+        // "hi" = 2 bytes
+        let t = ByteLengthTest {
+            value: CompactString::from("hi"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn has_bytes_exceeds_limit() {
+        // "héllo" = 6 bytes (é is 2 bytes) — exceeds max=4
+        let t = ByteLengthTest {
+            value: CompactString::from("héllo"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn has_bytes_empty_fails() {
+        let t = ByteLengthTest {
+            value: CompactString::new(""),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    // Tests length(chars, ...) which relies on HasChars.
+    // A multi-byte char is still one char.
+    #[derive(garde::Validate)]
+    struct CharLengthTest {
+        #[garde(length(chars, min = 1, max = 3))]
+        value: CompactString,
+    }
+
+    #[test]
+    fn has_chars_within_limit() {
+        // "héy" = 3 chars (even though é is 2 bytes)
+        let t = CharLengthTest {
+            value: CompactString::from("héy"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn has_chars_exceeds_limit() {
+        let t = CharLengthTest {
+            value: CompactString::from("abcd"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn has_chars_empty_fails() {
+        let t = CharLengthTest {
+            value: CompactString::new(""),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    // Tests length(...) with no mode, which uses HasSimpleLength (byte-based).
+    #[derive(garde::Validate)]
+    struct SimpleLengthTest {
+        #[garde(length(min = 2, max = 5))]
+        value: CompactString,
+    }
+
+    #[test]
+    fn has_simple_length_valid() {
+        let t = SimpleLengthTest {
+            value: CompactString::from("abc"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn has_simple_length_too_short() {
+        let t = SimpleLengthTest {
+            value: CompactString::from("a"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn has_simple_length_too_long() {
+        let t = SimpleLengthTest {
+            value: CompactString::from("abcdef"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    // Tests length(utf16, ...) which relies on HasUtf16CodeUnits.
+    // Emoji outside the BMP require 2 UTF-16 code units (surrogate pair).
+    #[derive(garde::Validate)]
+    struct Utf16LengthTest {
+        #[garde(length(utf16, min = 1, max = 2))]
+        value: CompactString,
+    }
+
+    #[test]
+    fn has_utf16_bmp_char_valid() {
+        // "é" = 1 UTF-16 code unit
+        let t = Utf16LengthTest {
+            value: CompactString::from("é"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn has_utf16_surrogate_pair_valid() {
+        // "😀" = 2 UTF-16 code units
+        let t = Utf16LengthTest {
+            value: CompactString::from("😀"),
+        };
+        assert!(t.validate().is_ok());
+    }
+
+    #[test]
+    fn has_utf16_exceeds_limit() {
+        // "😀😀" = 4 UTF-16 code units — exceeds max=2
+        let t = Utf16LengthTest {
+            value: CompactString::from("😀😀"),
+        };
+        assert!(t.validate().is_err());
+    }
+
+    // Ensure CompactString and String produce identical results across all traits.
+    #[derive(garde::Validate)]
+    struct StringTest {
+        #[garde(ascii)]
+        #[garde(length(bytes, min = 1, max = 100))]
+        #[garde(length(chars, min = 1, max = 100))]
+        #[garde(length(min = 1, max = 100))]
+        #[garde(length(utf16, min = 1, max = 100))]
+        value: std::string::String,
+    }
+
+    #[derive(garde::Validate)]
+    struct CompactTest {
+        #[garde(ascii)]
+        #[garde(length(bytes, min = 1, max = 100))]
+        #[garde(length(chars, min = 1, max = 100))]
+        #[garde(length(min = 1, max = 100))]
+        #[garde(length(utf16, min = 1, max = 100))]
+        value: CompactString,
+    }
+
+    #[test]
+    fn matches_string_behavior() {
+        for s in &["hello", "héllo", "😀", "a", ""] {
+            let string_result = StringTest {
+                value: std::string::String::from(*s),
+            }
+            .validate();
+            let compact_result = CompactTest {
+                value: CompactString::from(*s),
+            }
+            .validate();
+            assert_eq!(
+                string_result.is_ok(),
+                compact_result.is_ok(),
+                "mismatch for input {:?}",
+                s
+            );
+        }
+    }
+}

--- a/compact_str/src/features/mod.rs
+++ b/compact_str/src/features/mod.rs
@@ -12,6 +12,8 @@ mod bytes;
 mod defmt;
 #[cfg(feature = "diesel")]
 mod diesel;
+#[cfg(feature = "garde")]
+mod garde;
 #[cfg(feature = "markup")]
 mod markup;
 #[cfg(feature = "proptest")]

--- a/examples/garde/Cargo.toml
+++ b/examples/garde/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example-garde"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+compact_str = { path = "../../compact_str", features = ["garde"] }
+garde = { version = "0.23", features = ["derive"] }

--- a/examples/garde/src/main.rs
+++ b/examples/garde/src/main.rs
@@ -1,0 +1,63 @@
+use compact_str::CompactString;
+use garde::Validate;
+
+/// A user registration form with CompactString fields validated by garde.
+///
+/// CompactString implements all of garde's string traits, so it works as a
+/// drop-in replacement for String in validated structs.
+#[derive(Debug, Validate)]
+struct RegistrationForm {
+    /// 3–32 chars
+    #[garde(length(chars, min = 3, max = 32))]
+    username: CompactString,
+
+    /// At least 8 bytes (handles multi-byte passwords correctly)
+    #[garde(length(bytes, min = 8))]
+    password: CompactString,
+
+    /// Must be ASCII only
+    #[garde(ascii, length(min = 1, max = 64))]
+    invite_code: CompactString,
+}
+
+fn main() {
+    let valid = RegistrationForm {
+        username: CompactString::from("alice"),
+        password: CompactString::from("s3cur3p@ss"),
+        invite_code: CompactString::from("WELCOME2024"),
+    };
+    match valid.validate_with(&()) {
+        Ok(()) => println!("Valid form: {:?}", valid),
+        Err(e) => println!("Unexpected error: {e}"),
+    }
+
+    let short_username = RegistrationForm {
+        username: CompactString::from("al"),
+        password: CompactString::from("s3cur3p@ss"),
+        invite_code: CompactString::from("WELCOME2024"),
+    };
+    match short_username.validate() {
+        Ok(()) => println!("Unexpected success"),
+        Err(e) => println!("Validation error (username too short):\n{e}"),
+    }
+
+    let short_password = RegistrationForm {
+        username: CompactString::from("bob"),
+        password: CompactString::from("short"),
+        invite_code: CompactString::from("WELCOME2024"),
+    };
+    match short_password.validate() {
+        Ok(()) => println!("Unexpected success"),
+        Err(e) => println!("Validation error (password too short):\n{e}"),
+    }
+
+    let non_ascii_code = RegistrationForm {
+        username: CompactString::from("carol"),
+        password: CompactString::from("s3cur3p@ss"),
+        invite_code: CompactString::from("WËLCOME"),
+    };
+    match non_ascii_code.validate() {
+        Ok(()) => println!("Unexpected success"),
+        Err(e) => println!("Validation error (non-ASCII invite code):\n{e}"),
+    }
+}


### PR DESCRIPTION
Adds an optional `garde` feature that implements garde's string rule traits for `CompactString`, so it drops into `#[derive(garde::Validate)]` structs the same way `String` does. `CompactString` now implements `AsStr`, `length::HasBytes`, `length::HasChars`, `length::HasSimpleLength`, and `length::HasUtf16CodeUnits` — covering the `ascii` rule and every flavor of `length` (`bytes`, `chars`, `utf16`, and the default byte-based mode).

The impls just forward to the equivalent `CompactString` methods, mirroring what garde does for `String` — note `HasSimpleLength` returns the byte length, matching garde's own `String` behavior. There's a test that runs a struct through every rule against both `String` and `CompactString` and asserts they agree, plus an `examples/garde` crate with a realistic registration-form validation.

This is the `garde` half of #458 by @0x7d8, split onto its own branch so it can land without waiting on the sqlx 0.9 bump in that PR — co-authored so the credit stays with them.

Verified with `cargo test --features garde` (15 tests, including the `String`-parity check) and `cargo run -p example-garde`. `garde 0.23.0` is the latest release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_