### PR TITLE
fix: fix `CompactString::try_with_capacity` is unsound

### DIFF
--- a/compact_str/src/repr/capacity.rs
+++ b/compact_str/src/repr/capacity.rs
@@ -69,7 +69,7 @@ impl Capacity {
         cfg_if::cfg_if! {
             if #[cfg(target_pointer_width = "64")] {
                 // on 64-bit arches we can always fit the capacity inline
-                debug_assert!(capacity <= MAX_VALUE);
+                assert!(capacity <= MAX_VALUE, "Exceeds maximum representable capacity");
                 // SAFETY: a 64-bit capacity is `< 2^56`, so its `to_le()` form leaves the
                 // discriminant byte free for `HEAP_MARKER`, letting the compiler fold the dead
                 // `Err` arm at callers like `From<String>`. (`to_le()`, not the raw value:

--- a/compact_str/src/tests.rs
+++ b/compact_str/src/tests.rs
@@ -2077,6 +2077,14 @@ fn test_alloc_excessively_long_string() {
     std::hint::black_box(CompactString::with_capacity((1 << 56) - 2));
 }
 
+// Regression test case for #495
+#[cfg(target_pointer_width = "64")]
+#[test]
+#[should_panic = "Exceeds maximum representable capacity"]
+fn test_alloc_with_unencodable_capacity() {
+    assert!(CompactString::try_with_capacity(1usize << 56).is_err());
+}
+
 // This feature was enabled by <https://github.com/rust-lang/rust/pull/94075> which was first
 // released in Rust 1.65.
 #[test]


### PR DESCRIPTION
Fix #495 

In release mode the assertion should check the capacity so that we can prevent the UB reported in #495.

I don't think this is a complete fix because `try_with_capacity` crashes with the large capacity but at least it prevents the unsoundness. The complete fix may be added later with some decisions (What error should be returned? Should `Capacity::new` be falliable like `Capacity::try_new`? etc.).