### PR TITLE
ci: give cargo test matrix legs version-independent check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,13 @@ jobs:
       matrix:
         include:
           - toolchain: "1.96.1"
+            name: stable
           - toolchain: "nightly-2026-07-08"
+            name: nightly
 
-    name: cargo test
+    # Use a version-independent name so the check name (and any required-status-check that
+    # references it) doesn't change every time we bump the pinned toolchain.
+    name: cargo test (${{ matrix.name }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `cargo test` matrix embedded the toolchain version in its check names, so `cargo test (1.96.1)` / `cargo test (nightly-2026-07-08)` get **renamed every time we bump the pinned toolchain** — which silently breaks any required-status-check (and any open auto-merge) that references the old name.

This names the legs `stable` / `nightly` so the checks become `cargo test (stable)` and `cargo test (nightly)`, independent of the version. After this, a toolchain bump never renames a required check.

Note: this renames those two checks one last time, so the required-checks list needs updating to the new names after it merges.