### PR TITLE
ci: remove temporary push trigger from Miri Proptest workflow

### DIFF
--- a/.github/workflows/miri-proptest.yml
+++ b/.github/workflows/miri-proptest.yml
@@ -1,10 +1,4 @@
 on:
-  # TEMPORARY: run on pushes to this branch so we can smoke the job in real CI (mobile can't
-  # trigger workflow_dispatch). Remove this `push:` block before merging -- the job is meant to
-  # be nightly / on-demand only, not on the PR path.
-  push:
-    branches:
-      - ci/miri-proptest
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
The `push:` trigger on `miri-proptest.yml` was only there to smoke-test the job in real CI while setting it up, and it rode into `main` with the original merge. This restores the workflow to its intended nightly `schedule` + `workflow_dispatch` triggers.