### PR TITLE
ci: add skip companions so path-filtered checks can be required

### DIFF
--- a/.github/workflows/cross_platform_skip.yml
+++ b/.github/workflows/cross_platform_skip.yml
@@ -1,0 +1,38 @@
+# Companion "skip" workflow for cross_platform.yml.
+#
+# cross_platform.yml is path-filtered -- it only runs when `compact_str/**` or its own file
+# changes. GitHub does NOT treat a workflow skipped by a path filter as passing: a *required*
+# status check that never reports leaves the PR blocked forever. This workflow triggers on the
+# inverse path set and reports the same check names as success, so the required checks are
+# satisfied on PRs that don't touch those paths -- without running the slow, emulated
+# cross-platform matrix.
+#
+# Keep the `name` list below in sync with the matrix in cross_platform.yml.
+on:
+  pull_request:
+    paths-ignore:
+      - 'compact_str/**'
+      - '.github/workflows/cross_platform.yml'
+
+name: X-Plat
+
+jobs:
+  cross-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - macos
+          - Windows
+          - Linux 32-bit
+          - Linux ARMv6 32-bit
+          - Linux ARMv7-A 32-bit
+          - Linux PowerPC Big Endian 32-bit
+          - Linux PowerPC Little Endian 64-bit
+          - Linux ARM64 Little Endian 64-bit
+          - Linux PowerPC Big Endian 64-bit
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: echo "cross_platform.yml doesn't apply to this change; reporting success to satisfy the required check."

--- a/.github/workflows/fuzz_skip.yml
+++ b/.github/workflows/fuzz_skip.yml
@@ -1,0 +1,21 @@
+# Companion "skip" workflow for fuzz.yml -- see cross_platform_skip.yml for the full rationale.
+#
+# fuzz.yml is path-filtered, so on PRs that don't touch its paths the required `libFuzzer [x86_64]`
+# check would never report and block merging. This reports that check name as success on the
+# inverse path set. Keep the job name in sync with fuzz.yml.
+on:
+  pull_request:
+    paths-ignore:
+      - 'compact_str/**'
+      - 'fuzz/**'
+      - '.github/workflows/fuzz.yml'
+
+name: Fuzz
+
+jobs:
+  libFuzzer_x86_64:
+    name: libFuzzer [x86_64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: echo "fuzz.yml doesn't apply to this change; reporting success to satisfy the required check."

--- a/.github/workflows/msrv_skip.yml
+++ b/.github/workflows/msrv_skip.yml
@@ -1,0 +1,20 @@
+# Companion "skip" workflow for msrv.yml -- see cross_platform_skip.yml for the full rationale.
+#
+# msrv.yml is path-filtered, so on PRs that don't touch its paths the required `cargo check msrv...`
+# check would never report and block merging. This reports that check name as success on the
+# inverse path set. Keep the job name in sync with msrv.yml.
+on:
+  pull_request:
+    paths-ignore:
+      - 'compact_str/**'
+      - '.github/workflows/msrv.yml'
+
+name: MSRV
+
+jobs:
+  msrv:
+    name: cargo check msrv...
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: echo "msrv.yml doesn't apply to this change; reporting success to satisfy the required check."


### PR DESCRIPTION
`cross_platform.yml` (X-Plat), `fuzz.yml`, and `msrv.yml` are path-filtered — they only run on PRs that touch `compact_str/**` (and a couple of related paths). GitHub does **not** treat a workflow skipped by a path filter as passing, so if those checks are marked *required*, any PR that doesn't touch those paths (docs, workflow tweaks) is blocked forever waiting on checks that never report.

These three companion workflows fix that. Each triggers on the **inverse** path set and defines jobs with the **same check names** that just report success. So for any PR exactly one side reports each check:

- Touches `compact_str/**` → the real job runs and gates (full coverage).
- Doesn't → the stub reports success, so the required check is satisfied.

Covered checks (kept in sync with the real workflows):
- **X-Plat**: the 9 targets (`macos`, `Windows`, `Linux 32-bit`, `Linux ARMv6/ARMv7-A 32-bit`, `Linux PowerPC {Big,Little} Endian {32,64}-bit`, `Linux ARM64 Little Endian 64-bit`)
- **Fuzz**: `libFuzzer [x86_64]`
- **MSRV**: `cargo check msrv...`

Stubs run on `ubuntu-latest` in seconds since only the check name matters. One edge to note: a PR that touches `compact_str/**` **and** unrelated files triggers both sides — but the real (slow) job still runs and its result is what gates, so a real failure still blocks.