### PR TITLE
perf: speed up append, integer formatting, and inline creation

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 compact_str = { path = "../compact_str" }
 compact_str_6 = { package = "compact_str", version = "0.6" }
 criterion = { version = "0.5", default-features = false }
+gungraun = "0.19"
 iai = "0.1.1"
 smartstring = "1.0.1"
 smol_str = "0.2"
@@ -31,4 +32,20 @@ harness = false
 
 [[bench]]
 name = "random"
+harness = false
+
+[[bench]]
+name = "gungraun_apis"
+harness = false
+
+[[bench]]
+name = "gungraun_compact_str"
+harness = false
+
+[[bench]]
+name = "gungraun_comparison"
+harness = false
+
+[[bench]]
+name = "gungraun_random"
 harness = false

--- a/bench/benches/gungraun_apis.rs
+++ b/bench/benches/gungraun_apis.rs
@@ -1,0 +1,141 @@
+//! Gungraun (Callgrind) instruction-count benchmarks for various APIs, making sure
+//! `CompactString` is at least no slower than `String`.
+
+use std::hint::black_box;
+
+use compact_str::CompactString;
+use gungraun::{library_benchmark, library_benchmark_group, main};
+
+static VERY_LONG_STR: &str = include_str!("../data/moby10b.txt");
+
+fn make_compact(word: &str) -> CompactString {
+    CompactString::new(word)
+}
+
+fn make_string(word: &str) -> String {
+    String::from(word)
+}
+
+// --- CompactString --------------------------------------------------------------------------
+
+#[library_benchmark(setup = make_compact)]
+#[bench::inline("i am short")]
+#[bench::heap("I am a very long string that will get allocated on the heap")]
+#[bench::very_long(VERY_LONG_STR)]
+fn compact_string_length(compact_str: CompactString) -> usize {
+    black_box(black_box(&compact_str).len())
+}
+
+#[library_benchmark]
+#[bench::small(10)]
+#[bench::large(100)]
+fn compact_string_reserve(additional: usize) -> CompactString {
+    let mut compact_str = CompactString::default();
+    compact_str.reserve(black_box(additional));
+    black_box(compact_str)
+}
+
+#[library_benchmark(setup = make_compact)]
+#[bench::small("i am short")]
+fn compact_string_clone(compact: CompactString) -> CompactString {
+    black_box(black_box(&compact).clone())
+}
+
+#[library_benchmark(setup = make_compact)]
+#[bench::large("I am a very long string that will get allocated on the heap")]
+fn compact_string_clone_and_modify(compact: CompactString) -> CompactString {
+    let mut clone = black_box(&compact).clone();
+    clone.push('!');
+    clone.push(' ');
+    clone.push_str("And that is quite cool~");
+    black_box(clone)
+}
+
+#[library_benchmark]
+#[bench::empty("I am a very long string that will get allocated on the heap", 0)]
+#[bench::short("hello", 10)]
+#[bench::inline_to_heap_20("hello world", 20)]
+#[bench::heap_20("this is a long string that will start on the heap", 20)]
+fn compact_string_extend_chars(base: &str, count: usize) -> CompactString {
+    let mut compact = CompactString::new(black_box(base));
+    compact.extend((0..count).map(|_| '!'));
+    black_box(compact)
+}
+
+#[library_benchmark(setup = make_string)]
+#[bench::inline("I am short")]
+#[bench::heap("I am a long string, look at me!")]
+#[bench::heap_long(VERY_LONG_STR)]
+fn compact_string_from_string(word: String) -> CompactString {
+    black_box(CompactString::from(black_box(word)))
+}
+
+// --- std::String ----------------------------------------------------------------------------
+
+#[library_benchmark(setup = make_string)]
+#[bench::short("i am short")]
+#[bench::long("I am a very long string that will get allocated on the heap")]
+#[bench::very_long(VERY_LONG_STR)]
+fn std_string_length(string: String) -> usize {
+    black_box(black_box(&string).len())
+}
+
+#[library_benchmark]
+#[bench::small(10)]
+#[bench::large(100)]
+fn std_str_reserve(additional: usize) -> String {
+    let mut std_str = String::default();
+    std_str.reserve(black_box(additional));
+    black_box(std_str)
+}
+
+#[library_benchmark(setup = make_string)]
+#[bench::small("i am short")]
+fn std_str_clone(std_str: String) -> String {
+    black_box(black_box(&std_str).clone())
+}
+
+#[library_benchmark(setup = make_string)]
+#[bench::large("I am a very long string that will get allocated on the heap")]
+fn std_str_clone_and_modify(std_str: String) -> String {
+    let mut clone = black_box(&std_str).clone();
+    clone.push('!');
+    clone.push(' ');
+    clone.push_str("And that is quite cool~");
+    black_box(clone)
+}
+
+#[library_benchmark]
+#[bench::empty("hello", 0)]
+#[bench::short("hello", 10)]
+#[bench::chars_20("hello", 20)]
+fn std_str_extend_chars(base: &str, count: usize) -> String {
+    let mut std_str = String::from(black_box(base));
+    std_str.extend((0..count).map(|_| '!'));
+    black_box(std_str)
+}
+
+library_benchmark_group!(
+    name = compact_str_benches,
+    benchmarks = [
+        compact_string_length,
+        compact_string_reserve,
+        compact_string_clone,
+        compact_string_clone_and_modify,
+        compact_string_extend_chars,
+        compact_string_from_string,
+    ]
+);
+
+library_benchmark_group!(
+    name = std_string,
+    benchmarks = [
+        std_string_length,
+        std_str_reserve,
+        std_str_clone,
+        std_str_clone_and_modify,
+        std_str_extend_chars,
+    ]
+);
+
+main!(library_benchmark_groups = compact_str_benches, std_string);

--- a/bench/benches/gungraun_compact_str.rs
+++ b/bench/benches/gungraun_compact_str.rs
@@ -1,0 +1,225 @@
+//! Gungraun (Callgrind) instruction-count benchmarks for `CompactString` creation, conversion,
+//! and the internal repr.
+
+use std::hint::black_box;
+use std::mem::size_of;
+
+use compact_str::{CompactString, ToCompactString};
+use compact_str_6::CompactString as CompactString6;
+use gungraun::{library_benchmark, library_benchmark_group, main};
+
+fn make_string(word: &str) -> String {
+    String::from(word)
+}
+
+fn make_repeated(len: usize) -> String {
+    (0..len).map(|_| 'a').collect()
+}
+
+// --- CompactString::new / String::from ------------------------------------------------------
+
+#[library_benchmark]
+#[bench::chars_0("")]
+#[bench::chars_16("im sixteen chars")]
+#[bench::chars_24("i am twenty four chars!!")]
+fn compact_string_new(word: &str) -> CompactString {
+    black_box(CompactString::new(black_box(word)))
+}
+
+#[library_benchmark]
+#[bench::chars_59("I am a very long string that will get allocated on the heap")]
+fn compact_string_from_str(word: &str) -> CompactString {
+    black_box(CompactString::from(black_box(word)))
+}
+
+#[library_benchmark]
+#[bench::chars_59("I am a very long string that will get allocated on the heap")]
+fn std_string_from_str(word: &str) -> String {
+    black_box(String::from(black_box(word)))
+}
+
+// --- CompactString::new(String) -------------------------------------------------------------
+
+#[library_benchmark(setup = make_repeated)]
+#[bench::inline_short(size_of::<String>() / 2)]
+#[bench::inline_limit(size_of::<String>())]
+#[bench::heap_boundary(size_of::<String>() + 1)]
+#[bench::heap_medium(64)]
+#[bench::heap_large(1024)]
+fn compact_string_new_owned(value: String) -> CompactString {
+    black_box(CompactString::new(black_box(value)))
+}
+
+// --- ToCompactString ------------------------------------------------------------------------
+
+#[library_benchmark]
+#[bench::u8(42_u8)]
+fn u8_to_compact_string(num: u8) -> CompactString {
+    black_box(black_box(num).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::u32(54321_u32)]
+fn u32_to_compact_string(num: u32) -> CompactString {
+    black_box(black_box(num).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::isize(-9999999_isize)]
+fn isize_to_compact_string(num: isize) -> CompactString {
+    black_box(black_box(num).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::max(u64::MAX)]
+fn u64_to_compact_string(num: u64) -> CompactString {
+    black_box(black_box(num).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::big(12345678909876543210123456789_u128)]
+fn u128_to_compact_string(num: u128) -> CompactString {
+    black_box(black_box(num).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::yes(true)]
+fn bool_to_compact_string(flag: bool) -> CompactString {
+    black_box(black_box(flag).to_compact_string())
+}
+
+#[library_benchmark(setup = make_string)]
+#[bench::hello_world("hello world!")]
+fn string_to_compact_string(word: String) -> CompactString {
+    black_box(black_box(&word).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::a('a')]
+fn char_to_compact_string(c: char) -> CompactString {
+    black_box(black_box(c).to_compact_string())
+}
+
+#[library_benchmark]
+#[bench::inline("module")]
+#[bench::heap("package.submodule.long_name")]
+fn str_to_compact_string(value: &str) -> CompactString {
+    black_box(black_box(value).to_compact_string())
+}
+
+// --- Internal repr: creation ----------------------------------------------------------------
+
+#[library_benchmark(setup = make_repeated)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn repr_creation_compact_str_6(word: String) -> CompactString6 {
+    black_box(CompactString6::new(black_box(&word)))
+}
+
+#[library_benchmark(setup = make_repeated)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn repr_creation_compact_str(word: String) -> CompactString {
+    black_box(CompactString::new(black_box(&word)))
+}
+
+#[library_benchmark(setup = make_repeated)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn repr_creation_std_string(word: String) -> String {
+    black_box(String::from(black_box(&word)))
+}
+
+// --- Internal repr: access ------------------------------------------------------------------
+
+fn setup_compact_str_6(len: usize) -> CompactString6 {
+    CompactString6::new(make_repeated(len))
+}
+
+fn setup_compact_str(len: usize) -> CompactString {
+    CompactString::new(make_repeated(len))
+}
+
+#[library_benchmark(setup = setup_compact_str_6)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_50(50)]
+fn repr_access_compact_str_6(compact: CompactString6) {
+    black_box(black_box(&compact).as_str());
+}
+
+#[library_benchmark(setup = setup_compact_str)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_50(50)]
+fn repr_access_compact_str(compact: CompactString) {
+    black_box(black_box(&compact).as_str());
+}
+
+#[library_benchmark(setup = make_repeated)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_50(50)]
+fn repr_access_std_string(std_str: String) {
+    black_box(black_box(&std_str).as_str());
+}
+
+library_benchmark_group!(
+    name = compact_str_benches,
+    benchmarks = [
+        compact_string_new,
+        compact_string_from_str,
+        std_string_from_str,
+        compact_string_new_owned,
+        u8_to_compact_string,
+        u32_to_compact_string,
+        isize_to_compact_string,
+        u64_to_compact_string,
+        u128_to_compact_string,
+        bool_to_compact_string,
+        string_to_compact_string,
+        char_to_compact_string,
+        str_to_compact_string,
+    ]
+);
+
+library_benchmark_group!(
+    name = repr_benches,
+    benchmarks = [
+        repr_creation_compact_str_6,
+        repr_creation_compact_str,
+        repr_creation_std_string,
+        repr_access_compact_str_6,
+        repr_access_compact_str,
+        repr_access_std_string,
+    ]
+);
+
+main!(library_benchmark_groups = compact_str_benches, repr_benches);

--- a/bench/benches/gungraun_comparison.rs
+++ b/bench/benches/gungraun_comparison.rs
@@ -1,0 +1,231 @@
+//! Gungraun (Callgrind) instruction-count comparison of `CompactString`, `SmolStr`,
+//! `SmartString`, and `std::String` across a range of lengths. Each group uses `compare_by_id`
+//! so the same length is compared across types.
+
+use std::hint::black_box;
+
+use compact_str::CompactString;
+use gungraun::{library_benchmark, library_benchmark_group, main};
+use smartstring::alias::String as SmartString;
+use smol_str::SmolStr;
+
+fn make_word(len: usize) -> String {
+    (0..len).map(|_| 'a').collect()
+}
+
+fn setup_compact(len: usize) -> CompactString {
+    CompactString::new(make_word(len))
+}
+
+fn setup_smol(len: usize) -> SmolStr {
+    SmolStr::new(make_word(len))
+}
+
+fn setup_smart(len: usize) -> SmartString {
+    SmartString::from(make_word(len))
+}
+
+fn setup_string(len: usize) -> String {
+    make_word(len)
+}
+
+// --- Creation -------------------------------------------------------------------------------
+
+#[library_benchmark(setup = make_word)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn creation_compact_string(word: String) -> CompactString {
+    black_box(CompactString::new(black_box(&word)))
+}
+
+#[library_benchmark(setup = make_word)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn creation_smol_str(word: String) -> SmolStr {
+    black_box(SmolStr::new(black_box(&word)))
+}
+
+#[library_benchmark(setup = make_word)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn creation_smart_string(word: String) -> SmartString {
+    black_box(SmartString::from(black_box(&word)))
+}
+
+#[library_benchmark(setup = make_word)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn creation_std_string(word: String) -> String {
+    black_box(String::from(black_box(&word)))
+}
+
+// --- Cloning --------------------------------------------------------------------------------
+
+#[library_benchmark(setup = setup_compact)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn cloning_compact_string(compact: CompactString) -> CompactString {
+    black_box(black_box(&compact).clone())
+}
+
+#[library_benchmark(setup = setup_smol)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn cloning_smol_str(smol: SmolStr) -> SmolStr {
+    black_box(black_box(&smol).clone())
+}
+
+#[library_benchmark(setup = setup_smart)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn cloning_smart_string(smart: SmartString) -> SmartString {
+    black_box(black_box(&smart).clone())
+}
+
+#[library_benchmark(setup = setup_string)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn cloning_std_string(string: String) -> String {
+    black_box(black_box(&string).clone())
+}
+
+// --- Access ---------------------------------------------------------------------------------
+
+#[library_benchmark(setup = setup_compact)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn access_compact_string(compact: CompactString) {
+    black_box(black_box(&compact).as_str());
+}
+
+#[library_benchmark(setup = setup_smol)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn access_smol_str(smol: SmolStr) {
+    black_box(black_box(&smol).as_str());
+}
+
+#[library_benchmark(setup = setup_smart)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn access_smart_string(smart: SmartString) {
+    black_box(black_box(&smart).as_str());
+}
+
+#[library_benchmark(setup = setup_string)]
+#[bench::len_0(0)]
+#[bench::len_11(11)]
+#[bench::len_12(12)]
+#[bench::len_22(22)]
+#[bench::len_23(23)]
+#[bench::len_24(24)]
+#[bench::len_25(25)]
+#[bench::len_50(50)]
+fn access_std_string(string: String) {
+    black_box(black_box(&string).as_str());
+}
+
+library_benchmark_group!(
+    name = string_creation,
+    compare_by_id = true,
+    benchmarks = [
+        creation_compact_string,
+        creation_smol_str,
+        creation_smart_string,
+        creation_std_string,
+    ]
+);
+
+library_benchmark_group!(
+    name = string_cloning,
+    compare_by_id = true,
+    benchmarks = [
+        cloning_compact_string,
+        cloning_smol_str,
+        cloning_smart_string,
+        cloning_std_string,
+    ]
+);
+
+library_benchmark_group!(
+    name = string_access,
+    compare_by_id = true,
+    benchmarks = [
+        access_compact_string,
+        access_smol_str,
+        access_smart_string,
+        access_std_string,
+    ]
+);
+
+main!(
+    library_benchmark_groups = string_creation,
+    string_cloning,
+    string_access
+);

--- a/bench/benches/gungraun_random.rs
+++ b/bench/benches/gungraun_random.rs
@@ -1,0 +1,75 @@
+//! Gungraun (Callgrind) instruction-count benchmarks to determine if one bit of code is faster
+//! than another.
+
+use std::hint::black_box;
+
+use gungraun::{library_benchmark, library_benchmark_group, main};
+
+#[library_benchmark]
+fn if_statement_min() {
+    let mask = 192;
+    let vals: [u8; 4] = [0, 46, 202, 255];
+    for x in vals {
+        let len = if x >= mask { (x & !mask) as usize } else { 24 };
+        black_box(len);
+    }
+}
+
+#[library_benchmark]
+fn cmp_min() {
+    let mask = 192;
+    let vals: [u8; 4] = [0, 46, 202, 255];
+    for x in vals {
+        let len = core::cmp::min(x.wrapping_sub(mask), 24);
+        black_box(len);
+    }
+}
+
+#[inline(always)]
+fn logarithm(val: u32) -> usize {
+    ((val as f64).log10().floor()) as usize + 1
+}
+
+#[inline(always)]
+fn match_statement(val: u32) -> usize {
+    match val {
+        u32::MIN..=9 => 1,
+        10..=99 => 2,
+        100..=999 => 3,
+        1000..=9999 => 4,
+        10000..=99999 => 5,
+        100000..=999999 => 6,
+        1000000..=9999999 => 7,
+        10000000..=99999999 => 8,
+        100000000..=999999999 => 9,
+        1000000000..=u32::MAX => 10,
+    }
+}
+
+#[library_benchmark]
+#[bench::min(u32::MIN)]
+#[bench::half(u32::MAX / 2)]
+#[bench::max(u32::MAX)]
+fn num_digits_logarithm(val: u32) -> usize {
+    black_box(logarithm(black_box(val)))
+}
+
+#[library_benchmark]
+#[bench::min(u32::MIN)]
+#[bench::half(u32::MAX / 2)]
+#[bench::max(u32::MAX)]
+fn num_digits_match_statement(val: u32) -> usize {
+    black_box(match_statement(black_box(val)))
+}
+
+library_benchmark_group!(
+    name = random,
+    benchmarks = [
+        if_statement_min,
+        cmp_min,
+        num_digits_logarithm,
+        num_digits_match_statement,
+    ]
+);
+
+main!(library_benchmark_groups = random);

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -2,6 +2,36 @@ use core::ptr;
 
 use super::{Repr, LENGTH_MASK, MAX_SIZE};
 
+/// Copies `len` bytes from `src` to `dst`.
+///
+/// `copy_nonoverlapping` with a runtime length emits a `memcpy` call, which is expensive for the
+/// short copies used when inlining a string. Since an inline string is at most `MAX_SIZE` bytes,
+/// constant-length overlapping copies cover every length while staying inlined.
+///
+/// # Safety
+/// * `len <= MAX_SIZE`.
+/// * `src` and `dst` are valid for `len` bytes and do not overlap.
+#[inline(always)]
+unsafe fn copy_small(src: *const u8, dst: *mut u8, len: usize) {
+    debug_assert!(len <= MAX_SIZE);
+
+    if len >= 16 {
+        ptr::copy_nonoverlapping(src, dst, 16);
+        ptr::copy_nonoverlapping(src.add(len - 16), dst.add(len - 16), 16);
+    } else if len >= 8 {
+        ptr::copy_nonoverlapping(src, dst, 8);
+        ptr::copy_nonoverlapping(src.add(len - 8), dst.add(len - 8), 8);
+    } else if len >= 4 {
+        ptr::copy_nonoverlapping(src, dst, 4);
+        ptr::copy_nonoverlapping(src.add(len - 4), dst.add(len - 4), 4);
+    } else if len >= 2 {
+        ptr::copy_nonoverlapping(src, dst, 2);
+        ptr::copy_nonoverlapping(src.add(len - 2), dst.add(len - 2), 2);
+    } else if len == 1 {
+        *dst = *src;
+    }
+}
+
 /// A buffer stored on the stack whose size is equal to the stack size of `String`
 #[cfg(target_pointer_width = "64")]
 #[repr(C, align(8))]
@@ -40,7 +70,7 @@ impl InlineBuffer {
         // * dst (`buffer`) is valid for `len` bytes because we assert src is less than MAX_SIZE
         // * src and dst don't overlap because we created dst
         //
-        ptr::copy_nonoverlapping(text.as_ptr(), buffer.0.as_mut_ptr(), len);
+        copy_small(text.as_ptr(), buffer.0.as_mut_ptr(), len);
 
         buffer
     }

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -347,8 +347,11 @@ impl Repr {
         let len = self.len();
         let str_len = s.len();
 
-        // Reserve at least enough space to fit `s`
-        self.reserve(str_len).unwrap_with_msg();
+        // Only call the (out-of-line) grow path when we actually need to; the common append
+        // already has room. A `&'static str` always has to be converted first.
+        if self.is_static_str() || len + str_len > self.capacity() {
+            self.reserve(str_len).unwrap_with_msg();
+        }
 
         // Copy the string into the spare capacity without first creating a reference to the
         // uninitialized memory.
@@ -536,6 +539,7 @@ impl Repr {
     /// # Safety
     /// * `len` bytes in the buffer must be valid UTF-8
     /// * If the underlying buffer is stored inline, `len` must be <= MAX_SIZE
+    #[inline]
     pub(crate) unsafe fn set_len(&mut self, len: usize) {
         if let Some(s) = self.as_static_variant_mut() {
             s.set_len(len);
@@ -826,7 +830,7 @@ impl Drop for Repr {
 impl Extend<char> for Repr {
     #[inline]
     fn extend<T: IntoIterator<Item = char>>(&mut self, iter: T) {
-        let iter = iter.into_iter();
+        let mut iter = iter.into_iter();
 
         let (lower_bound, _) = iter.size_hint();
         if lower_bound > 0 {
@@ -834,8 +838,46 @@ impl Extend<char> for Repr {
             let _: Result<(), ReserveError> = self.reserve(lower_bound);
         }
 
-        for c in iter {
-            self.push_str(c.encode_utf8(&mut [0; 4]));
+        // Append into the spare capacity directly, tracking the length locally so we avoid the
+        // per-char `len`/`set_len` discriminant work of pushing one char at a time. If a char
+        // doesn't fit, grow via `push_str` and re-resolve the buffer.
+        'refetch: loop {
+            // Pull a char before resolving the buffer so an empty iterator does no work.
+            let mut next = iter.next();
+            if next.is_none() {
+                return;
+            }
+
+            let cap = self.capacity();
+            let mut cur = self.len();
+            // Also converts a `&'static str` into an owned inline buffer.
+            let ptr = self.as_mut_ptr();
+            let mut buf = [0u8; 4];
+
+            while let Some(c) = next {
+                let encoded = c.encode_utf8(&mut buf);
+                let n = encoded.len();
+
+                if cur + n > cap {
+                    // SAFETY: `cur` bytes of valid UTF-8 have been written into the buffer.
+                    unsafe { self.set_len(cur) };
+                    self.push_str(encoded);
+                    continue 'refetch;
+                }
+
+                // SAFETY: `cur + n <= cap` leaves room for `n` bytes; `ptr` stays valid until the
+                // next `continue 'refetch`, which re-derives it; `encoded` cannot overlap `ptr`.
+                unsafe {
+                    ptr.add(cur).copy_from_nonoverlapping(encoded.as_ptr(), n);
+                }
+                cur += n;
+
+                next = iter.next();
+            }
+
+            // SAFETY: `cur` bytes of valid UTF-8 have been written into the buffer.
+            unsafe { self.set_len(cur) };
+            return;
         }
     }
 }

--- a/compact_str/src/repr/num.rs
+++ b/compact_str/src/repr/num.rs
@@ -6,8 +6,8 @@
 use core::{mem, num, ptr};
 
 use super::traits::IntoRepr;
-use super::Repr;
-use crate::{ToCompactStringError, UnwrapWithMsg};
+use super::{InlineBuffer, Repr, LENGTH_MASK, MAX_SIZE};
+use crate::ToCompactStringError;
 
 const DEC_DIGITS_LUT: &[u8] = b"\
       0001020304050607080910111213141516171819\
@@ -21,11 +21,24 @@ macro_rules! impl_IntoRepr {
     ($t:ident, $conv_ty:ident) => {
         impl IntoRepr for $t {
             fn into_repr(self) -> Result<Repr, ToCompactStringError> {
-                // Determine the number of digits in this value
+                // The formatted value is at most 20 characters (`i64::MIN`). On 64-bit that always
+                // fits inline, so we can write straight into an `InlineBuffer` and skip the
+                // discriminant dispatch of `with_capacity`/`as_mut_ptr`/`set_len`. The only case
+                // that doesn't fit is `u64`/`i64` on a 32-bit target (`MAX_SIZE` is 12 there); we
+                // hand those off to `itoa` like the 128-bit types.
                 //
-                // Note: this considers the `-` symbol
+                // `MAX_LEN` is an upper bound on the formatted length including the sign; it's `<
+                // MAX_SIZE` (not `<=`) so the length still fits in the last byte.
+                const MAX_LEN: usize = <$t>::MAX.ilog10() as usize + 2;
+
+                if MAX_LEN >= MAX_SIZE {
+                    let mut itoa_buf = itoa::Buffer::new();
+                    return Ok(Repr::new(itoa_buf.format(self))?);
+                }
+
+                // Number of characters to write, including a leading `-` for negatives.
                 let num_digits = NumChars::num_chars(self);
-                let mut repr = Repr::with_capacity(num_digits).unwrap_with_msg();
+                let mut buffer = [0u8; MAX_SIZE];
 
                 #[allow(unused_comparisons)]
                 let is_nonnegative = self >= 0;
@@ -37,9 +50,7 @@ macro_rules! impl_IntoRepr {
                 };
                 let mut curr = num_digits as isize;
 
-                // get mutable pointer to our buffer
-                let buf_ptr = repr.as_mut_ptr();
-
+                let buf_ptr = buffer.as_mut_ptr();
                 let lut_ptr = DEC_DIGITS_LUT.as_ptr();
 
                 unsafe {
@@ -92,11 +103,13 @@ macro_rules! impl_IntoRepr {
                 // we should have moved all the way down our buffer
                 debug_assert_eq!(curr, 0);
 
-                // SAFETY: We initialized all `num_digits` bytes above with ASCII digits and an
-                // optional leading `-`.
-                unsafe { repr.set_len(num_digits) };
+                // `num_digits < MAX_SIZE`, so the length lives in the last byte, distinct from the
+                // digits.
+                buffer[MAX_SIZE - 1] = num_digits as u8 | LENGTH_MASK;
 
-                Ok(repr)
+                // SAFETY: the leading `num_digits` bytes are ASCII digits (with an optional `-`),
+                // and the last byte is a valid inline length marker.
+                Ok(Repr::from_inline(InlineBuffer(buffer)))
             }
         }
     };
@@ -315,74 +328,20 @@ impl NumChars for i32 {
 impl NumChars for u64 {
     #[inline(always)]
     fn num_chars(val: u64) -> usize {
-        match val {
-            u64::MIN..=9 => 1,
-            10..=99 => 2,
-            100..=999 => 3,
-            1000..=9999 => 4,
-            10000..=99999 => 5,
-            100000..=999999 => 6,
-            1000000..=9999999 => 7,
-            10000000..=99999999 => 8,
-            100000000..=999999999 => 9,
-            1000000000..=9999999999 => 10,
-            10000000000..=99999999999 => 11,
-            100000000000..=999999999999 => 12,
-            1000000000000..=9999999999999 => 13,
-            10000000000000..=99999999999999 => 14,
-            100000000000000..=999999999999999 => 15,
-            1000000000000000..=9999999999999999 => 16,
-            10000000000000000..=99999999999999999 => 17,
-            100000000000000000..=999999999999999999 => 18,
-            1000000000000000000..=9999999999999999999 => 19,
-            10000000000000000000..=u64::MAX => 20,
-        }
+        // `checked_ilog10` is `None` only for `0`, which has one digit. Cheaper than a 20-arm
+        // match for 64-bit values, and exact (unlike `f64::log10`).
+        val.checked_ilog10().map_or(1, |log| log as usize + 1)
     }
 }
 
 impl NumChars for i64 {
     #[inline(always)]
     fn num_chars(val: i64) -> usize {
-        match val {
-            i64::MIN..=-1000000000000000000 => 20,
-            -999999999999999999..=-100000000000000000 => 19,
-            -99999999999999999..=-10000000000000000 => 18,
-            -9999999999999999..=-1000000000000000 => 17,
-            -999999999999999..=-100000000000000 => 16,
-            -99999999999999..=-10000000000000 => 15,
-            -9999999999999..=-1000000000000 => 14,
-            -999999999999..=-100000000000 => 13,
-            -99999999999..=-10000000000 => 12,
-            -9999999999..=-1000000000 => 11,
-            -999999999..=-100000000 => 10,
-            -99999999..=-10000000 => 9,
-            -9999999..=-1000000 => 8,
-            -999999..=-100000 => 7,
-            -99999..=-10000 => 6,
-            -9999..=-1000 => 5,
-            -999..=-100 => 4,
-            -99..=-10 => 3,
-            -9..=-1 => 2,
-            0..=9 => 1,
-            10..=99 => 2,
-            100..=999 => 3,
-            1000..=9999 => 4,
-            10000..=99999 => 5,
-            100000..=999999 => 6,
-            1000000..=9999999 => 7,
-            10000000..=99999999 => 8,
-            100000000..=999999999 => 9,
-            1000000000..=9999999999 => 10,
-            10000000000..=99999999999 => 11,
-            100000000000..=999999999999 => 12,
-            1000000000000..=9999999999999 => 13,
-            10000000000000..=99999999999999 => 14,
-            100000000000000..=999999999999999 => 15,
-            1000000000000000..=9999999999999999 => 16,
-            10000000000000000..=99999999999999999 => 17,
-            100000000000000000..=999999999999999999 => 18,
-            1000000000000000000..=i64::MAX => 19,
-        }
+        // Digits of the magnitude plus one for the sign. `unsigned_abs` avoids `-i64::MIN`.
+        val.unsigned_abs()
+            .checked_ilog10()
+            .map_or(1, |log| log as usize + 1)
+            + (val < 0) as usize
     }
 }
 


### PR DESCRIPTION
Optimize several hot paths, reducing both instruction counts and wall-clock time:

- push_str: check spare capacity inline and only call the out-of-line grow path when actually needed, so hot append/push loops avoid a per-call reserve. Mark set_len #[inline] so it fuses with the caller.
- Extend<char>: write chars straight into spare capacity, tracking length in a local and committing set_len once, instead of pushing one char at a time.
- Integer to_compact_string: build the InlineBuffer directly, skipping the discriminant dispatch of with_capacity/as_mut_ptr/set_len, and use checked_ilog10 for the 64-bit digit count. u64/i64 on 32-bit targets (where the value can exceed the inline buffer) fall back to itoa.
- InlineBuffer::new: copy short strings with inlined fixed-size copies rather than an out-of-line memcpy call.

Also add gungraun (Callgrind) benchmarks mirroring the criterion suite.

| Operation                   | Instructions | Wall time |
| --------------------------- | -----------: | --------: |
| extend chars (short)        |         -71% |      -84% |
| extend chars (inline->heap) |         -74% |      -75% |
| extend chars (heap)         |         -63% |      -59% |
| u8 -> CompactString         |         -33% |      -23% |
| u32 -> CompactString        |         -13% |      -24% |
| u64 -> CompactString        |         -23% |      -23% |
| char -> CompactString       |         -59% |        -* |
| CompactString::new (24 ch)  |         -19% |      -15% |