### PR TITLE
deps: update optional deps to latest (bevy_reflect 0.19, markup 0.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
     * Implemented in [`fix: avoid exposing uninitialized spare capacity`](https://github.com/ParkMyCar/compact_str/pull/468).
 * Fixed `CompactString::retain` to avoid briefly creating references to invalid UTF-8.
     * Implemented in [`Avoid invalid UTF-8 references in retain`](https://github.com/ParkMyCar/compact_str/pull/469).
+* Bump the [`bevy_reflect`](https://crates.io/crates/bevy_reflect) dependency to `v0.19`.
+    * Implemented in [`deps: update optional deps to latest`](https://github.com/ParkMyCar/compact_str/pull/490).
+* Bump the [`markup`](https://crates.io/crates/markup) dependency to `v0.16`.
+    * Implemented in [`deps: update optional deps to latest`](https://github.com/ParkMyCar/compact_str/pull/490).
 
 ## Performance
 * Reuse an owned `String`'s existing allocation in `CompactString::new`.

--- a/compact_str/Cargo.toml
+++ b/compact_str/Cargo.toml
@@ -41,13 +41,13 @@ zeroize = ["dep:zeroize"]
 
 [dependencies]
 arbitrary = { version = "1", optional = true, default-features = false }
-bevy_reflect = { version = "0.17.1", optional = true }
+bevy_reflect = { version = "0.19", optional = true }
 borsh = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
 defmt = { version = "1", optional = true }
 diesel = { version = "2", optional = true, default-features = false }
 garde = { version = "0.23", optional = true, default-features = false, features = ["derive"] }
-markup = { version = "0.15", optional = true, default-features = false }
+markup = { version = "0.16", optional = true, default-features = false }
 proptest = { version = "1", optional = true, default-features = false, features = [
     "std",
 ] }

--- a/examples/bevy-reflect/Cargo.toml
+++ b/examples/bevy-reflect/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 compact_str = { version = "0.9.0", features = ["bevy-reflect"], path="../../compact_str" }
-bevy_ecs = "0.17.1"
-bevy_reflect = "0.17.1"
+bevy_ecs = "0.19"
+bevy_reflect = "0.19"


### PR DESCRIPTION
Bump the two optional deps that were pinned below their latest release; all others already resolve to the newest version via their caret requirement. Both build and pass their feature tests with no integration changes. Core (non-optional) deps are untouched, so the crate MSRV is unaffected.