### PR TITLE
perf: bulk-copy valid runs in from_utf8_lossy

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1364,6 +1364,9 @@ impl CompactString {
         // `String::from_utf8_lossy`, but writes straight into the `CompactString` rather than
         // building an intermediate `String`.
         const REPLACEMENT: &str = "\u{FFFD}";
+        // `v.len()` is a heuristic, not an upper bound: a 1-byte invalid subsequence expands to the
+        // 3-byte replacement character, so pathological all-invalid input may reallocate. This
+        // matches what `String::from_utf8_lossy` does (`String::with_capacity(v.len())`).
         let mut result = Self::with_capacity(v.len());
         let mut remaining = v;
         loop {

--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1352,89 +1352,44 @@ impl CompactString {
     /// );
     /// ```
     pub fn from_utf8_lossy(v: &[u8]) -> Self {
-        fn next_char<'a>(
-            iter: &mut <&[u8] as IntoIterator>::IntoIter,
-            buf: &'a mut [u8; 4],
-        ) -> Option<&'a [u8]> {
-            const REPLACEMENT: &[u8] = "\u{FFFD}".as_bytes();
+        // Fast path: the entire input is valid UTF-8, so copy it in a single shot. This is the
+        // common case, and mirrors `String::from_utf8_lossy`, which borrows the input here.
+        let mut error = match core::str::from_utf8(v) {
+            Ok(valid) => return Self::new(valid),
+            Err(error) => error,
+        };
 
-            macro_rules! ensure_range {
-                ($idx:literal, $range:pat) => {{
-                    let mut i = iter.clone();
-                    match i.next() {
-                        Some(&c) if matches!(c, $range) => {
-                            buf[$idx] = c;
-                            *iter = i;
-                        }
-                        _ => return Some(REPLACEMENT),
-                    }
-                }};
-            }
-
-            macro_rules! ensure_cont {
-                ($idx:literal) => {{
-                    ensure_range!($idx, 0x80..=0xBF);
-                }};
-            }
-
-            let c = *iter.next()?;
-            buf[0] = c;
-
-            match c {
-                0x00..=0x7F => {
-                    // simple ASCII: push as is
-                    Some(&buf[..1])
-                }
-                0xC2..=0xDF => {
-                    // two bytes
-                    ensure_cont!(1);
-                    Some(&buf[..2])
-                }
-                0xE0..=0xEF => {
-                    // three bytes
-                    match c {
-                        // 0x80..=0x9F encodes surrogate half
-                        0xE0 => ensure_range!(1, 0xA0..=0xBF),
-                        // 0xA0..=0xBF encodes surrogate half
-                        0xED => ensure_range!(1, 0x80..=0x9F),
-                        // all UTF-8 continuation bytes are valid
-                        _ => ensure_cont!(1),
-                    }
-                    ensure_cont!(2);
-                    Some(&buf[..3])
-                }
-                0xF0..=0xF4 => {
-                    // four bytes
-                    match c {
-                        // 0x80..=0x8F encodes overlong three byte codepoint
-                        0xF0 => ensure_range!(1, 0x90..=0xBF),
-                        // 0x90..=0xBF encodes codepoint > U+10FFFF
-                        0xF4 => ensure_range!(1, 0x80..=0x8F),
-                        // all UTF-8 continuation bytes are valid
-                        _ => ensure_cont!(1),
-                    }
-                    ensure_cont!(2);
-                    ensure_cont!(3);
-                    Some(&buf[..4])
-                }
-                | 0x80..=0xBF // unicode continuation, invalid
-                | 0xC0..=0xC1 // overlong one byte character
-                | 0xF5..=0xF7 // four bytes that encode > U+10FFFF
-                | 0xF8..=0xFB // five bytes, invalid
-                | 0xFC..=0xFD // six bytes, invalid
-                | 0xFE..=0xFF => Some(REPLACEMENT), // always invalid
-            }
-        }
-
-        let mut buf = [0; 4];
+        // Slow path: bulk-copy each run of valid UTF-8, emitting a single replacement character for
+        // every maximal invalid subsequence. This produces the same result as
+        // `String::from_utf8_lossy`, but writes straight into the `CompactString` rather than
+        // building an intermediate `String`.
+        const REPLACEMENT: &str = "\u{FFFD}";
         let mut result = Self::with_capacity(v.len());
-        let mut iter = v.iter();
-        while let Some(s) = next_char(&mut iter, &mut buf) {
-            // SAFETY: next_char() only returns valid strings
-            let s = unsafe { core::str::from_utf8_unchecked(s) };
-            result.push_str(s);
+        let mut remaining = v;
+        loop {
+            let valid_up_to = error.valid_up_to();
+            // SAFETY: `remaining[..valid_up_to]` is valid UTF-8, by definition of `valid_up_to`.
+            let valid = unsafe { core::str::from_utf8_unchecked(&remaining[..valid_up_to]) };
+            result.push_str(valid);
+            result.push_str(REPLACEMENT);
+
+            let invalid_len = match error.error_len() {
+                Some(len) => len,
+                // `None` means the input ended with an incomplete (but not yet invalid) sequence,
+                // which we've now replaced, so we're done.
+                None => return result,
+            };
+            remaining = &remaining[valid_up_to + invalid_len..];
+
+            // Re-validate the rest. If it's all valid we're done; otherwise loop on the next error.
+            match core::str::from_utf8(remaining) {
+                Ok(valid) => {
+                    result.push_str(valid);
+                    return result;
+                }
+                Err(next) => error = next,
+            }
         }
-        result
     }
 
     fn from_utf16x(

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -29,6 +29,17 @@ pub(crate) fn rand_bytes() -> impl Strategy<Value = Vec<u8>> {
     proptest::collection::vec(any::<u8>(), 0..80)
 }
 
+/// Generates byte sequences that interleave valid (often multibyte) UTF-8 runs with arbitrary byte
+/// fragments. Uniformly random bytes are almost never long valid non-ASCII runs, so this is what
+/// exercises `from_utf8_lossy` bulk-copying a valid multibyte run that sits between two errors.
+pub(crate) fn rand_utf8_with_errors() -> impl Strategy<Value = Vec<u8>> {
+    let segment = prop_oneof![
+        rand_unicode().prop_map(String::into_bytes),
+        proptest::collection::vec(any::<u8>(), 0..8),
+    ];
+    proptest::collection::vec(segment, 0..20).prop_map(|segments| segments.concat())
+}
+
 /// generates a random collection of `u16`s, upto 80 elements long
 pub(crate) fn rand_u16s() -> impl Strategy<Value = Vec<u16>> {
     proptest::collection::vec(any::<u16>(), 0..80)
@@ -1747,6 +1758,18 @@ fn test_from_utf8_unchecked_empty() {
 #[proptest]
 #[cfg_attr(miri, ignore)]
 fn proptest_from_utf8_lossy(#[strategy(rand_bytes())] bytes: Vec<u8>) {
+    let compact = CompactString::from_utf8_lossy(&bytes);
+    let control = String::from_utf8_lossy(&bytes);
+
+    assert_eq!(compact, control);
+    assert_eq!(compact.len(), control.len());
+}
+
+// Like `proptest_from_utf8_lossy`, but the inputs interleave valid multibyte runs with invalid
+// fragments, which stresses the bulk-copy of valid runs between errors that random bytes miss.
+#[proptest]
+#[cfg_attr(miri, ignore)]
+fn proptest_from_utf8_lossy_interleaved(#[strategy(rand_utf8_with_errors())] bytes: Vec<u8>) {
     let compact = CompactString::from_utf8_lossy(&bytes);
     let control = String::from_utf8_lossy(&bytes);
 


### PR DESCRIPTION
Closes #406.

`from_utf8_lossy` decoded the input **one character at a time**, calling `push_str` for every char — so even a fully-valid ASCII string paid a `reserve` + copy + `set_len` per byte. That's what made it several times slower than the `CompactString::from(String::from_utf8_lossy(..))` workaround from the issue.

This rewrites it around `core::str::from_utf8`:
- **Fast path** (fully-valid input, the common case): construct directly from the validated `&str`.
- **Slow path**: bulk-copy each run of valid UTF-8 and emit one replacement character per maximal invalid subsequence, driven by `Utf8Error::valid_up_to()` / `error_len()`.

This produces exactly the same output as `String::from_utf8_lossy` — the pre-existing `proptest_from_utf8_lossy` test compares the two over random bytes, and I ran it at 10k cases — but writes straight into the `CompactString` rather than allocating an intermediate `String`, so on invalid input it's actually a bit *faster* than the std workaround. The single `unsafe` (`from_utf8_unchecked`) only wraps bytes the validator already proved valid via `valid_up_to`.

### Benchmarks (cachegrind, instructions retired)

| input | before | after | std `from(from_utf8_lossy)` |
|---|---|---|---|
| small ASCII | 612M | **163M** (~3.75× faster) | 195M |
| mixed (ASCII + multibyte + invalid) | 1,332M | **390M** (~3.4× faster) | 440M |

Verified on stable 1.96.1 and MSRV 1.71: clippy clean under `-D warnings`, full test suite + doctests pass.