### PR TITLE
deps: bump sqlx to 0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   RUSTFLAGS: "-D warnings"
   PROPTEST_CASES: 10000
   MIRIFLAGS: "-Zmiri-strict-provenance"
-  RUST_VERSION: 1.92.0
+  RUST_VERSION: 1.96.1
   RUST_NIGHTLY_VERSION: "nightly-2026-07-08"
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolchain: "1.92.0"
+          - toolchain: "1.96.1"
           - toolchain: "nightly-2026-07-08"
 
     name: cargo test

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,7 +10,7 @@ name: Clippy
 env:
   CARGO_TERM_COLOR: "always"
   RUSTFLAGS: "-D warnings"
-  RUST_VERSION: 1.92.0
+  RUST_VERSION: 1.96.1
   RUST_NIGHTLY_VERSION: "nightly-2026-07-08"
 
 jobs:

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -55,7 +55,7 @@ serde = { version = "1", optional = true, default-features = false, features = [
     "alloc",
 ] }
 smallvec = { version = "1", optional = true, features = ["union"] }
-sqlx = { version = "0.8", optional = true, default-features = false }
+sqlx = { version = "0.9", optional = true, default-features = false }
 utoipa = { version = "5", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
@@ -76,6 +76,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 test-case = "3"
 test-strategy = "0.3"
+# Enables `zeroize/alloc` for the `String` baseline in the zeroize parity tests, without widening the public feature.
+zeroize = { version = "1", default-features = false, features = ["alloc"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/compact_str/src/features/sqlx.rs
+++ b/compact_str/src/features/sqlx.rs
@@ -43,7 +43,7 @@ where
 impl<'q> Encode<'q, sqlx::MySql> for CompactString {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::MySql as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::MySql as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::MySql>::encode_by_ref(&self.as_str(), buf)
     }
@@ -81,7 +81,7 @@ where
 impl<'q> Encode<'q, sqlx::Postgres> for CompactString {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Postgres as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Postgres as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Postgres>::encode_by_ref(&self.as_str(), buf)
     }
@@ -133,14 +133,14 @@ where
 impl<'q> Encode<'q, sqlx::Sqlite> for CompactString {
     fn encode(
         self,
-        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Sqlite>::encode(self.into_string(), buf)
     }
 
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Sqlite as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         Encode::<'_, sqlx::Sqlite>::encode(alloc::string::String::from(self.as_str()), buf)
     }

--- a/examples/sqlx/Cargo.toml
+++ b/examples/sqlx/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-compact_str = { version = "0.9.0", features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "mysql", "postgres", "sqlite"] }
+compact_str = { path = "../../compact_str", features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "mysql", "postgres", "sqlite"] }
 tempfile = "3"
-tokio = { version = "1.20.0", features = ["rt", "macros"]}
+tokio = { version = "1.20.0", features = ["rt", "macros"] }


### PR DESCRIPTION
Bumps the optional `sqlx` dependency to 0.9 and migrates the `Encode` impls to its API (the GAT lifetime is gone from `Database::ArgumentBuffer`). sqlx 0.9's MSRV is 1.94, so CI's pinned stable (`RUST_VERSION`) moves to the latest, 1.96.1 — the crate's own `rust-version = 1.71` is unchanged, since `sqlx` is optional and only its users need 1.94 (which sqlx requires regardless).

The bump also surfaced a latent zeroize issue: the tests assert `CompactString::zeroize` matches `String::zeroize`, which only holds when the zeroize crate's `alloc` feature is on. compact_str was getting that for free from sqlx 0.8's transitive deps, and sqlx 0.9 drops them. `CompactString`'s own impl doesn't need `alloc`, so rather than widen the public feature I enable `zeroize/alloc` through a dev-dependency, just for the `String` baseline the tests compare against.

This is the sqlx half of #457 by @0x7d8, split onto its own branch and co-authored so the credit stays with them.

Verified on 1.96.1: full test suite (306 lib + 83 doc), clippy, and fmt all pass, and compact_str still builds for a bare-metal no_std target with the `zeroize` feature.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGTA38KYXfd6EgVAiUYJ1e)_