### PR TITLE
perf: optimize several parts of the creation code path

### DIFF
--- a/compact_str/src/lib.rs
+++ b/compact_str/src/lib.rs
@@ -1989,7 +1989,7 @@ impl Clone for CompactString {
 impl Default for CompactString {
     #[inline]
     fn default() -> Self {
-        CompactString::new("")
+        CompactString::const_new("")
     }
 }
 

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -35,15 +35,16 @@ impl HeapBuffer {
     /// Allocate a heap buffer, copy `text` into it, and return the raw `(ptr, capacity)` pair
     /// instead of a full [`HeapBuffer`]. The shared cold core behind `new` / `alloc_copy_panic`.
     ///
-    /// The caller assembles the `HeapBuffer`/`Repr` itself. Returning the two-word `(ptr, capacity)`
-    /// -- which comes back in registers -- rather than a 24-byte `HeapBuffer` avoids a by-value
-    /// aggregate return across this outlined call boundary. That aggregate return otherwise forced
-    /// the whole of `Repr::new`/`new_panic`, including their hot inline arm, through a stack
-    /// temporary that LLVM scatter-copied into the return slot on x86 (a store-to-load forwarding
-    /// stall on every construction).
+    /// N.B. The caller assembles the [`HeapBuffer`] themself. Returning the two-word
+    /// `(ptr, capacity)`, which gets passed in registers, rather than a 24-byte
+    /// `HeapBuffer` avoids a by-value aggregate return across this outlined call boundary.
+    /// 
+    /// The aggregate return otherwise forced the whole of `Repr::new`/`new_panic`, including
+    /// their hot inline arm, through a stack temporary that LLVM scatter-copied into the
+    /// return slot on x86, causing a forwarding stall on every construction.
     ///
-    /// `#[cold]`/`#[inline(never)]`: keeps the alloc/copy machinery out of line and lays the heap
-    /// arm out cold at every callsite.
+    /// `#[cold]`/`#[inline(never)]` keeps the alloc/copy machinery out of line and lays
+    /// the heap arm out cold at every callsite.
     #[cold]
     #[inline(never)]
     pub(crate) fn alloc_copy(text: &str) -> Result<(ptr::NonNull<u8>, Capacity), ReserveError> {
@@ -52,9 +53,9 @@ impl HeapBuffer {
 
         // copy our string into the buffer we just allocated
         //
-        // SAFETY: `src` (`text`) and `dest` (`ptr`) are both valid for `len` bytes -- `len` comes
-        // from `src`, and `dest` was freshly allocated with at least that length -- and they don't
-        // overlap because `dest` is newly allocated.
+        // SAFETY: `src` (`text`) and `dest` (`ptr`) are both valid for `len` bytes. `len`
+        // comes from `src`, and `dest` was freshly allocated with at least that length. 
+        // And they don't overlap because `dest` is newly allocated.
         unsafe { super::copy_medium(text.as_ptr(), ptr.as_ptr(), len) };
 
         Ok((ptr, cap))
@@ -62,8 +63,9 @@ impl HeapBuffer {
 
     /// Create a [`HeapBuffer`] with the provided text.
     ///
-    /// `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from the register-passed
-    /// `(ptr, capacity)`; only that pair crosses the cold [`alloc_copy`] boundary.
+    /// N.B. `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from
+    /// the register-passed `(ptr, capacity)`. It's important only that pair crosses the
+    /// cold [`alloc_copy`] boundary.
     #[inline(always)]
     pub(crate) fn new(text: &str) -> Result<Self, ReserveError> {
         let (ptr, cap) = Self::alloc_copy(text)?;
@@ -76,9 +78,9 @@ impl HeapBuffer {
 
     /// Infallible [`alloc_copy`], panicking on allocation failure.
     ///
-    /// `#[inline(always)]` so the tiny unwrap lives at the callsite (which then builds the `Repr`
-    /// from the register-passed `(ptr, capacity)`), while the actual allocating body stays in the
-    /// cold, out-of-line [`alloc_copy`].
+    /// N.B. `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from
+    /// the register-passed `(ptr, capacity)`. It's important only that pair crosses the
+    /// cold [`alloc_copy`] boundary.
     #[inline(always)]
     #[track_caller]
     pub(crate) fn alloc_copy_panic(text: &str) -> HeapBuffer {
@@ -92,12 +94,23 @@ impl HeapBuffer {
 
     /// Create an empty [`HeapBuffer`] with a specific capacity
     ///
-    /// Note: deliberately not `#[inline]` — see `HeapBuffer::new`. This is a cold allocating path.
+    /// N.B. `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from
+    /// the register-passed `(ptr, capacity)`. It's important only that pair crosses the
+    /// cold [`alloc_copy`] boundary.
+    #[inline(always)]
     pub(crate) fn with_capacity(capacity: usize) -> Result<Self, ReserveError> {
-        let len = 0;
-        let (cap, ptr) = allocate_ptr(capacity)?;
+        let (ptr, cap) = Self::alloc(capacity)?;
+        Ok(HeapBuffer { ptr, len: 0, cap })
+    }
 
-        Ok(HeapBuffer { ptr, len, cap })
+    /// Out-of-line allocation core for [`Self::with_capacity`].
+    /// 
+    /// See [`Self::alloc_copy`] for why it returns the two-word pair instead of a `HeapBuffer`.
+    #[cold]
+    #[inline(never)]
+    fn alloc(capacity: usize) -> Result<(ptr::NonNull<u8>, Capacity), ReserveError> {
+        let (cap, ptr) = allocate_ptr(capacity)?;
+        Ok((ptr, cap))
     }
 
     /// Create a [`HeapBuffer`] with `text` that has _at least_ `additional` bytes of capacity
@@ -105,8 +118,28 @@ impl HeapBuffer {
     /// To prevent frequent re-allocations, this method will create a [`HeapBuffer`] with a capacity
     /// of `text.len() + additional` or `text.len() * 1.5`, whichever is greater
     ///
-    /// Note: deliberately not `#[inline]` — see `HeapBuffer::new`. This is a cold allocating path.
+    /// N.B. `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from
+    /// the register-passed `(ptr, capacity)`. It's important only that pair crosses the
+    /// cold [`alloc_copy`] boundary.
+    #[inline(always)]
     pub(crate) fn with_additional(text: &str, additional: usize) -> Result<Self, ReserveError> {
+        let (ptr, cap) = Self::alloc_copy_extra(text, additional)?;
+        Ok(HeapBuffer {
+            ptr,
+            len: text.len(),
+            cap,
+        })
+    }
+
+    /// Out-of-line allocate+copy core for [`Self::with_additional`].
+    /// 
+    /// See [`Self::alloc_copy`] for why it returns the two-word pair instead of a `HeapBuffer`.
+    #[cold]
+    #[inline(never)]
+    fn alloc_copy_extra(
+        text: &str,
+        additional: usize,
+    ) -> Result<(ptr::NonNull<u8>, Capacity), ReserveError> {
         let len = text.len();
         let new_capacity = amortized_growth(len, additional);
         let (cap, ptr) = allocate_ptr(new_capacity)?;
@@ -118,7 +151,7 @@ impl HeapBuffer {
         // length. We also know they're non-overlapping because `dest` is newly allocated
         unsafe { super::copy_medium(text.as_ptr(), ptr.as_ptr(), len) };
 
-        Ok(HeapBuffer { ptr, len, cap })
+        Ok((ptr, cap))
     }
 
     /// Return the capacity of the [`HeapBuffer`]

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -32,37 +32,62 @@ static_assertions::assert_eq_size!(HeapBuffer, Repr);
 static_assertions::assert_eq_align!(HeapBuffer, Repr);
 
 impl HeapBuffer {
-    /// Allocate a fresh heap buffer and copy `text` into it, the shared core for
-    /// `new`/`new_panic`.
-    #[inline]
-    fn build(text: &str) -> Result<Self, ReserveError> {
+    /// Allocate a heap buffer, copy `text` into it, and return the raw `(ptr, capacity)` pair
+    /// instead of a full [`HeapBuffer`]. The shared cold core behind `new` / `alloc_copy_panic`.
+    ///
+    /// The caller assembles the `HeapBuffer`/`Repr` itself. Returning the two-word `(ptr, capacity)`
+    /// -- which comes back in registers -- rather than a 24-byte `HeapBuffer` avoids a by-value
+    /// aggregate return across this outlined call boundary. That aggregate return otherwise forced
+    /// the whole of `Repr::new`/`new_panic`, including their hot inline arm, through a stack
+    /// temporary that LLVM scatter-copied into the return slot on x86 (a store-to-load forwarding
+    /// stall on every construction).
+    ///
+    /// `#[cold]`/`#[inline(never)]`: keeps the alloc/copy machinery out of line and lays the heap
+    /// arm out cold at every callsite.
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn alloc_copy(text: &str) -> Result<(ptr::NonNull<u8>, Capacity), ReserveError> {
         let len = text.len();
         let (cap, ptr) = allocate_ptr(len)?;
 
         // copy our string into the buffer we just allocated
         //
-        // SAFETY: We know both `src` and `dest` are valid for respectively reads and writes of
-        // length `len` because `len` comes from `src`, and `dest` was allocated to be at least that
-        // length. We also know they're non-overlapping because `dest` is newly allocated
+        // SAFETY: `src` (`text`) and `dest` (`ptr`) are both valid for `len` bytes -- `len` comes
+        // from `src`, and `dest` was freshly allocated with at least that length -- and they don't
+        // overlap because `dest` is newly allocated.
         unsafe { super::copy_medium(text.as_ptr(), ptr.as_ptr(), len) };
 
-        Ok(HeapBuffer { ptr, len, cap })
+        Ok((ptr, cap))
     }
 
     /// Create a [`HeapBuffer`] with the provided text.
     ///
-    /// Note(parker): deliberately not `#[inline]`, this is the cold allocating heap
-    /// construction path, keeping it out-of-line prevents it from bloating every
-    /// `CompactString` construction callsite.
+    /// `#[inline(always)]` so the `HeapBuffer` is assembled at the callsite from the register-passed
+    /// `(ptr, capacity)`; only that pair crosses the cold [`alloc_copy`] boundary.
+    #[inline(always)]
     pub(crate) fn new(text: &str) -> Result<Self, ReserveError> {
-        Self::build(text)
+        let (ptr, cap) = Self::alloc_copy(text)?;
+        Ok(HeapBuffer {
+            ptr,
+            len: text.len(),
+            cap,
+        })
     }
 
-    /// Like [`HeapBuffer::new`], but panics on allocation failure instead of returning a
-    /// `Result`.
+    /// Infallible [`alloc_copy`], panicking on allocation failure.
+    ///
+    /// `#[inline(always)]` so the tiny unwrap lives at the callsite (which then builds the `Repr`
+    /// from the register-passed `(ptr, capacity)`), while the actual allocating body stays in the
+    /// cold, out-of-line [`alloc_copy`].
+    #[inline(always)]
     #[track_caller]
-    pub(crate) fn new_panic(text: &str) -> Self {
-        Self::build(text).unwrap_with_msg()
+    pub(crate) fn alloc_copy_panic(text: &str) -> HeapBuffer {
+        let (ptr, cap) = Self::alloc_copy(text).unwrap_with_msg();
+        HeapBuffer {
+            ptr,
+            len: text.len(),
+            cap,
+        }
     }
 
     /// Create an empty [`HeapBuffer`] with a specific capacity

--- a/compact_str/src/repr/heap.rs
+++ b/compact_str/src/repr/heap.rs
@@ -38,7 +38,7 @@ impl HeapBuffer {
     /// N.B. The caller assembles the [`HeapBuffer`] themself. Returning the two-word
     /// `(ptr, capacity)`, which gets passed in registers, rather than a 24-byte
     /// `HeapBuffer` avoids a by-value aggregate return across this outlined call boundary.
-    /// 
+    ///
     /// The aggregate return otherwise forced the whole of `Repr::new`/`new_panic`, including
     /// their hot inline arm, through a stack temporary that LLVM scatter-copied into the
     /// return slot on x86, causing a forwarding stall on every construction.
@@ -54,7 +54,7 @@ impl HeapBuffer {
         // copy our string into the buffer we just allocated
         //
         // SAFETY: `src` (`text`) and `dest` (`ptr`) are both valid for `len` bytes. `len`
-        // comes from `src`, and `dest` was freshly allocated with at least that length. 
+        // comes from `src`, and `dest` was freshly allocated with at least that length.
         // And they don't overlap because `dest` is newly allocated.
         unsafe { super::copy_medium(text.as_ptr(), ptr.as_ptr(), len) };
 
@@ -104,7 +104,7 @@ impl HeapBuffer {
     }
 
     /// Out-of-line allocation core for [`Self::with_capacity`].
-    /// 
+    ///
     /// See [`Self::alloc_copy`] for why it returns the two-word pair instead of a `HeapBuffer`.
     #[cold]
     #[inline(never)]
@@ -132,7 +132,7 @@ impl HeapBuffer {
     }
 
     /// Out-of-line allocate+copy core for [`Self::with_additional`].
-    /// 
+    ///
     /// See [`Self::alloc_copy`] for why it returns the two-word pair instead of a `HeapBuffer`.
     #[cold]
     #[inline(never)]

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -90,7 +90,7 @@ impl InlineBuffer {
             w0 = load(src as *const u64);
             // N.B. Overlapping load with w0 for the tail of the string.
             let tail = load(src.add(len - 8) as *const u64);
-            
+
             // bytes `[8, len)` of the string are the top `len - 8` bytes of `tail`
             w1 = if len == 8 {
                 0

--- a/compact_str/src/repr/inline.rs
+++ b/compact_str/src/repr/inline.rs
@@ -18,6 +18,121 @@ impl InlineBuffer {
     /// SAFETY:
     /// * The caller must guarantee that the length of `text` is less than [`MAX_SIZE`]
     #[inline]
+    #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
+    pub(crate) unsafe fn new(text: &str) -> Self {
+        debug_assert!(text.len() <= MAX_SIZE);
+
+        use core::ptr::read_unaligned as load;
+
+        let len = text.len();
+        let src = text.as_ptr();
+
+        // Note(parker): This implementation builds an `InlineBuffer` entirely in
+        // registers. It solves a long standing performance issue `compact_str` has had
+        // since it's creation.
+        // The simple implementation is to copy the string into a stack buffer of
+        // MAX_SIZE. Via our `copy_small` helper or libc's `memcpy` function, it is
+        // executed as two overlapping stores.
+        //
+        // For example, the string "hello world" is copied as two 8-byte ops:
+        //
+        // 1. "hello wo" into [0, 7]
+        // 2. "lo world" into [3, 10]
+        //
+        // Then we have do a _third_ store to the final byte for the length.
+        //
+        // ( Note: we also need to consider the stores that zero the original buffer, but
+        //   for illustrative purposes considering just "hello world" is enough )
+        //
+        // Immediately after, the stack buffer gets moved, returned as a Repr and then to
+        // the user as a CompactString. These consumers read the data as _whole aligned words_.
+        // At this point the data is in the CPU's store buffer, not yet written out to
+        // the L1 cache.
+        //
+        // Enter the ~~SPOOKY ZONE~~ of micro-architectures.
+        //
+        // On Intel, the CPU can forward a load from the store buffer __if the load is
+        // fully contained within a single store__. Our issue is that the first word/8-bytes
+        // _overlaps two stores_ and thus causes a pipeline hazard
+        // Apple's `aarch64` can forward multi-store loads, so this is less of a problem
+        // there.
+        //
+        //
+        // Below, we build an `InlineBuffer` in registers, replacing the overlapping
+        // stores. Afterwards, the buffer is materialized with at most three aligned
+        // non-overlapping stores, or kept in registers entirely.
+
+        let last_byte = (len as u64 | LENGTH_MASK as u64) << 56;
+
+        let (w0, w1, w2);
+        if len >= 16 {
+            // SAFETY: `len >= 16` means `src` is valid for 16 bytes. and `src + len - 8`
+            // is valid for 8 bytes because `len <= text.len()`.
+            w0 = load(src as *const u64);
+            w1 = load(src.add(8) as *const u64);
+            // N.B. For any length < MAX_SIZE, this is an overlaping read of `w1` and the
+            // tail of the string.
+            let tail = load(src.add(len - 8) as *const u64);
+
+            // bytes `[16, len)` of the string are the top `len - 16` bytes of `tail`.
+            let data = if len == 16 {
+                0
+            } else {
+                tail >> ((MAX_SIZE - len) * 8)
+            };
+            w2 = if len == MAX_SIZE {
+                data
+            } else {
+                data | last_byte
+            };
+        } else if len >= 8 {
+            // SAFETY: `src` is valid for `len >= 8` bytes.
+            w0 = load(src as *const u64);
+            // N.B. Overlapping load with w0 for the tail of the string.
+            let tail = load(src.add(len - 8) as *const u64);
+            
+            // bytes `[8, len)` of the string are the top `len - 8` bytes of `tail`
+            w1 = if len == 8 {
+                0
+            } else {
+                tail >> ((16 - len) * 8)
+            };
+            w2 = last_byte;
+        } else if len >= 4 {
+            // SAFETY: `src` is valid for `len >= 4` bytes.
+            let head = load(src as *const u32) as u64;
+            let tail = load(src.add(len - 4) as *const u32) as u64;
+            w0 = head | (tail << ((len - 4) * 8));
+            w1 = 0;
+            w2 = last_byte;
+        } else if len >= 2 {
+            // SAFETY: `src` is valid for `len >= 2` bytes.
+            let head = load(src as *const u16) as u64;
+            let tail = load(src.add(len - 2) as *const u16) as u64;
+            w0 = head | (tail << ((len - 2) * 8));
+            w1 = 0;
+            w2 = last_byte;
+        } else if len == 1 {
+            w0 = *src as u64;
+            w1 = 0;
+            w2 = last_byte;
+        } else {
+            w0 = 0;
+            w1 = 0;
+            w2 = last_byte;
+        }
+
+        // SAFETY: `[u64; 3]` and `InlineBuffer` have the same size, and on little-endian
+        // the byte order of the words matches the byte order of the buffer.
+        core::mem::transmute([w0, w1, w2])
+    }
+
+    /// Construct a new [`InlineString`]. A string that lives in a small buffer on the stack
+    ///
+    /// SAFETY:
+    /// * The caller must guarantee that the length of `text` is less than [`MAX_SIZE`]
+    #[inline]
+    #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
     pub(crate) unsafe fn new(text: &str) -> Self {
         debug_assert!(text.len() <= MAX_SIZE);
 

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -99,12 +99,13 @@ impl Repr {
             let inline = unsafe { InlineBuffer::new(text) };
             Repr::from_inline(inline)
         } else {
-            // `alloc_copy_panic` is `#[inline(always)]`, so the `HeapBuffer` it returns is
-            // assembled right here at the callsite; the only value crossing the (cold) call
-            // boundary is the two-word `(ptr, capacity)` from `HeapBuffer::alloc_copy`, passed back
-            // in registers. Returning a full 24-byte `HeapBuffer` across that boundary instead
-            // routed it through a stack temporary that LLVM scatter-copied into the return slot on
-            // x86 -- pessimizing even the hot inline arm above (a store-forwarding stall).
+            // N.B. `alloc_copy_panic` is `#[inline(always)]`, so the `HeapBuffer` it
+            // returns is assembled right here at the callsite. The only value crossing
+            // the call boundary is the two-word `(ptr, capacity)`.
+            //
+            // Previously returning a full 24-byte `HeapBuffer` across that boundary
+            // instead routed it through a stack temporary that LLVM scatter-copied into
+            // the return slot on x86 which caused a store-forwarding stall.
             let heap = HeapBuffer::alloc_copy_panic(text);
             Repr::from_heap(heap)
         }
@@ -183,23 +184,16 @@ impl Repr {
         let og_cap = s.capacity();
         let cap = Capacity::new(og_cap);
 
-        #[cold]
-        fn capacity_on_heap(s: String) -> Result<Repr, ReserveError> {
-            HeapBuffer::new(s.as_str()).map(Repr::from_heap)
-        }
-
-        #[cold]
-        fn empty() -> Result<Repr, ReserveError> {
-            Ok(EMPTY)
-        }
-
         if cap.is_heap() {
-            // We only hit this case if the provided String is > 16MB and we're on a 32-bit arch. We
-            // expect it to be unlikely, thus we hint that to the compiler
-            capacity_on_heap(s)
+            // We only hit this case if the provided String is > 16MB and we're on a 32-bit arch.
+            //
+            // `alloc_copy` is the cold out-of-line core, keeping this arm off the hot path without
+            // a helper that would return the 24-byte `Repr` through a stack temporary.
+            let len = s.len();
+            let (ptr, cap) = HeapBuffer::alloc_copy(s.as_str())?;
+            Ok(Repr::from_heap(HeapBuffer { ptr, len, cap }))
         } else if og_cap == 0 {
-            // We don't expect converting from an empty String often, so we make this code path cold
-            empty()
+            Ok(EMPTY)
         } else if should_inline && s.len() <= MAX_SIZE {
             // SAFETY: Checked to make sure the string would fit inline
             let inline = unsafe { InlineBuffer::new(s.as_str()) };

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -782,16 +782,15 @@ impl Repr {
 impl Clone for Repr {
     #[inline]
     fn clone(&self) -> Self {
-        #[inline(never)]
-        fn clone_heap(this: &Repr) -> Repr {
-            Repr::new(this.as_str()).unwrap_with_msg()
-        }
-
         // There are only two cases we need to care about: If the string is allocated on the heap
         // or not. If it is, then the data must be cloned properly, otherwise we can simply copy
         // the `Repr`.
+        //
+        // `new_panic`'s heap arm is the cold out-of-line `alloc_copy` returning `(ptr, cap)` in
+        // registers; an out-of-line helper returning the 24-byte `Repr` here would route the hot
+        // copy arm below through a scatter-copied stack temporary on x86 (store-forwarding stall).
         if self.is_heap_allocated() {
-            clone_heap(self)
+            Repr::new_panic(self.as_str())
         } else {
             // SAFETY: We just checked that `self` can be copied because it is an inline string or
             // a reference to a `&'static str`.

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -985,6 +985,7 @@ const unsafe fn assume(cond: bool) {
 /// * `len <= MAX_SIZE`.
 /// * `src` is valid for reads of `len` bytes; `dst` is valid for writes of `len` bytes.
 /// * `src` and `dst` do not overlap.
+#[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
 #[inline(always)]
 pub(crate) unsafe fn copy_small(src: *const u8, dst: *mut u8, len: usize) {
     debug_assert!(len <= MAX_SIZE);

--- a/compact_str/src/repr/mod.rs
+++ b/compact_str/src/repr/mod.rs
@@ -99,7 +99,13 @@ impl Repr {
             let inline = unsafe { InlineBuffer::new(text) };
             Repr::from_inline(inline)
         } else {
-            let heap = HeapBuffer::new_panic(text);
+            // `alloc_copy_panic` is `#[inline(always)]`, so the `HeapBuffer` it returns is
+            // assembled right here at the callsite; the only value crossing the (cold) call
+            // boundary is the two-word `(ptr, capacity)` from `HeapBuffer::alloc_copy`, passed back
+            // in registers. Returning a full 24-byte `HeapBuffer` across that boundary instead
+            // routed it through a stack temporary that LLVM scatter-copied into the return slot on
+            // x86 -- pessimizing even the hot inline arm above (a store-forwarding stall).
+            let heap = HeapBuffer::alloc_copy_panic(text);
             Repr::from_heap(heap)
         }
     }


### PR DESCRIPTION
This PR contains two optimizations for the `CompactString::new` path. There are comments in code that describe them in detail, but the summary is:

1. build an `InlineBuffer` in registers to avoid pipeline hazards with overlapping "stores"
2. refactor `HeapBuffer` so the only values passing a function boundary are whole word `(ptr, capacity)` to avoid a scatter store on x86

### Wall-clock benchmarks

length     | hardware     | before  | after   | improvement
-----------|--------------|---------|---------|------------
  11       | Apple M4     | 1.6 ns  | 992 ps  | 1.6x
  11       | x86_64 Xenon | 7.2 ns  | 1.35 ns | **5.3x**
  24       | Apple M4     | 1.7 ns  | 992 ps  | 1.7x
  24       | x86_64 Xenon | 9.9 ns  | 1.36 ns | **7.3x**
  25 (heap)| Apple M4     | 14.4 ns | 13.4 ns | 1.07x
  25 (heap)| x86_64 Xenon | 19.2 ns | 12.5 ns | 1.5x