### PR TITLE
chore: schemars follow-ups (example, changelog, tests, ordering)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Added support for the [`garde`](https://crates.io/crates/garde) validation crate under an
   optional feature, implementing its string rule traits for `CompactString`.
     * Implemented in [`feat: add garde validation support`](https://github.com/ParkMyCar/compact_str/pull/471).
+* Added support for the [`schemars`](https://crates.io/crates/schemars) crate under an optional
+  feature, implementing `JsonSchema` for `CompactString`. Every method delegates to `String`'s
+  impl, so the generated schema is identical to a `String`'s.
+    * Implemented in [`feat: support schemars`](https://github.com/ParkMyCar/compact_str/pull/454).
 * Bump the [`sqlx`](https://crates.io/crates/sqlx) dependency to `v0.9`. Enabling the `sqlx`
   feature now requires Rust `v1.94`.
     * Implemented in [`deps: bump sqlx to 0.9`](https://github.com/ParkMyCar/compact_str/pull/474).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "examples/diesel",
     "examples/garde",
     "examples/macros",
+    "examples/schemars",
     "examples/serde",
     "examples/sqlx",
     "examples/traits",

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -24,10 +24,10 @@ defmt = ["dep:defmt"]
 diesel = ["dep:diesel"]
 garde = ["dep:garde"]
 markup = ["dep:markup"]
-schemars = ["dep:schemars"]
 proptest = ["dep:proptest"]
 quickcheck = ["dep:quickcheck"]
 rkyv = ["dep:rkyv"]
+schemars = ["dep:schemars"]
 serde = ["dep:serde"]
 smallvec = ["dep:smallvec"]
 sqlx = ["dep:sqlx", "std"]
@@ -46,12 +46,12 @@ defmt = { version = "1", optional = true }
 diesel = { version = "2", optional = true, default-features = false }
 garde = { version = "0.23", optional = true, default-features = false, features = ["derive"] }
 markup = { version = "0.15", optional = true, default-features = false }
-schemars = { version = "1", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = [
     "std",
 ] }
 quickcheck = { version = "1", optional = true, default-features = false }
 rkyv = { version = "0.8", optional = true, default-features = false }
+schemars = { version = "1", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = [
     "derive",
     "alloc",

--- a/compact_str/src/features/schemars.rs
+++ b/compact_str/src/features/schemars.rs
@@ -3,26 +3,28 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 
-use schemars::Schema;
-use schemars::SchemaGenerator;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 
 use crate::CompactString;
 
-impl schemars::JsonSchema for CompactString {
+// A `CompactString` serializes exactly like a `std::string::String`, so its JSON
+// schema should be identical. We delegate every method to `String`'s impl to keep
+// the two perfectly in sync (name, id, inlining behavior, and the schema itself).
+impl JsonSchema for CompactString {
     fn inline_schema() -> bool {
-        <String as schemars::JsonSchema>::inline_schema()
+        <String as JsonSchema>::inline_schema()
     }
 
     fn schema_name() -> Cow<'static, str> {
-        <String as schemars::JsonSchema>::schema_name()
+        <String as JsonSchema>::schema_name()
     }
 
     fn schema_id() -> Cow<'static, str> {
-        <String as schemars::JsonSchema>::schema_id()
+        <String as JsonSchema>::schema_id()
     }
 
     fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-        <String as schemars::JsonSchema>::json_schema(generator)
+        <String as JsonSchema>::json_schema(generator)
     }
 }
 
@@ -30,23 +32,61 @@ impl schemars::JsonSchema for CompactString {
 mod tests {
     use alloc::string::String;
 
-    use schemars::JsonSchema;
+    use schemars::{JsonSchema, SchemaGenerator};
 
     use crate::CompactString;
 
     #[test]
-    fn test_schema_matches_string() {
-        let compact_name = CompactString::schema_name();
-        let string_name = String::schema_name();
-        assert_eq!(compact_name, string_name);
+    fn test_metadata_matches_string() {
+        assert_eq!(CompactString::schema_name(), String::schema_name());
+        assert_eq!(CompactString::schema_id(), String::schema_id());
+        assert_eq!(
+            CompactString::inline_schema(),
+            String::inline_schema(),
+            "inlining behavior must match String so nested schemas are identical",
+        );
+    }
 
-        let compact_id = CompactString::schema_id();
-        let string_id = String::schema_id();
-        assert_eq!(compact_id, string_id);
+    #[test]
+    fn test_json_schema_matches_string() {
+        let mut compact_gen = SchemaGenerator::default();
+        let compact_schema = CompactString::json_schema(&mut compact_gen);
 
-        let mut gen = schemars::SchemaGenerator::default();
-        let compact_schema = CompactString::json_schema(&mut gen);
-        let string_schema = String::json_schema(&mut gen);
+        let mut string_gen = SchemaGenerator::default();
+        let string_schema = String::json_schema(&mut string_gen);
+
         assert_eq!(compact_schema, string_schema);
+    }
+
+    #[test]
+    fn test_schema_describes_a_string() {
+        let mut generator = SchemaGenerator::default();
+        let schema = CompactString::json_schema(&mut generator);
+        let value = serde_json::to_value(&schema).unwrap();
+
+        assert_eq!(value.get("type").and_then(|t| t.as_str()), Some("string"));
+    }
+
+    // Even when generated as part of a larger document (which exercises the
+    // reference/definition machinery via `subschema_for`), the output for a
+    // `CompactString` field must be byte-for-byte identical to a `String` field.
+    #[test]
+    fn test_subschema_matches_string() {
+        let mut compact_gen = SchemaGenerator::default();
+        let compact_sub = compact_gen.subschema_for::<CompactString>();
+        let compact_defs = compact_gen.into_root_schema_for::<CompactString>();
+
+        let mut string_gen = SchemaGenerator::default();
+        let string_sub = string_gen.subschema_for::<String>();
+        let string_defs = string_gen.into_root_schema_for::<String>();
+
+        assert_eq!(
+            serde_json::to_value(&compact_sub).unwrap(),
+            serde_json::to_value(&string_sub).unwrap(),
+        );
+        assert_eq!(
+            serde_json::to_value(&compact_defs).unwrap(),
+            serde_json::to_value(&string_defs).unwrap(),
+        );
     }
 }

--- a/examples/schemars/Cargo.toml
+++ b/examples/schemars/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example-schemars"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+compact_str = { version = "0.9.0", features = ["schemars"], path = "../../compact_str" }
+schemars = "1"
+serde_json = "1"

--- a/examples/schemars/src/main.rs
+++ b/examples/schemars/src/main.rs
@@ -1,0 +1,21 @@
+#![allow(dead_code)]
+
+use compact_str::CompactString;
+use schemars::JsonSchema;
+
+/// CompactString can be used as a drop-in replacement for String in schemars schemas.
+#[derive(JsonSchema)]
+struct Pet {
+    id: u64,
+    name: CompactString,
+    tags: Vec<CompactString>,
+    nickname: Option<CompactString>,
+}
+
+fn main() {
+    // CompactString works seamlessly with schemars' JsonSchema derive, producing a
+    // schema identical to one where the fields used `String`.
+    let schema = schemars::schema_for!(Pet);
+    println!("Pet schema (using CompactString for string fields):");
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}


### PR DESCRIPTION
Follow-up polish on top of the merged `schemars` support ([#454](https://github.com/ParkMyCar/compact_str/pull/454))